### PR TITLE
Introduce a concept guide for writing JSON and YAML based on a protobuf message

### DIFF
--- a/_includes/doc-side-concepts-nav.html
+++ b/_includes/doc-side-concepts-nav.html
@@ -6,4 +6,5 @@
 	<li class="doc-side-nav-list-item"><a href="{{ site.baseurl }}/docs/concepts/attributes.html" {% if current[3] == 'attributes.html' %}class='current'{% endif %}>Attributes</a></li>
 	<li class="doc-side-nav-list-item"><a href="{{ site.baseurl }}/docs/concepts/mixer.html" {% if current[3] == 'mixer.html' %}class='current'{% endif %}>Mixer</a></li>
 	<li class="doc-side-nav-list-item"><a href="{{ site.baseurl }}/docs/concepts/config.html" {% if current[3] == 'config.html' %}class='current'{% endif %}>Configuration</a></li>
+  <li class="doc-side-nav-list-item"><a href="{{ site.baseurl }}/docs/concepts/writing-config.html" {% if current[3] == 'writing-config.html' %}class='current'{% endif %}>Writing Configuration</a></li>
  </ul>

--- a/docs/concepts/writing-config.md
+++ b/docs/concepts/writing-config.md
@@ -36,7 +36,7 @@ message Metric {
     <td>
 <pre>
 {
-  "descriptor_name": "request_count",
+  "descriptorName": "request_count",
   "value": "1",
   "labels": {
       "source": "origin.ip",
@@ -61,7 +61,7 @@ message Metric {
   </tr>
   <tr>
     <td>
-<pre>
+<pre>`
 message Metric {
         string descriptor_name = 1;
         string value = 2;
@@ -78,14 +78,14 @@ message MetricsParams {
 {
   "metrics": [
     {
-      "descriptor_name": "request_count",
+      "descriptorName": "request_count",
       "value": "1",
       "labels": {
             "source": "origin.ip",
             "target": "target.service",
       },
     }, {
-      "descriptor_name": "request_latency",
+      "descriptorName": "request_latency",
       "value": "response.duration",
       "labels": {
             "source": "origin.ip",
@@ -100,7 +100,7 @@ message MetricsParams {
 </tbody>
 </table>
 
-*Note that we never name the outer-most message (the `MetricsParams`), but we do need the outer set of braces marking our JSON as an object.*
+*Note that we never name the outer-most message (the `MetricsParams`), but we do need the outer set of braces marking our JSON as an object. Also note that we shift from snake_case to lowerCamelCase; both are accepted but lowerCamelCase is idiomatic.*
 
 ### Proto `enum` fields uses the name of the value:
 
@@ -131,7 +131,7 @@ message AttributeDescriptor {
 <pre>
 {
   "name": "request.duration",
-  "value_type": "INT64",
+  "valueType": "INT64",
 }
 </pre>
       </td>
@@ -178,10 +178,10 @@ message MonitoredResourceDescriptor {
   "labels": [
     {
       "name": "label one",
-      "value_type": "STRING",
+      "valueType": "STRING",
     }, {
       "name": "second label",
-      "value_type": "DOUBLE",
+      "valueType": "DOUBLE",
     },
   ],
 }
@@ -223,18 +223,18 @@ message Metric {
     <td>
 <pre>
 {
-  "descriptor_name": "request_count",
+  "descriptorName": "request_count",
   "value": "1",
   "labels": {
       "source": "origin.ip",
-        "target": "target.service",
+      "target": "target.service",
   },
 }  
 </pre>
     </td>
     <td>
 <pre>
-descriptor_name: request_count
+descriptorName: request_count
 value: "1"
 labels:
   source: origin.ip
@@ -274,14 +274,14 @@ message MetricsParams {
 {
   "metrics": [
     {
-      "descriptor_name": "request_count",
+      "descriptorName": "request_count",
       "value": "1",
       "labels": {
             "source": "origin.ip",
             "target": "target.service",
       },
     }, {
-      "descriptor_name": "request_latency",
+      "descriptorName": "request_latency",
       "value": "response.duration",
       "labels": {
             "source": "origin.ip",
@@ -295,12 +295,12 @@ message MetricsParams {
     <td>
 <pre>
 metrics:
-- descriptor_name: request_count
+- descriptorName: request_count
   value: "1"
   labels:
     source: origin.ip
     target: target.service
-- descriptor_name: request_latency
+- descriptorName: request_latency
   value: response.duration
   labels:
     source: origin.ip
@@ -340,14 +340,14 @@ message AttributeDescriptor {
 <pre>
 {
   "name": "request.duration",
-  "value_type": "INT64",
+  "valueType": "INT64",
 }
 </pre>
       </td>
       <td>
 <pre>
 name: request.duration
-value_type: INT64
+valueType: INT64
 </pre>
 
 or
@@ -401,10 +401,10 @@ message MonitoredResourceDescriptor {
   "labels": [
     {
       "name": "label one",
-      "value_type": "STRING",
+      "valueType": "STRING",
     }, {
       "name": "second label",
-      "value_type": "DOUBLE",
+      "valueType": "DOUBLE",
     },
   ],
 }
@@ -415,9 +415,9 @@ message MonitoredResourceDescriptor {
 name: My Monitored Resource
 labels:
 - name: label one
-  value_type: STRING
+  valueType: STRING
 - name: second label
-  value_type: DOUBLE
+  valueType: DOUBLE
 </pre>
       </td>
     </tr>

--- a/docs/concepts/writing-config.md
+++ b/docs/concepts/writing-config.md
@@ -1,0 +1,433 @@
+---
+title: Writing Istio Configuration
+headline: Writing Istio Configuration
+sidenav: doc-side-concepts-nav.html
+bodyclass: docs
+layout: docs
+type: markdown
+---
+
+{% capture overview %}
+This document describes how to write configuration that conforms to Istio's schemas. All configuration schemas in Istio are defined as protobuf messages. When in doubt, search for the protos.
+{% endcapture %}
+
+{% capture body %}
+## Translating to JSON
+The protobuf language guide defines [the canonical mapping between protobuf and JSON](https://developers.google.com/protocol-buffers/docs/proto3#json), refer to it as the source of truth. We provide a few specific examples that appear in the Mixer's configuration.
+
+### Proto `map`s and `message`s map to JSON objects:
+
+<table>
+  <tbody>
+  <tr>
+    <th>Proto</th>
+    <th>JSON</th>
+  </tr>
+  <tr>
+    <td>
+<pre>
+message Metric {
+        string descriptor_name = 1;
+        string value = 2;
+        map<string, string> labels = 3;
+}
+</pre>
+    </td>
+    <td>
+<pre>
+{
+  "descriptor_name": "request_count",
+  "value": "1",
+  "labels": {
+      "source": "origin.ip",
+        "target": "target.service",
+  },
+}  
+</pre>
+    </td>
+  </tr>
+</tbody>
+</table>
+
+*Note that a map's keys are always converted to strings, no matter the data type declared in the proto file. They are converted back to the correct runtime type by the proto parsing libraries.*
+
+### A `repeated` Proto field maps to a JSON array:
+
+<table>
+  <tbody>
+  <tr>
+    <th>Proto</th>
+    <th>JSON</th>
+  </tr>
+  <tr>
+    <td>
+<pre>
+message Metric {
+        string descriptor_name = 1;
+        string value = 2;
+        map<string, string> labels = 3;
+}
+
+message MetricsParams {
+    repeated Metric metrics = 1;
+}
+</pre>
+    </td>
+    <td>
+<pre>
+{
+  "metrics": [
+    {
+      "descriptor_name": "request_count",
+      "value": "1",
+      "labels": {
+            "source": "origin.ip",
+            "target": "target.service",
+      },
+    }, {
+      "descriptor_name": "request_latency",
+      "value": "response.duration",
+      "labels": {
+            "source": "origin.ip",
+            "target": "target.service",
+      },
+    }
+  ]
+}  
+</pre>
+    </td>
+  </tr>
+</tbody>
+</table>
+
+*Note that we never name the outer-most message (the `MetricsParams`), but we do need the outer set of braces marking our JSON as an object.*
+
+### A proto `enum` field uses the name of the value you want to specify:
+
+<table>
+  <tbody>
+    <tr>
+      <th>Proto</th>
+      <th>JSON</th>
+    </tr>
+    <tr>
+      <td>
+<pre>
+enum ValueType {
+    STRING = 1;
+    INT64 = 2;
+    DOUBLE = 3;
+    // more values omitted
+}
+
+message AttributeDescriptor {
+    string name = 1;
+    string description = 2;
+    ValueType value_type = 3;
+}
+</pre>
+      </td>
+      <td>
+<pre>
+{
+  "name": "request.duration",
+  "value_type": "INT64",
+}
+</pre>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+*Notice we don't provide a `description`: fields with no value can be omitted.*
+
+### `message` fields can contain other messages:
+<table>
+  <tbody>
+    <tr>
+      <th>Proto</th>
+      <th>JSON</th>
+    </tr>
+    <tr>
+      <td>
+<pre>
+enum ValueType {
+    STRING = 1;
+    INT64 = 2;
+    DOUBLE = 3;
+    // more values omitted
+}
+
+message LabelDescriptor {
+    string name = 1;
+    string description = 2;
+    ValueType value_type = 3;
+}
+
+message MonitoredResourceDescriptor {
+  string name = 1;
+  string description = 2;
+  repeated LabelDescriptor labels = 3;
+}
+</pre>
+      </td>
+      <td>
+<pre>
+{
+  "name": "My Monitored Resource",
+  "labels": [
+    {
+      "name": "label one",
+      "value_type": "STRING",
+    }, {
+      "name": "second label",
+      "value_type": "DOUBLE",
+    },
+  ],
+}
+</pre>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+
+## Translating to YAML
+
+There is no canonical mapping between protobufs and YAML; instead protobuf defines a canonical mapping to JSON, and YAML defines a canonical mapping to JSON. To ingest YAML as a proto we convert it to JSON then to  protobuf.
+
+**Important things to note:**
+- YAML fields are implicitly strings
+- JSON arrays map to YAML lists; each element in a list is prefixed by a dash (`-`)
+- JSON objects map to a set of field names all at the same indentation level in YAML
+- YAML is whitespace sensitive and must use spaces; tabs are never allowed
+
+### `map`s and `message`s:
+<table>
+  <tbody>
+  <tr>
+    <th>Proto</th>
+    <th>JSON</th>
+    <th>YAML</th>
+  </tr>
+  <tr>
+    <td>
+<pre>
+message Metric {
+        string descriptor_name = 1;
+        string value = 2;
+        map<string, string> labels = 3;
+}
+</pre>
+    </td>
+    <td>
+<pre>
+{
+  "descriptor_name": "request_count",
+  "value": "1",
+  "labels": {
+      "source": "origin.ip",
+        "target": "target.service",
+  },
+}  
+</pre>
+    </td>
+    <td>
+<pre>
+descriptor_name: request_count
+value: "1"
+labels:
+  source: origin.ip
+  target: target.service
+</pre>
+    </td>
+  </tr>
+</tbody>
+</table>
+
+*Note that when numeric literals are used as strings (like `value` above) they must be enclosed in quotes. Quotation marks (`"`) are optional for normal strings.*
+
+### `repeated` fields:
+<table>
+  <tbody>
+  <tr>
+    <th>Proto</th>
+    <th>JSON</th>
+    <th>YAML</th>
+  </tr>
+  <tr>
+    <td>
+<pre>
+message Metric {
+        string descriptor_name = 1;
+        string value = 2;
+        map<string, string> labels = 3;
+}
+
+message MetricsParams {
+    repeated Metric metrics = 1;
+}
+</pre>
+    </td>
+    <td>
+<pre>
+{
+  "metrics": [
+    {
+      "descriptor_name": "request_count",
+      "value": "1",
+      "labels": {
+            "source": "origin.ip",
+            "target": "target.service",
+      },
+    }, {
+      "descriptor_name": "request_latency",
+      "value": "response.duration",
+      "labels": {
+            "source": "origin.ip",
+            "target": "target.service",
+      },
+    }
+  ]
+}  
+</pre>
+    </td>
+    <td>
+<pre>
+metrics:
+- descriptor_name: request_count
+  value: "1"
+  labels:
+    source: origin.ip
+    target: target.service
+- descriptor_name: request_latency
+  value: response.duration
+  labels:
+    source: origin.ip
+    target: target.service
+</pre>
+    </td>
+  </tr>
+</tbody>
+</table>
+
+### `enum` fields:
+<table>
+  <tbody>
+    <tr>
+      <th>Proto</th>
+      <th>JSON</th>
+      <th>YAML</th>
+    </tr>
+    <tr>
+      <td>
+<pre>
+enum ValueType {
+    STRING = 1;
+    INT64 = 2;
+    DOUBLE = 3;
+    // more values omitted
+}
+
+message AttributeDescriptor {
+    string name = 1;
+    string description = 2;
+    ValueType value_type = 3;
+}
+</pre>
+      </td>
+      <td>
+<pre>
+{
+  "name": "request.duration",
+  "value_type": "INT64",
+}
+</pre>
+      </td>
+      <td>
+<pre>
+name: request.duration
+value_type: INT64
+</pre>
+
+or
+
+<pre>
+name: request.duration
+valueType: INT64
+</pre>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+*Note that YAML parsing will handle both `snake_case` and `camelCase` field names.*
+
+### Nested `message`s:
+<table>
+  <tbody>
+    <tr>
+      <th>Proto</th>
+      <th>JSON</th>
+      <th>YAML</th>
+    </tr>
+    <tr>
+      <td>
+<pre>
+enum ValueType {
+    STRING = 1;
+    INT64 = 2;
+    DOUBLE = 3;
+    // more values omitted
+}
+
+message LabelDescriptor {
+    string name = 1;
+    string description = 2;
+    ValueType value_type = 3;
+}
+
+message MonitoredResourceDescriptor {
+  string name = 1;
+  string description = 2;
+  repeated LabelDescriptor labels = 3;
+}
+</pre>
+      </td>
+      <td>
+<pre>
+{
+  "name": "My Monitored Resource",
+  "labels": [
+    {
+      "name": "label one",
+      "value_type": "STRING",
+    }, {
+      "name": "second label",
+      "value_type": "DOUBLE",
+    },
+  ],
+}
+</pre>
+      </td>
+      <td>
+<pre>
+name: My Monitored Resource
+labels:
+- name: label one
+  value_type: STRING
+- name: second label
+  value_type: DOUBLE
+</pre>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+{% endcapture %}
+
+{% capture whatsnext %}
+* TODO: link to overall mixer config concept guide (how the config pieces fit together)
+{% endcapture %}
+
+{% include templates/concept.md %}

--- a/docs/concepts/writing-config.md
+++ b/docs/concepts/writing-config.md
@@ -1,6 +1,6 @@
 ---
-title: Writing Istio Configuration
-headline: Writing Istio Configuration
+title: Writing Configuration
+headline: Writing Configuration
 sidenav: doc-side-concepts-nav.html
 bodyclass: docs
 layout: docs
@@ -8,7 +8,7 @@ type: markdown
 ---
 
 {% capture overview %}
-This document describes how to write configuration that conforms to Istio's schemas. All configuration schemas in Istio are defined as protobuf messages. When in doubt, search for the protos.
+This document describes how to write configuration that conforms to Istio's schemas. All configuration schemas in Istio are defined as [protobuf messages](https://developers.google.com/protocol-buffers/docs/proto3). When in doubt, search for the protos.
 {% endcapture %}
 
 {% capture body %}

--- a/docs/concepts/writing-config.md
+++ b/docs/concepts/writing-config.md
@@ -22,7 +22,7 @@ There is no canonical mapping between protobufs and YAML; instead [protobuf defi
 - Proto `message`s map to JSON objects; in YAML objects are field names all at the same indentation level
 - YAML is whitespace sensitive and must use spaces; tabs are never allowed
 
-### Proto `map` and `message` fields:
+### `map` and `message` fields
 
 <table>
   <tbody>
@@ -55,7 +55,7 @@ labels:
 
 *Note that when numeric literals are used as strings (like `value` above) they must be enclosed in quotes. Quotation marks (`"`) are optional for normal strings.*
 
-### Proto `repeated` fields:
+### `repeated` fields
 
 <table>
   <tbody>
@@ -96,7 +96,7 @@ metrics:
 </tbody>
 </table>
 
-### Proto `enum` fields:
+### `enum` fields
 
 <table>
   <tbody>
@@ -140,7 +140,7 @@ valueType: INT64
 
 *Note that YAML parsing will handle both `snake_case` and `lowerCamelCase` field names. `lowerCamelCase` is the canonical version in YAML.*
 
-### Proto with nested `message` fields:
+### Nested `message` fields
 
 <table>
   <tbody>

--- a/docs/concepts/writing-config.md
+++ b/docs/concepts/writing-config.md
@@ -15,7 +15,7 @@ This document describes how to write configuration that conforms to Istio's sche
 ## Translating to JSON
 The protobuf language guide defines [the canonical mapping between protobuf and JSON](https://developers.google.com/protocol-buffers/docs/proto3#json), refer to it as the source of truth. We provide a few specific examples that appear in the Mixer's configuration.
 
-### Proto `map`s and `message`s map to JSON objects:
+### Proto `map` and `message` translate to JSON objects:
 
 <table>
   <tbody>
@@ -51,7 +51,7 @@ message Metric {
 
 *Note that a map's keys are always converted to strings, no matter the data type declared in the proto file. They are converted back to the correct runtime type by the proto parsing libraries.*
 
-### A `repeated` Proto field maps to a JSON array:
+### Proto `repeated` fields translate to JSON arrays:
 
 <table>
   <tbody>
@@ -102,7 +102,7 @@ message MetricsParams {
 
 *Note that we never name the outer-most message (the `MetricsParams`), but we do need the outer set of braces marking our JSON as an object.*
 
-### A proto `enum` field uses the name of the value you want to specify:
+### Proto `enum` fields uses the name of the value:
 
 <table>
   <tbody>
@@ -141,7 +141,7 @@ message AttributeDescriptor {
 
 *Notice we don't provide a `description`: fields with no value can be omitted.*
 
-### `message` fields can contain other messages:
+### Proto `message` fields can contain other messages:
 <table>
   <tbody>
     <tr>
@@ -202,7 +202,7 @@ There is no canonical mapping between protobufs and YAML; instead protobuf defin
 - JSON objects map to a set of field names all at the same indentation level in YAML
 - YAML is whitespace sensitive and must use spaces; tabs are never allowed
 
-### `map`s and `message`s:
+### Proto `map` and `message` fields:
 <table>
   <tbody>
   <tr>
@@ -247,7 +247,7 @@ labels:
 
 *Note that when numeric literals are used as strings (like `value` above) they must be enclosed in quotes. Quotation marks (`"`) are optional for normal strings.*
 
-### `repeated` fields:
+### Proto `repeated` fields:
 <table>
   <tbody>
   <tr>
@@ -311,7 +311,7 @@ metrics:
 </tbody>
 </table>
 
-### `enum` fields:
+### Proto `enum` fields:
 <table>
   <tbody>
     <tr>
@@ -363,7 +363,7 @@ valueType: INT64
 
 *Note that YAML parsing will handle both `snake_case` and `camelCase` field names.*
 
-### Nested `message`s:
+### Proto with nested `message` fields:
 <table>
   <tbody>
     <tr>


### PR DESCRIPTION
Unfortunately I had to hard-code our tables in HTML because I wanted multi-line code snippets in the table. Github markdown only supports a single line of content in a tabel's cell when the table is declared in markdown with pipes.