### PR TITLE
Generated docs for our protos

### DIFF
--- a/_docs/reference/api/api.md
+++ b/_docs/reference/api/api.md
@@ -1,0 +1,11 @@
+---
+category: Reference
+title: API and Configuration Schemas
+
+marker: true
+order: 100
+
+bodyclass: docs
+layout: docs
+type: markdown
+---

--- a/_docs/reference/api/enovy-config.md
+++ b/_docs/reference/api/enovy-config.md
@@ -1,0 +1,908 @@
+---
+category: Reference
+title: Envoy Configuration Schema
+overview: Generated documentation for Envoy's Configuration Schema
+              
+parent: API and Configuration Schemas
+order: 60
+
+bodyclass: docs
+layout: docs
+type: markdown
+---
+<a name="rpc_istio.proxy.v1alpha.config"></a>
+## Package istio.proxy.v1alpha.config
+
+<a name="rpc_istio.proxy.v1alpha.config_index"></a>
+### Index
+
+* [CircuitBreaker](#istio.proxy.v1alpha.config.CircuitBreaker)
+(message)
+* [CircuitBreaker.SimpleCircuitBreakerPolicy](#istio.proxy.v1alpha.config.CircuitBreaker.SimpleCircuitBreakerPolicy)
+(message)
+* [DestinationPolicy](#istio.proxy.v1alpha.config.DestinationPolicy)
+(message)
+* [DestinationWeight](#istio.proxy.v1alpha.config.DestinationWeight)
+(message)
+* [HTTPFaultInjection](#istio.proxy.v1alpha.config.HTTPFaultInjection)
+(message)
+* [HTTPFaultInjection.Abort](#istio.proxy.v1alpha.config.HTTPFaultInjection.Abort)
+(message)
+* [HTTPFaultInjection.Delay](#istio.proxy.v1alpha.config.HTTPFaultInjection.Delay)
+(message)
+* [HTTPRetry](#istio.proxy.v1alpha.config.HTTPRetry)
+(message)
+* [HTTPRetry.SimpleRetryPolicy](#istio.proxy.v1alpha.config.HTTPRetry.SimpleRetryPolicy)
+(message)
+* [HTTPTimeout](#istio.proxy.v1alpha.config.HTTPTimeout)
+(message)
+* [HTTPTimeout.SimpleTimeoutPolicy](#istio.proxy.v1alpha.config.HTTPTimeout.SimpleTimeoutPolicy)
+(message)
+* [L4FaultInjection](#istio.proxy.v1alpha.config.L4FaultInjection)
+(message)
+* [L4FaultInjection.Terminate](#istio.proxy.v1alpha.config.L4FaultInjection.Terminate)
+(message)
+* [L4FaultInjection.Throttle](#istio.proxy.v1alpha.config.L4FaultInjection.Throttle)
+(message)
+* [L4MatchAttributes](#istio.proxy.v1alpha.config.L4MatchAttributes)
+(message)
+* [LoadBalancing](#istio.proxy.v1alpha.config.LoadBalancing)
+(message)
+* [LoadBalancing.SimpleLBPolicy](#istio.proxy.v1alpha.config.LoadBalancing.SimpleLBPolicy)
+(enum)
+* [MatchCondition](#istio.proxy.v1alpha.config.MatchCondition)
+(message)
+* [ProxyMeshConfig](#istio.proxy.v1alpha.config.ProxyMeshConfig)
+(message)
+* [ProxyMeshConfig.AuthPolicy](#istio.proxy.v1alpha.config.ProxyMeshConfig.AuthPolicy)
+(enum)
+* [ProxyMeshConfig.IngressControllerMode](#istio.proxy.v1alpha.config.ProxyMeshConfig.IngressControllerMode)
+(enum)
+* [RouteRule](#istio.proxy.v1alpha.config.RouteRule)
+(message)
+* [StringMatch](#istio.proxy.v1alpha.config.StringMatch)
+(message)
+
+<a name="istio.proxy.v1alpha.config.CircuitBreaker"></a>
+### CircuitBreaker
+Circuit breaker configuration.
+
+<table>
+ <tr>
+  <th>Field</th>
+  <th>Type</th>
+  <th>Description</th>
+ </tr>
+<a name="istio.proxy.v1alpha.config.CircuitBreaker.simple_cb"></a>
+ <tr>
+  <td><code>simple_cb</code></td>
+  <td><a href="#istio.proxy.v1alpha.config.CircuitBreaker.SimpleCircuitBreakerPolicy">SimpleCircuitBreakerPolicy</a> (oneof )</td>
+  <td></td>
+ </tr>
+<a name="istio.proxy.v1alpha.config.CircuitBreaker.custom"></a>
+ <tr>
+  <td><code>custom</code></td>
+  <td><a href="https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#any">Any</a> (oneof )</td>
+  <td>For proxies that support custom circuit breaker policies.</td>
+ </tr>
+</table>
+
+<a name="istio.proxy.v1alpha.config.CircuitBreaker.SimpleCircuitBreakerPolicy"></a>
+### SimpleCircuitBreakerPolicy
+
+<table>
+ <tr>
+  <th>Field</th>
+  <th>Type</th>
+  <th>Description</th>
+ </tr>
+<a name="istio.proxy.v1alpha.config.CircuitBreaker.SimpleCircuitBreakerPolicy.max_connections"></a>
+ <tr>
+  <td><code>max_connections</code></td>
+  <td>int32</td>
+  <td>Maximum number of connections to a backend.</td>
+ </tr>
+<a name="istio.proxy.v1alpha.config.CircuitBreaker.SimpleCircuitBreakerPolicy.http_max_pending_requests"></a>
+ <tr>
+  <td><code>http_max_pending_requests</code></td>
+  <td>int32</td>
+  <td>Maximum number of pending requests to a backend.</td>
+ </tr>
+<a name="istio.proxy.v1alpha.config.CircuitBreaker.SimpleCircuitBreakerPolicy.http_max_requests"></a>
+ <tr>
+  <td><code>http_max_requests</code></td>
+  <td>int32</td>
+  <td>Maximum number of requests to a backend.</td>
+ </tr>
+<a name="istio.proxy.v1alpha.config.CircuitBreaker.SimpleCircuitBreakerPolicy.sleep_window_seconds"></a>
+ <tr>
+  <td><code>sleep_window_seconds</code></td>
+  <td>double</td>
+  <td>Minimum time the circuit will be closed. In floating point seconds format.</td>
+ </tr>
+<a name="istio.proxy.v1alpha.config.CircuitBreaker.SimpleCircuitBreakerPolicy.http_consecutive_errors"></a>
+ <tr>
+  <td><code>http_consecutive_errors</code></td>
+  <td>int32</td>
+  <td>Number of 5XX errors before circuit is opened.</td>
+ </tr>
+<a name="istio.proxy.v1alpha.config.CircuitBreaker.SimpleCircuitBreakerPolicy.http_detection_interval_seconds"></a>
+ <tr>
+  <td><code>http_detection_interval_seconds</code></td>
+  <td>double</td>
+  <td>Interval for checking state of hystrix circuit.</td>
+ </tr>
+<a name="istio.proxy.v1alpha.config.CircuitBreaker.SimpleCircuitBreakerPolicy.http_max_requests_per_connection"></a>
+ <tr>
+  <td><code>http_max_requests_per_connection</code></td>
+  <td>int32</td>
+  <td>Maximum number of requests per connection to a backend.</td>
+ </tr>
+<a name="istio.proxy.v1alpha.config.CircuitBreaker.SimpleCircuitBreakerPolicy.http_max_ejection_percent"></a>
+ <tr>
+  <td><code>http_max_ejection_percent</code></td>
+  <td>int32</td>
+  <td>Maximum % of hosts in the destination service that can be ejected due to circuit breaking. Defaults to 10%.</td>
+ </tr>
+</table>
+
+<a name="istio.proxy.v1alpha.config.DestinationPolicy"></a>
+### DestinationPolicy
+DestinationPolicy declares policies that determine how to handle traffic for a
+destination service (load balancing policies, failure recovery policies such
+as timeouts, retries, circuit breakers, etc).  Policies are applicable per
+individual service versions. ONLY ONE policy can be defined per service version.
+/
+Note that these policies are enforced on client-side connections or
+requests, i.e., enforced when the service is opening a
+connection/sending a request via the proxy to the destination.
+
+<table>
+ <tr>
+  <th>Field</th>
+  <th>Type</th>
+  <th>Description</th>
+ </tr>
+<a name="istio.proxy.v1alpha.config.DestinationPolicy.destination"></a>
+ <tr>
+  <td><code>destination</code></td>
+  <td>string</td>
+  <td>REQUIRED. Service name for which the service version is defined. The value MUST be a fully-qualified domain name, e.g. "my-service.default.svc.cluster.local".</td>
+ </tr>
+<a name="istio.proxy.v1alpha.config.DestinationPolicy.tags"></a>
+ <tr>
+  <td><code>tags</code></td>
+  <td>repeated map&lt;string, string&gt;</td>
+  <td>Service version destination identifier for the destination service. The identifier is qualified by the destination service name, e.g. version "env=prod" in "my-service.default.svc.cluster.local". N.B. The map is used instead of pstruct due to lack of serialization support in golang protobuf library (see <a href="https://github.com/golang/protobuf/pull/208">https://github.com/golang/protobuf/pull/208</a>)</td>
+ </tr>
+<a name="istio.proxy.v1alpha.config.DestinationPolicy.load_balancing"></a>
+ <tr>
+  <td><code>load_balancing</code></td>
+  <td><a href="#istio.proxy.v1alpha.config.LoadBalancing">LoadBalancing</a></td>
+  <td>Load balancing policy</td>
+ </tr>
+<a name="istio.proxy.v1alpha.config.DestinationPolicy.circuit_breaker"></a>
+ <tr>
+  <td><code>circuit_breaker</code></td>
+  <td><a href="#istio.proxy.v1alpha.config.CircuitBreaker">CircuitBreaker</a></td>
+  <td>Circuit breaker policy</td>
+ </tr>
+<a name="istio.proxy.v1alpha.config.DestinationPolicy.custom"></a>
+ <tr>
+  <td><code>custom</code></td>
+  <td><a href="https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#any">Any</a></td>
+  <td>Other custom policy implementations</td>
+ </tr>
+</table>
+
+<a name="istio.proxy.v1alpha.config.DestinationWeight"></a>
+### DestinationWeight
+Each routing rule is associated with one or more service versions (see
+glossary in beginning of document). Weights associated with the version
+determine the proportion of traffic it receives.
+
+<table>
+ <tr>
+  <th>Field</th>
+  <th>Type</th>
+  <th>Description</th>
+ </tr>
+<a name="istio.proxy.v1alpha.config.DestinationWeight.destination"></a>
+ <tr>
+  <td><code>destination</code></td>
+  <td>string</td>
+  <td>Destination uniquely identifies the destination service. If not specified, the value is inherited from the parent route rule. Value must be in fully qualified domain name format (e.g., "my-service.default.svc.cluster.local").</td>
+ </tr>
+<a name="istio.proxy.v1alpha.config.DestinationWeight.tags"></a>
+ <tr>
+  <td><code>tags</code></td>
+  <td>repeated map&lt;string, string&gt;</td>
+  <td>Service version identifier for the destination service. N.B. The map is used instead of pstruct due to lack of serialization support in golang protobuf library (see <a href="https://github.com/golang/protobuf/pull/208">https://github.com/golang/protobuf/pull/208</a>)</td>
+ </tr>
+<a name="istio.proxy.v1alpha.config.DestinationWeight.weight"></a>
+ <tr>
+  <td><code>weight</code></td>
+  <td>int32</td>
+  <td>The proportion of traffic to be forwarded to the service version. Max is 100. Sum of weights across destinations should add up to 100. If there is only destination in a rule, the weight value is assumed to be 100.</td>
+ </tr>
+</table>
+
+<a name="istio.proxy.v1alpha.config.HTTPFaultInjection"></a>
+### HTTPFaultInjection
+Faults can be injected into the API calls by the proxy, for testing the
+failure recovery capabilities of downstream services.  Faults include
+aborting the Http request from downstream service, delaying the proxying of
+requests, or both. MUST specify either delay or abort or both.
+
+<table>
+ <tr>
+  <th>Field</th>
+  <th>Type</th>
+  <th>Description</th>
+ </tr>
+<a name="istio.proxy.v1alpha.config.HTTPFaultInjection.delay"></a>
+ <tr>
+  <td><code>delay</code></td>
+  <td><a href="#istio.proxy.v1alpha.config.HTTPFaultInjection.Delay">Delay</a></td>
+  <td>Delay requests before forwarding, emulating various failures such as network issues, overloaded upstream service, etc.</td>
+ </tr>
+<a name="istio.proxy.v1alpha.config.HTTPFaultInjection.abort"></a>
+ <tr>
+  <td><code>abort</code></td>
+  <td><a href="#istio.proxy.v1alpha.config.HTTPFaultInjection.Abort">Abort</a></td>
+  <td>Abort Http request attempts and return error codes back to downstream service, giving the impression that the upstream service is faulty. N.B. Both delay and abort can be specified simultaneously. Delay and Abort are independent of one another. For e.g., if Delay is restricted to 5% of requests while Abort is restricted to 10% of requests, the 10% in abort specification applies to all requests directed to the service. It may be the case that one or more requests being aborted were also delayed.</td>
+ </tr>
+</table>
+
+<a name="istio.proxy.v1alpha.config.HTTPFaultInjection.Abort"></a>
+### Abort
+Abort Http request attempts and return error codes back to downstream
+service.
+
+<table>
+ <tr>
+  <th>Field</th>
+  <th>Type</th>
+  <th>Description</th>
+ </tr>
+<a name="istio.proxy.v1alpha.config.HTTPFaultInjection.Abort.percent"></a>
+ <tr>
+  <td><code>percent</code></td>
+  <td>float</td>
+  <td>percentage of requests to be aborted with the error code provided.</td>
+ </tr>
+<a name="istio.proxy.v1alpha.config.HTTPFaultInjection.Abort.override_header_name"></a>
+ <tr>
+  <td><code>override_header_name</code></td>
+  <td>string</td>
+  <td>Specify abort code as part of Http request.</td>
+ </tr>
+<a name="istio.proxy.v1alpha.config.HTTPFaultInjection.Abort.grpc_status"></a>
+ <tr>
+  <td><code>grpc_status</code></td>
+  <td>string (oneof )</td>
+  <td></td>
+ </tr>
+<a name="istio.proxy.v1alpha.config.HTTPFaultInjection.Abort.http2_error"></a>
+ <tr>
+  <td><code>http2_error</code></td>
+  <td>string (oneof )</td>
+  <td></td>
+ </tr>
+<a name="istio.proxy.v1alpha.config.HTTPFaultInjection.Abort.http_status"></a>
+ <tr>
+  <td><code>http_status</code></td>
+  <td>int32 (oneof )</td>
+  <td></td>
+ </tr>
+</table>
+
+<a name="istio.proxy.v1alpha.config.HTTPFaultInjection.Delay"></a>
+### Delay
+MUST specify either a fixed delay or exponential delay. Exponential
+delay is unsupported at the moment.
+
+<table>
+ <tr>
+  <th>Field</th>
+  <th>Type</th>
+  <th>Description</th>
+ </tr>
+<a name="istio.proxy.v1alpha.config.HTTPFaultInjection.Delay.percent"></a>
+ <tr>
+  <td><code>percent</code></td>
+  <td>float</td>
+  <td>percentage of requests on which the delay will be injected</td>
+ </tr>
+<a name="istio.proxy.v1alpha.config.HTTPFaultInjection.Delay.override_header_name"></a>
+ <tr>
+  <td><code>override_header_name</code></td>
+  <td>string</td>
+  <td>Specify delay duration as part of Http request.</td>
+ </tr>
+<a name="istio.proxy.v1alpha.config.HTTPFaultInjection.Delay.fixed_delay_seconds"></a>
+ <tr>
+  <td><code>fixed_delay_seconds</code></td>
+  <td>double (oneof )</td>
+  <td>Add a fixed delay before forwarding the request. Delay duration in seconds.nanoseconds</td>
+ </tr>
+<a name="istio.proxy.v1alpha.config.HTTPFaultInjection.Delay.exponential_delay_seconds"></a>
+ <tr>
+  <td><code>exponential_delay_seconds</code></td>
+  <td>double (oneof )</td>
+  <td>Add a delay (based on an exponential function) before forwarding the request. mean delay needed to derive the exponential delay values</td>
+ </tr>
+</table>
+
+<a name="istio.proxy.v1alpha.config.HTTPRetry"></a>
+### HTTPRetry
+Retry policy to use when a request fails.
+
+<table>
+ <tr>
+  <th>Field</th>
+  <th>Type</th>
+  <th>Description</th>
+ </tr>
+<a name="istio.proxy.v1alpha.config.HTTPRetry.simple_retry"></a>
+ <tr>
+  <td><code>simple_retry</code></td>
+  <td><a href="#istio.proxy.v1alpha.config.HTTPRetry.SimpleRetryPolicy">SimpleRetryPolicy</a> (oneof )</td>
+  <td></td>
+ </tr>
+<a name="istio.proxy.v1alpha.config.HTTPRetry.custom"></a>
+ <tr>
+  <td><code>custom</code></td>
+  <td><a href="https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#any">Any</a> (oneof )</td>
+  <td>For proxies that support custom retry policies</td>
+ </tr>
+</table>
+
+<a name="istio.proxy.v1alpha.config.HTTPRetry.SimpleRetryPolicy"></a>
+### SimpleRetryPolicy
+
+<table>
+ <tr>
+  <th>Field</th>
+  <th>Type</th>
+  <th>Description</th>
+ </tr>
+<a name="istio.proxy.v1alpha.config.HTTPRetry.SimpleRetryPolicy.attempts"></a>
+ <tr>
+  <td><code>attempts</code></td>
+  <td>int32</td>
+  <td>Number of retries for a given request. The interval between retries will be determined automatically (25ms+). Actual number of retries attempted depends on the http_timeout</td>
+ </tr>
+<a name="istio.proxy.v1alpha.config.HTTPRetry.SimpleRetryPolicy.per_try_timeout_seconds"></a>
+ <tr>
+  <td><code>per_try_timeout_seconds</code></td>
+  <td>double</td>
+  <td>Timeout per retry attempt for a given request. Specified in seconds.nanoseconds format.</td>
+ </tr>
+<a name="istio.proxy.v1alpha.config.HTTPRetry.SimpleRetryPolicy.override_header_name"></a>
+ <tr>
+  <td><code>override_header_name</code></td>
+  <td>string</td>
+  <td>Downstream Service could specify retry attempts via Http header to the proxy, if the proxy supports such a feature.</td>
+ </tr>
+</table>
+
+<a name="istio.proxy.v1alpha.config.HTTPTimeout"></a>
+### HTTPTimeout
+Request timeout: wait time until a response is received. Does not
+indicate the time for the entire response to arrive.
+
+<table>
+ <tr>
+  <th>Field</th>
+  <th>Type</th>
+  <th>Description</th>
+ </tr>
+<a name="istio.proxy.v1alpha.config.HTTPTimeout.simple_timeout"></a>
+ <tr>
+  <td><code>simple_timeout</code></td>
+  <td><a href="#istio.proxy.v1alpha.config.HTTPTimeout.SimpleTimeoutPolicy">SimpleTimeoutPolicy</a> (oneof )</td>
+  <td></td>
+ </tr>
+<a name="istio.proxy.v1alpha.config.HTTPTimeout.custom"></a>
+ <tr>
+  <td><code>custom</code></td>
+  <td><a href="https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#any">Any</a> (oneof )</td>
+  <td>For proxies that support custom timeout policies</td>
+ </tr>
+</table>
+
+<a name="istio.proxy.v1alpha.config.HTTPTimeout.SimpleTimeoutPolicy"></a>
+### SimpleTimeoutPolicy
+
+<table>
+ <tr>
+  <th>Field</th>
+  <th>Type</th>
+  <th>Description</th>
+ </tr>
+<a name="istio.proxy.v1alpha.config.HTTPTimeout.SimpleTimeoutPolicy.timeout_seconds"></a>
+ <tr>
+  <td><code>timeout_seconds</code></td>
+  <td>double</td>
+  <td>Timeout for a HTTP request. Includes retries as well. Unit is in floating point seconds. Default 15 seconds. Specified in seconds.nanoseconds format</td>
+ </tr>
+<a name="istio.proxy.v1alpha.config.HTTPTimeout.SimpleTimeoutPolicy.override_header_name"></a>
+ <tr>
+  <td><code>override_header_name</code></td>
+  <td>string</td>
+  <td>Downstream service could specify timeout via Http header to the proxy, if the proxy supports such a feature.</td>
+ </tr>
+</table>
+
+<a name="istio.proxy.v1alpha.config.L4FaultInjection"></a>
+### L4FaultInjection
+/@exclude Faults can be injected into the connections from downstream by the
+proxy, for testing the failure recovery capabilities of downstream
+services.  Faults include aborting the connection from downstream
+service, delaying the proxying of connection to the destination
+service, and throttling the bandwidth of the connection (either
+end). Bandwidth throttling for failure testing should not be confused
+with the rate limiting policy enforcement provided by the Mixer
+component. L4 fault injection is not supported at the moment.
+Unlike Http services, we have very little context for raw Tcp|Udp
+connections. We could throttle bandwidth of the connections (slow down
+the connection) and/or abruptly reset (terminate) the Tcp connection
+after it has been established.
+
+<table>
+ <tr>
+  <th>Field</th>
+  <th>Type</th>
+  <th>Description</th>
+ </tr>
+<a name="istio.proxy.v1alpha.config.L4FaultInjection.throttle"></a>
+ <tr>
+  <td><code>throttle</code></td>
+  <td><a href="#istio.proxy.v1alpha.config.L4FaultInjection.Throttle">Throttle</a></td>
+  <td>We first throttle (if set) and then terminate the connection.</td>
+ </tr>
+<a name="istio.proxy.v1alpha.config.L4FaultInjection.terminate"></a>
+ <tr>
+  <td><code>terminate</code></td>
+  <td><a href="#istio.proxy.v1alpha.config.L4FaultInjection.Terminate">Terminate</a></td>
+  <td></td>
+ </tr>
+</table>
+
+<a name="istio.proxy.v1alpha.config.L4FaultInjection.Terminate"></a>
+### Terminate
+Abruptly reset (terminate) the Tcp connection after it has been
+established, emulating remote server crash or link failure.
+
+<table>
+ <tr>
+  <th>Field</th>
+  <th>Type</th>
+  <th>Description</th>
+ </tr>
+<a name="istio.proxy.v1alpha.config.L4FaultInjection.Terminate.percent"></a>
+ <tr>
+  <td><code>percent</code></td>
+  <td>float</td>
+  <td>percentage of established Tcp connections to be terminated/reset</td>
+ </tr>
+<a name="istio.proxy.v1alpha.config.L4FaultInjection.Terminate.terminate_after_seconds"></a>
+ <tr>
+  <td><code>terminate_after_seconds</code></td>
+  <td>double</td>
+  <td></td>
+ </tr>
+</table>
+
+<a name="istio.proxy.v1alpha.config.L4FaultInjection.Throttle"></a>
+### Throttle
+Bandwidth throttling for Tcp and Udp connections
+
+<table>
+ <tr>
+  <th>Field</th>
+  <th>Type</th>
+  <th>Description</th>
+ </tr>
+<a name="istio.proxy.v1alpha.config.L4FaultInjection.Throttle.percent"></a>
+ <tr>
+  <td><code>percent</code></td>
+  <td>float</td>
+  <td>percentage of connections to throttle.</td>
+ </tr>
+<a name="istio.proxy.v1alpha.config.L4FaultInjection.Throttle.downstream_limit_bps"></a>
+ <tr>
+  <td><code>downstream_limit_bps</code></td>
+  <td>int64</td>
+  <td>bandwidth limit in "bits" per second between downstream and proxy</td>
+ </tr>
+<a name="istio.proxy.v1alpha.config.L4FaultInjection.Throttle.upstream_limit_bps"></a>
+ <tr>
+  <td><code>upstream_limit_bps</code></td>
+  <td>int64</td>
+  <td>bandwidth limits in "bits" per second between proxy and upstream</td>
+ </tr>
+<a name="istio.proxy.v1alpha.config.L4FaultInjection.Throttle.throttle_for_seconds"></a>
+ <tr>
+  <td><code>throttle_for_seconds</code></td>
+  <td><a href="https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#doublevalue">DoubleValue</a></td>
+  <td>Stop throttling after the given duration. If not set, the connection will be throttled for its lifetime.</td>
+ </tr>
+<a name="istio.proxy.v1alpha.config.L4FaultInjection.Throttle.throttle_after_seconds"></a>
+ <tr>
+  <td><code>throttle_after_seconds</code></td>
+  <td>double (oneof )</td>
+  <td>Wait for X seconds after the connection is established, before starting bandwidth throttling. This would allow us to inject fault after the application protocol (e.g., MySQL) has had time to establish sessions/whatever handshake necessary.</td>
+ </tr>
+<a name="istio.proxy.v1alpha.config.L4FaultInjection.Throttle.throttle_after_bytes"></a>
+ <tr>
+  <td><code>throttle_after_bytes</code></td>
+  <td>double (oneof )</td>
+  <td>Alternatively, we could wait for a certain number of bytes to be transferred to upstream before throttling the bandwidth.</td>
+ </tr>
+</table>
+
+<a name="istio.proxy.v1alpha.config.L4MatchAttributes"></a>
+### L4MatchAttributes
+L4 connection match attributes. Note that L4 connection matching
+support is incomplete.
+
+<table>
+ <tr>
+  <th>Field</th>
+  <th>Type</th>
+  <th>Description</th>
+ </tr>
+<a name="istio.proxy.v1alpha.config.L4MatchAttributes.source_subnet"></a>
+ <tr>
+  <td><code>source_subnet[]</code></td>
+  <td>repeated string</td>
+  <td>IPv4 or IPv6 ip address with optional subnet. E.g., a.b.c.d/xx form or just a.b.c.d</td>
+ </tr>
+<a name="istio.proxy.v1alpha.config.L4MatchAttributes.destination_subnet"></a>
+ <tr>
+  <td><code>destination_subnet[]</code></td>
+  <td>repeated string</td>
+  <td>IPv4 or IPv6 ip address of destination with optional subnet. E.g., a.b.c.d/xx form or just a.b.c.d. This is only valid when the destination service has several IPs and the application explicitly specifies a particular IP.</td>
+ </tr>
+</table>
+
+<a name="istio.proxy.v1alpha.config.LoadBalancing"></a>
+### LoadBalancing
+Load balancing policy to use when forwarding traffic.
+
+<table>
+ <tr>
+  <th>Field</th>
+  <th>Type</th>
+  <th>Description</th>
+ </tr>
+<a name="istio.proxy.v1alpha.config.LoadBalancing.name"></a>
+ <tr>
+  <td><code>name</code></td>
+  <td><a href="#istio.proxy.v1alpha.config.LoadBalancing.SimpleLBPolicy">SimpleLBPolicy</a> (oneof )</td>
+  <td></td>
+ </tr>
+<a name="istio.proxy.v1alpha.config.LoadBalancing.custom"></a>
+ <tr>
+  <td><code>custom</code></td>
+  <td><a href="https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#any">Any</a> (oneof )</td>
+  <td>/Custom LB policy implementations</td>
+ </tr>
+</table>
+
+<a name="istio.proxy.v1alpha.config.LoadBalancing.SimpleLBPolicy"></a>
+### SimpleLBPolicy
+Common load balancing policies supported in Istio service mesh.
+
+
+<table>
+ <tr>
+  <th>Value</th>
+  <th>Description</th>
+ </tr>
+<a name="istio.proxy.v1alpha.config.LoadBalancing.SimpleLBPolicy.ROUND_ROBIN"></a>
+ <tr>
+  <td>ROUND_ROBIN</td>
+  <td></td>
+ </tr>
+<a name="istio.proxy.v1alpha.config.LoadBalancing.SimpleLBPolicy.LEAST_CONN"></a>
+ <tr>
+  <td>LEAST_CONN</td>
+  <td></td>
+ </tr>
+<a name="istio.proxy.v1alpha.config.LoadBalancing.SimpleLBPolicy.RANDOM"></a>
+ <tr>
+  <td>RANDOM</td>
+  <td>Envoy has IP_HASH, but requires a HTTP header name to hash on</td>
+ </tr>
+</table>
+
+<a name="istio.proxy.v1alpha.config.MatchCondition"></a>
+### MatchCondition
+Match condition specifies a set of criterion to be met in order for the
+route rule to be applied to the connection or HTTP request.  The
+condition provides distinct set of conditions for each protocol with
+the intention that conditions apply only to the service ports that
+match the protocol.
+
+<table>
+ <tr>
+  <th>Field</th>
+  <th>Type</th>
+  <th>Description</th>
+ </tr>
+<a name="istio.proxy.v1alpha.config.MatchCondition.source"></a>
+ <tr>
+  <td><code>source</code></td>
+  <td>string</td>
+  <td>Identifies the service initiating a connection or a request by its name. If specified, name MUST BE a fully qualified domain name such as foo.bar.com</td>
+ </tr>
+<a name="istio.proxy.v1alpha.config.MatchCondition.source_tags"></a>
+ <tr>
+  <td><code>source_tags</code></td>
+  <td>repeated map&lt;string, string&gt;</td>
+  <td>Identifies the source service version. The identifier is interpreted by the platform to match a service version for the source service. N.B. The map is used instead of pstruct due to lack of serialization support in golang protobuf library (see <a href="https://github.com/golang/protobuf/pull/208">https://github.com/golang/protobuf/pull/208</a>)</td>
+ </tr>
+<a name="istio.proxy.v1alpha.config.MatchCondition.tcp"></a>
+ <tr>
+  <td><code>tcp</code></td>
+  <td><a href="#istio.proxy.v1alpha.config.L4MatchAttributes">L4MatchAttributes</a></td>
+  <td>Set of layer 4 match conditions based on the IP ranges. INCOMPLETE implementation</td>
+ </tr>
+<a name="istio.proxy.v1alpha.config.MatchCondition.udp"></a>
+ <tr>
+  <td><code>udp</code></td>
+  <td><a href="#istio.proxy.v1alpha.config.L4MatchAttributes">L4MatchAttributes</a></td>
+  <td>Set of layer 4 match conditions based on the IP ranges</td>
+ </tr>
+<a name="istio.proxy.v1alpha.config.MatchCondition.http_headers"></a>
+ <tr>
+  <td><code>http_headers</code></td>
+  <td>repeated map&lt;string, <a href="#istio.proxy.v1alpha.config.StringMatch">StringMatch</a>&gt;</td>
+  <td>Set of HTTP match conditions based on HTTP/1.1, HTTP/2, GRPC request metadata, such as "uri", "scheme", "authority". The header keys are case-insensitive.</td>
+ </tr>
+</table>
+
+<a name="istio.proxy.v1alpha.config.ProxyMeshConfig"></a>
+### ProxyMeshConfig
+ProxyMeshConfig defines variables shared by all proxies in the Istio
+service mesh.
+
+<table>
+ <tr>
+  <th>Field</th>
+  <th>Type</th>
+  <th>Description</th>
+ </tr>
+<a name="istio.proxy.v1alpha.config.ProxyMeshConfig.egress_proxy_address"></a>
+ <tr>
+  <td><code>egress_proxy_address</code></td>
+  <td>string</td>
+  <td>Address of the egress proxy service (e.g. "istio-egress:80")</td>
+ </tr>
+<a name="istio.proxy.v1alpha.config.ProxyMeshConfig.discovery_address"></a>
+ <tr>
+  <td><code>discovery_address</code></td>
+  <td>string</td>
+  <td>Address of the discovery service exposing SDS, CDS, RDS (e.g. "manager:8080")</td>
+ </tr>
+<a name="istio.proxy.v1alpha.config.ProxyMeshConfig.mixer_address"></a>
+ <tr>
+  <td><code>mixer_address</code></td>
+  <td>string</td>
+  <td>Address of the mixer service (e.g. "mixer:9090")</td>
+ </tr>
+<a name="istio.proxy.v1alpha.config.ProxyMeshConfig.proxy_listen_port"></a>
+ <tr>
+  <td><code>proxy_listen_port</code></td>
+  <td>int32</td>
+  <td>Port opened by the proxy for the traffic capture</td>
+ </tr>
+<a name="istio.proxy.v1alpha.config.ProxyMeshConfig.proxy_admin_port"></a>
+ <tr>
+  <td><code>proxy_admin_port</code></td>
+  <td>int32</td>
+  <td>Port opened by the proxy for the administrative interface</td>
+ </tr>
+<a name="istio.proxy.v1alpha.config.ProxyMeshConfig.drain_duration"></a>
+ <tr>
+  <td><code>drain_duration</code></td>
+  <td><a href="https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#duration">Duration</a></td>
+  <td>Duration of the grace period to drain connections from the parent proxy instance</td>
+ </tr>
+<a name="istio.proxy.v1alpha.config.ProxyMeshConfig.parent_shutdown_duration"></a>
+ <tr>
+  <td><code>parent_shutdown_duration</code></td>
+  <td><a href="https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#duration">Duration</a></td>
+  <td>Duration to wait before shutting down the parent proxy instance</td>
+ </tr>
+<a name="istio.proxy.v1alpha.config.ProxyMeshConfig.istio_service_cluster"></a>
+ <tr>
+  <td><code>istio_service_cluster</code></td>
+  <td>string</td>
+  <td>IstioServiceCluster defines the name for the service_cluster that is shared by all proxy instances. Since Istio does not assign a local service/service version to each proxy instance, the name is same for all of them. This setting corresponds to "--service-cluster" flag in Envoy. The value for "--service-node" is used by the proxy to identify its set of local instances to RDS for source-based routing. For example, if proxy sends its IP address, the RDS can compute routes that are relative to the service instances located at that IP address.</td>
+ </tr>
+<a name="istio.proxy.v1alpha.config.ProxyMeshConfig.discovery_refresh_delay"></a>
+ <tr>
+  <td><code>discovery_refresh_delay</code></td>
+  <td><a href="https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#duration">Duration</a></td>
+  <td>Delay between polling requests to the discovery service</td>
+ </tr>
+<a name="istio.proxy.v1alpha.config.ProxyMeshConfig.connect_timeout"></a>
+ <tr>
+  <td><code>connect_timeout</code></td>
+  <td><a href="https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#duration">Duration</a></td>
+  <td>Connection timeout used by the Envoy clusters</td>
+ </tr>
+<a name="istio.proxy.v1alpha.config.ProxyMeshConfig.ingress_class"></a>
+ <tr>
+  <td><code>ingress_class</code></td>
+  <td>string</td>
+  <td>Class of ingress resources to be processed by Istio ingress controller. This corresponds to the value of "kubernetes.io/ingress.class" annotation.</td>
+ </tr>
+<a name="istio.proxy.v1alpha.config.ProxyMeshConfig.ingress_controller_mode"></a>
+ <tr>
+  <td><code>ingress_controller_mode</code></td>
+  <td><a href="#istio.proxy.v1alpha.config.ProxyMeshConfig.IngressControllerMode">IngressControllerMode</a></td>
+  <td>Defines whether to use Istio ingress proxy for annotated or all ingress resources</td>
+ </tr>
+<a name="istio.proxy.v1alpha.config.ProxyMeshConfig.auth_policy"></a>
+ <tr>
+  <td><code>auth_policy</code></td>
+  <td><a href="#istio.proxy.v1alpha.config.ProxyMeshConfig.AuthPolicy">AuthPolicy</a></td>
+  <td>Authentication policy defines the global switch to control authentication for proxy-to-proxy communication</td>
+ </tr>
+<a name="istio.proxy.v1alpha.config.ProxyMeshConfig.auth_certs_path"></a>
+ <tr>
+  <td><code>auth_certs_path</code></td>
+  <td>string</td>
+  <td>Path to the secrets used by the authentication policy</td>
+ </tr>
+</table>
+
+<a name="istio.proxy.v1alpha.config.ProxyMeshConfig.AuthPolicy"></a>
+### AuthPolicy
+
+
+<table>
+ <tr>
+  <th>Value</th>
+  <th>Description</th>
+ </tr>
+<a name="istio.proxy.v1alpha.config.ProxyMeshConfig.AuthPolicy.NONE"></a>
+ <tr>
+  <td>NONE</td>
+  <td></td>
+ </tr>
+<a name="istio.proxy.v1alpha.config.ProxyMeshConfig.AuthPolicy.MUTUAL_TLS"></a>
+ <tr>
+  <td>MUTUAL_TLS</td>
+  <td>Proxy to proxy traffic is wrapped into mutual TLS connections</td>
+ </tr>
+</table>
+
+<a name="istio.proxy.v1alpha.config.ProxyMeshConfig.IngressControllerMode"></a>
+### IngressControllerMode
+
+
+<table>
+ <tr>
+  <th>Value</th>
+  <th>Description</th>
+ </tr>
+<a name="istio.proxy.v1alpha.config.ProxyMeshConfig.IngressControllerMode.OFF"></a>
+ <tr>
+  <td>OFF</td>
+  <td>Disables Ingress controller.</td>
+ </tr>
+<a name="istio.proxy.v1alpha.config.ProxyMeshConfig.IngressControllerMode.DEFAULT"></a>
+ <tr>
+  <td>DEFAULT</td>
+  <td>Ingress resources are applied if annotated with the configured ingress class, or not annotated with an ingress class at all. This mode is suitable for a controller running as the cluster's default ingress controller, which is expected to also process ingress resources not annotated at all.</td>
+ </tr>
+<a name="istio.proxy.v1alpha.config.ProxyMeshConfig.IngressControllerMode.STRICT"></a>
+ <tr>
+  <td>STRICT</td>
+  <td>Ingress resources are applied only if annotated with the configured ingress class. This mode is suitable for a controller which is a running as a secondary ingress controller (e.g., in addition to a cloud-provided ingress controller).</td>
+ </tr>
+</table>
+
+<a name="istio.proxy.v1alpha.config.RouteRule"></a>
+### RouteRule
+Route rule provides a custom routing policy based on the source and
+destination service versions and connection/request metadata.  The rule must
+provide a set of conditions for each protocol (TCP, UDP, HTTP) that the
+destination service exposes on its ports. The rule applies only to the ports
+on the destination service for which it provides protocol-specific match
+condition, e.g. if the rule does not specify TCP condition, the rule does
+not apply to TCP traffic towards the destination service.
+
+<table>
+ <tr>
+  <th>Field</th>
+  <th>Type</th>
+  <th>Description</th>
+ </tr>
+<a name="istio.proxy.v1alpha.config.RouteRule.destination"></a>
+ <tr>
+  <td><code>destination</code></td>
+  <td>string</td>
+  <td>REQUIRED: Destination uniquely identifies the destination associated with this routing rule. This field is applicable for hostname-based resolution for HTTP traffic as well as IP-based resolution for TCP/UDP traffic. The value MUST be a fully-qualified domain name, e.g. "my-service.default.svc.cluster.local".</td>
+ </tr>
+<a name="istio.proxy.v1alpha.config.RouteRule.precedence"></a>
+ <tr>
+  <td><code>precedence</code></td>
+  <td>int32</td>
+  <td>Precedence is used to disambiguate the order of application of rules for the same destination service. A higher number takes priority. If not specified, the value is assumed to be 0. The order of application for rules with the same precedence is unspecified.</td>
+ </tr>
+<a name="istio.proxy.v1alpha.config.RouteRule.match"></a>
+ <tr>
+  <td><code>match</code></td>
+  <td><a href="#istio.proxy.v1alpha.config.MatchCondition">MatchCondition</a></td>
+  <td>Optional match condtions to be satisfied for the route rule to be activated. If match is omitted, the route rule applies only to HTTP traffic.</td>
+ </tr>
+<a name="istio.proxy.v1alpha.config.RouteRule.route"></a>
+ <tr>
+  <td><code>route[]</code></td>
+  <td>repeated <a href="#istio.proxy.v1alpha.config.DestinationWeight">DestinationWeight</a></td>
+  <td>Each routing rule is associated with one or more service version destinations (see glossary in beginning of document). Weights associated with the service version determine the proportion of traffic it receives.</td>
+ </tr>
+<a name="istio.proxy.v1alpha.config.RouteRule.http_req_timeout"></a>
+ <tr>
+  <td><code>http_req_timeout</code></td>
+  <td><a href="#istio.proxy.v1alpha.config.HTTPTimeout">HTTPTimeout</a></td>
+  <td>Timeout policy for HTTP requests.</td>
+ </tr>
+<a name="istio.proxy.v1alpha.config.RouteRule.http_req_retries"></a>
+ <tr>
+  <td><code>http_req_retries</code></td>
+  <td><a href="#istio.proxy.v1alpha.config.HTTPRetry">HTTPRetry</a></td>
+  <td>Retry policy for HTTP requests.</td>
+ </tr>
+<a name="istio.proxy.v1alpha.config.RouteRule.http_fault"></a>
+ <tr>
+  <td><code>http_fault</code></td>
+  <td><a href="#istio.proxy.v1alpha.config.HTTPFaultInjection">HTTPFaultInjection</a></td>
+  <td>/L7 fault injection policy applies to Http traffic</td>
+ </tr>
+<a name="istio.proxy.v1alpha.config.RouteRule.l4_fault"></a>
+ <tr>
+  <td><code>l4_fault</code></td>
+  <td><a href="#istio.proxy.v1alpha.config.L4FaultInjection">L4FaultInjection</a></td>
+  <td>/@exclude L4 fault injection policy applies to Tcp/Udp (not Http) traffic</td>
+ </tr>
+</table>
+
+<a name="istio.proxy.v1alpha.config.StringMatch"></a>
+### StringMatch
+Describes how to matches a given string (exact match, prefix-based
+match or posix style regex based match). Match is case-sensitive. NOTE:
+use of regex depends on the specific proxy implementation.
+
+<table>
+ <tr>
+  <th>Field</th>
+  <th>Type</th>
+  <th>Description</th>
+ </tr>
+<a name="istio.proxy.v1alpha.config.StringMatch.exact"></a>
+ <tr>
+  <td><code>exact</code></td>
+  <td>string (oneof )</td>
+  <td></td>
+ </tr>
+<a name="istio.proxy.v1alpha.config.StringMatch.prefix"></a>
+ <tr>
+  <td><code>prefix</code></td>
+  <td>string (oneof )</td>
+  <td></td>
+ </tr>
+<a name="istio.proxy.v1alpha.config.StringMatch.regex"></a>
+ <tr>
+  <td><code>regex</code></td>
+  <td>string (oneof )</td>
+  <td></td>
+ </tr>
+</table>

--- a/_docs/reference/api/mixer-config.md
+++ b/_docs/reference/api/mixer-config.md
@@ -1,0 +1,1008 @@
+---
+category: Reference
+title: Mixer Configuration Schema
+overview: Generated documentation for Mixer's Configuration Schema
+              
+parent: API and Configuration Schemas
+order: 40
+
+bodyclass: docs
+layout: docs
+type: markdown
+---
+
+<a name="rpc_istio.mixer.v1_config"></a>
+## Package istio.mixer.v1.config
+
+<a name="rpc_istio.mixer.v1_config_index"></a>
+### Index
+
+* [Adapter](#istio.mixer.v1.config.Adapter)
+(message)
+* [Aspect](#istio.mixer.v1.config.Aspect)
+(message)
+* [AspectRule](#istio.mixer.v1.config.AspectRule)
+(message)
+* [AttributeManifest](#istio.mixer.v1.config.AttributeManifest)
+(message)
+* [DnsName](#istio.mixer.v1.config.DnsName)
+(message)
+* [EmailAddress](#istio.mixer.v1.config.EmailAddress)
+(message)
+* [GlobalConfig](#istio.mixer.v1.config.GlobalConfig)
+(message)
+* [IpAddress](#istio.mixer.v1.config.IpAddress)
+(message)
+* [ServiceConfig](#istio.mixer.v1.config.ServiceConfig)
+(message)
+* [Uri](#istio.mixer.v1.config.Uri)
+(message)
+
+<a name="istio.mixer.v1.config.Adapter"></a>
+### Adapter
+Adapter config defines specifics of adapter implementations
+We define an adapter that provides "metrics" aspect
+kind: istio/metrics
+name: metrics-statsd
+impl: “istio.io/adapters/statsd”
+params:
+   Host: statd.svc.cluster
+   Port: 8125
+
+<table>
+ <tr>
+  <th>Field</th>
+  <th>Type</th>
+  <th>Description</th>
+ </tr>
+<a name="istio.mixer.v1.config.Adapter.name"></a>
+ <tr>
+  <td><code>name</code></td>
+  <td>string</td>
+  <td>statsd-slow</td>
+ </tr>
+<a name="istio.mixer.v1.config.Adapter.kind"></a>
+ <tr>
+  <td><code>kind</code></td>
+  <td>string</td>
+  <td>metrics</td>
+ </tr>
+<a name="istio.mixer.v1.config.Adapter.impl"></a>
+ <tr>
+  <td><code>impl</code></td>
+  <td>string</td>
+  <td>istio.statsd</td>
+ </tr>
+<a name="istio.mixer.v1.config.Adapter.params"></a>
+ <tr>
+  <td><code>params</code></td>
+  <td><a href="https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#struct">Struct</a></td>
+  <td>Struct representation of a proto defined by the implementation based on impl {}</td>
+ </tr>
+</table>
+
+<a name="istio.mixer.v1.config.Aspect"></a>
+### Aspect
+Aspect is intent based. It specifies the intent "kind"
+following example specifies that the user would like to collect
+response_time with 3 labels (src_consumer_id, target_response_status_code,
+target_service_name)
+
+The Input section tells if target_service_name is not available it can be
+computed using the given expression
+
+
+     kind: istio/metrics
+     params:
+       metrics:
+       - name: response_time     # What to call this metric outbound.
+         value: metric_response_time  # from wellknown vocabulary
+         metric_kind: DELTA
+         labels:
+         - key: src_consumer_id
+         - key: target_response_status_code
+         - key: target_service_name
+
+<table>
+ <tr>
+  <th>Field</th>
+  <th>Type</th>
+  <th>Description</th>
+ </tr>
+<a name="istio.mixer.v1.config.Aspect.kind"></a>
+ <tr>
+  <td><code>kind</code></td>
+  <td>string</td>
+  <td></td>
+ </tr>
+<a name="istio.mixer.v1.config.Aspect.adapter"></a>
+ <tr>
+  <td><code>adapter</code></td>
+  <td>string</td>
+  <td>optional, allows specifying an adapter</td>
+ </tr>
+<a name="istio.mixer.v1.config.Aspect.params"></a>
+ <tr>
+  <td><code>params</code></td>
+  <td><a href="https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#struct">Struct</a></td>
+  <td>Struct representation of a proto defined by the aspect</td>
+ </tr>
+</table>
+
+<a name="istio.mixer.v1.config.AspectRule"></a>
+### AspectRule
+AspectRules are intent based
+
+<table>
+ <tr>
+  <th>Field</th>
+  <th>Type</th>
+  <th>Description</th>
+ </tr>
+<a name="istio.mixer.v1.config.AspectRule.selector"></a>
+ <tr>
+  <td><code>selector</code></td>
+  <td>string</td>
+  <td>selector is an attributes based predicate. attr1 == "20" &amp;&amp; attr2 == "30"</td>
+ </tr>
+<a name="istio.mixer.v1.config.AspectRule.aspects"></a>
+ <tr>
+  <td><code>aspects[]</code></td>
+  <td>repeated <a href="#istio.mixer.v1.config.Aspect">Aspect</a></td>
+  <td>The following aspects apply when the selector predicate evaluates to True</td>
+ </tr>
+<a name="istio.mixer.v1.config.AspectRule.rules"></a>
+ <tr>
+  <td><code>rules[]</code></td>
+  <td>repeated <a href="#istio.mixer.v1.config.AspectRule">AspectRule</a></td>
+  <td>Nested aspect Rule is evaluated if selector predicate evaluates to True</td>
+ </tr>
+</table>
+
+<a name="istio.mixer.v1.config.AttributeManifest"></a>
+### AttributeManifest
+AttributeManifest describes a set of Attributes produced by some component of an Istio deployment.
+
+<table>
+ <tr>
+  <th>Field</th>
+  <th>Type</th>
+  <th>Description</th>
+ </tr>
+<a name="istio.mixer.v1.config.AttributeManifest.revision"></a>
+ <tr>
+  <td><code>revision</code></td>
+  <td>string</td>
+  <td></td>
+ </tr>
+<a name="istio.mixer.v1.config.AttributeManifest.name"></a>
+ <tr>
+  <td><code>name</code></td>
+  <td>string</td>
+  <td>Name of the component producing these attributes. This can be the proxy (with the canonical name "istio-proxy") or the name of an attribute producing adapter in the mixer itself.</td>
+ </tr>
+<a name="istio.mixer.v1.config.AttributeManifest.attributes"></a>
+ <tr>
+  <td><code>attributes[]</code></td>
+  <td>repeated <a href="#istio.mixer.v1.config.descriptor.AttributeDescriptor">AttributeDescriptor</a></td>
+  <td>The set of attributes this Istio component will be responsible for producing at runtime.</td>
+ </tr>
+</table>
+
+<a name="istio.mixer.v1.config.DnsName"></a>
+### DnsName
+DnsName holds a valid domain name.
+
+<table>
+ <tr>
+  <th>Field</th>
+  <th>Type</th>
+  <th>Description</th>
+ </tr>
+<a name="istio.mixer.v1.config.DnsName.value"></a>
+ <tr>
+  <td><code>value</code></td>
+  <td>string</td>
+  <td></td>
+ </tr>
+</table>
+
+<a name="istio.mixer.v1.config.EmailAddress"></a>
+### EmailAddress
+EmailAddress holds a properly formatted email address.
+
+<table>
+ <tr>
+  <th>Field</th>
+  <th>Type</th>
+  <th>Description</th>
+ </tr>
+<a name="istio.mixer.v1.config.EmailAddress.value"></a>
+ <tr>
+  <td><code>value</code></td>
+  <td>string</td>
+  <td></td>
+ </tr>
+</table>
+
+<a name="istio.mixer.v1.config.GlobalConfig"></a>
+### GlobalConfig
+GlobalConfig defines configuration elements that are available
+for the rest of the config
+It is used to configure adapters and make them available in AspectRules
+
+<table>
+ <tr>
+  <th>Field</th>
+  <th>Type</th>
+  <th>Description</th>
+ </tr>
+<a name="istio.mixer.v1.config.GlobalConfig.revision"></a>
+ <tr>
+  <td><code>revision</code></td>
+  <td>string</td>
+  <td></td>
+ </tr>
+<a name="istio.mixer.v1.config.GlobalConfig.adapters"></a>
+ <tr>
+  <td><code>adapters[]</code></td>
+  <td>repeated <a href="#istio.mixer.v1.config.Adapter">Adapter</a></td>
+  <td></td>
+ </tr>
+<a name="istio.mixer.v1.config.GlobalConfig.manifests"></a>
+ <tr>
+  <td><code>manifests[]</code></td>
+  <td>repeated <a href="#istio.mixer.v1.config.AttributeManifest">AttributeManifest</a></td>
+  <td></td>
+ </tr>
+<a name="istio.mixer.v1.config.GlobalConfig.logs"></a>
+ <tr>
+  <td><code>logs[]</code></td>
+  <td>repeated <a href="#istio.mixer.v1.config.descriptor.LogEntryDescriptor">LogEntryDescriptor</a></td>
+  <td></td>
+ </tr>
+<a name="istio.mixer.v1.config.GlobalConfig.metrics"></a>
+ <tr>
+  <td><code>metrics[]</code></td>
+  <td>repeated <a href="#istio.mixer.v1.config.descriptor.MetricDescriptor">MetricDescriptor</a></td>
+  <td></td>
+ </tr>
+<a name="istio.mixer.v1.config.GlobalConfig.monitored_resources"></a>
+ <tr>
+  <td><code>monitored_resources[]</code></td>
+  <td>repeated <a href="#istio.mixer.v1.config.descriptor.MonitoredResourceDescriptor">MonitoredResourceDescriptor</a></td>
+  <td></td>
+ </tr>
+<a name="istio.mixer.v1.config.GlobalConfig.principals"></a>
+ <tr>
+  <td><code>principals[]</code></td>
+  <td>repeated <a href="#istio.mixer.v1.config.descriptor.PrincipalDescriptor">PrincipalDescriptor</a></td>
+  <td></td>
+ </tr>
+<a name="istio.mixer.v1.config.GlobalConfig.quotas"></a>
+ <tr>
+  <td><code>quotas[]</code></td>
+  <td>repeated <a href="#istio.mixer.v1.config.descriptor.QuotaDescriptor">QuotaDescriptor</a></td>
+  <td></td>
+ </tr>
+</table>
+
+<a name="istio.mixer.v1.config.IpAddress"></a>
+### IpAddress
+IpAddress holds an IPv4 or IPv6 address.
+
+<table>
+ <tr>
+  <th>Field</th>
+  <th>Type</th>
+  <th>Description</th>
+ </tr>
+<a name="istio.mixer.v1.config.IpAddress.value"></a>
+ <tr>
+  <td><code>value</code></td>
+  <td>bytes</td>
+  <td></td>
+ </tr>
+</table>
+
+<a name="istio.mixer.v1.config.ServiceConfig"></a>
+### ServiceConfig
+Configures a set of services
+following example configures metrics collection and ratelimit for
+all services
+
+
+<a name="rpc_istio.mixer.v1_config_istio.mixer.v1.config.ServiceConfig_description_subsection"></a>
+#### service config
+subject: "namespace:ns1"
+revision: "1011"
+rules:
+- selector: target_name == "*"
+ aspects:
+ - kind: metrics
+   params:
+     metrics:   # defines metric collection across the board.
+     - name: response_time_by_status_code
+       value: metric.response_time     # certain attributes are metrics
+       metric_kind: DELTA
+       labels:
+       - key: response.status_code
+ - kind: ratelimiter
+   params:
+     limits:  # imposes 2 limits, 100/s per source and destination
+     - limit: "100/s"
+       labels:
+         - key: src.service_id
+         - key: target.service_id
+      - limit: "1000/s"  # every destination service gets 1000/s
+       labels:
+         - key: target.service_id
+
+<table>
+ <tr>
+  <th>Field</th>
+  <th>Type</th>
+  <th>Description</th>
+ </tr>
+<a name="istio.mixer.v1.config.ServiceConfig.subject"></a>
+ <tr>
+  <td><code>subject</code></td>
+  <td>string</td>
+  <td>subject is unique for a config type 2 config with the same subject will overwrite each other</td>
+ </tr>
+<a name="istio.mixer.v1.config.ServiceConfig.revision"></a>
+ <tr>
+  <td><code>revision</code></td>
+  <td>string</td>
+  <td>revision of this config. This is assigned by the server</td>
+ </tr>
+<a name="istio.mixer.v1.config.ServiceConfig.rules"></a>
+ <tr>
+  <td><code>rules[]</code></td>
+  <td>repeated <a href="#istio.mixer.v1.config.AspectRule">AspectRule</a></td>
+  <td></td>
+ </tr>
+</table>
+
+<a name="istio.mixer.v1.config.Uri"></a>
+### Uri
+Uri represents a properly formed URI.
+
+<table>
+ <tr>
+  <th>Field</th>
+  <th>Type</th>
+  <th>Description</th>
+ </tr>
+<a name="istio.mixer.v1.config.Uri.value"></a>
+ <tr>
+  <td><code>value</code></td>
+  <td>string</td>
+  <td></td>
+ </tr>
+</table>
+
+<a name="rpc_istio.mixer.v1_config_descriptor"></a>
+## Package istio.mixer.v1.config.descriptor
+
+<a name="rpc_istio.mixer.v1_config_descriptor_index"></a>
+### Index
+
+* [AttributeDescriptor](#istio.mixer.v1.config.descriptor.AttributeDescriptor)
+(message)
+* [LogEntryDescriptor](#istio.mixer.v1.config.descriptor.LogEntryDescriptor)
+(message)
+* [LogEntryDescriptor.PayloadFormat](#istio.mixer.v1.config.descriptor.LogEntryDescriptor.PayloadFormat)
+(enum)
+* [MetricDescriptor](#istio.mixer.v1.config.descriptor.MetricDescriptor)
+(message)
+* [MetricDescriptor.BucketsDefinition](#istio.mixer.v1.config.descriptor.MetricDescriptor.BucketsDefinition)
+(message)
+* [MetricDescriptor.BucketsDefinition.Explicit](#istio.mixer.v1.config.descriptor.MetricDescriptor.BucketsDefinition.Explicit)
+(message)
+* [MetricDescriptor.BucketsDefinition.Exponential](#istio.mixer.v1.config.descriptor.MetricDescriptor.BucketsDefinition.Exponential)
+(message)
+* [MetricDescriptor.BucketsDefinition.Linear](#istio.mixer.v1.config.descriptor.MetricDescriptor.BucketsDefinition.Linear)
+(message)
+* [MetricDescriptor.MetricKind](#istio.mixer.v1.config.descriptor.MetricDescriptor.MetricKind)
+(enum)
+* [MonitoredResourceDescriptor](#istio.mixer.v1.config.descriptor.MonitoredResourceDescriptor)
+(message)
+* [PrincipalDescriptor](#istio.mixer.v1.config.descriptor.PrincipalDescriptor)
+(message)
+* [QuotaDescriptor](#istio.mixer.v1.config.descriptor.QuotaDescriptor)
+(message)
+* [ValueType](#istio.mixer.v1.config.descriptor.ValueType)
+(enum)
+
+<a name="istio.mixer.v1.config.descriptor.AttributeDescriptor"></a>
+### AttributeDescriptor
+An `AttributeDescriptor` describes the schema of an Istio attribute type.
+
+
+
+<a name="rpc_istio.mixer.v1_config_descriptor_istio.mixer.v1.config.descriptor.AttributeDescriptor_description_subsection_subsection"></a>
+#### Istio Attributes
+Istio uses `attributes` to describe runtime activities of Istio services.
+An Istio attribute carries a specific piece of information about an activity,
+such as the error code of an API request, the latency of an API request, the
+original IP address of a TCP connection. The attributes are often generated
+and consumed by different services. For example, a frontend service can
+generate an authenticated user attribute and pass it to a backend service for
+access control purpose.
+
+To simplify the system and improve developer experience, Istio uses
+shared attribute definitions across all components. For example, the same
+authenticated user attribute will be used for logging, monitoring, analytics,
+billing, access control, auditing. Many Istio components provide their
+functionality by collecting, generating, and operating on attributes.
+For example, the proxy collects the error code attribute, and the logging
+stores it into a log.
+
+
+
+<a name="rpc_istio.mixer.v1_config_descriptor_istio.mixer.v1.config.descriptor.AttributeDescriptor_description_subsection_subsection_1"></a>
+#### Design
+Each Istio attribute must conform to an Istio attribute type. The
+`AttributeDescriptor` is used to define attribute types. Each type has a
+globally unique type name, the type of the value, and a detailed description
+that explains the semantics of the attribute type.
+
+The runtime presentation of an attribute is intentionally left out of this
+specification, because passing attribute using JSON, XML, or Protocol Buffers
+does not change the semantics of the attribute. Different implementations
+can choose different representations based on their needs.
+
+
+
+<a name="rpc_istio.mixer.v1_config_descriptor_istio.mixer.v1.config.descriptor.AttributeDescriptor_description_subsection_subsection_2"></a>
+#### HTTP Mapping
+Because many systems already have REST APIs, it makes sense to define a
+standard HTTP mapping for Istio attributes that are compatible with typical
+REST APIs. The design is to map one attribute to one HTTP header, the
+attribute name and value becomes the HTTP header name and value. The actual
+encoding scheme will be decided later.
+
+<table>
+ <tr>
+  <th>Field</th>
+  <th>Type</th>
+  <th>Description</th>
+ </tr>
+<a name="istio.mixer.v1.config.descriptor.AttributeDescriptor.name"></a>
+ <tr>
+  <td><code>name</code></td>
+  <td>string</td>
+  <td><p>The name of this descriptor, referenced from individual attribute instances and other descriptors.</p><p>The format of this name is:</p>
+<pre><code>Name = IDENT { &quot;.&quot; IDENT } ;
+</code></pre><p>Where <code>IDENT</code> must match the regular expression <code>a-z+</code>.</p><p>Attribute descriptor names must be unique within a single Istio deployment. There is a well- known set of attributes which have succinct names. Attributes not on this list should be named with a component-specific suffix such as request.count-my.component</p></td>
+ </tr>
+<a name="istio.mixer.v1.config.descriptor.AttributeDescriptor.description"></a>
+ <tr>
+  <td><code>description</code></td>
+  <td>string</td>
+  <td>An optional human-readable description of the attribute's purpose.</td>
+ </tr>
+<a name="istio.mixer.v1.config.descriptor.AttributeDescriptor.value_type"></a>
+ <tr>
+  <td><code>value_type</code></td>
+  <td><a href="#istio.mixer.v1.config.descriptor.ValueType">ValueType</a></td>
+  <td>The type of data carried by attributes</td>
+ </tr>
+</table>
+
+<a name="istio.mixer.v1.config.descriptor.LogEntryDescriptor"></a>
+### LogEntryDescriptor
+Defines the format of a single log entry.
+
+<table>
+ <tr>
+  <th>Field</th>
+  <th>Type</th>
+  <th>Description</th>
+ </tr>
+<a name="istio.mixer.v1.config.descriptor.LogEntryDescriptor.name"></a>
+ <tr>
+  <td><code>name</code></td>
+  <td>string</td>
+  <td>The name of this descriptor.</td>
+ </tr>
+<a name="istio.mixer.v1.config.descriptor.LogEntryDescriptor.display_name"></a>
+ <tr>
+  <td><code>display_name</code></td>
+  <td>string</td>
+  <td>An optional concise name for the log entry type, which can be displayed in user interfaces. Use sentence case without an ending period, for example "Request count".</td>
+ </tr>
+<a name="istio.mixer.v1.config.descriptor.LogEntryDescriptor.description"></a>
+ <tr>
+  <td><code>description</code></td>
+  <td>string</td>
+  <td>An optional description of the log entry type, which can be used in documentation.</td>
+ </tr>
+<a name="istio.mixer.v1.config.descriptor.LogEntryDescriptor.payload_format"></a>
+ <tr>
+  <td><code>payload_format</code></td>
+  <td><a href="#istio.mixer.v1.config.descriptor.LogEntryDescriptor.PayloadFormat">PayloadFormat</a></td>
+  <td>Format of the value of the payload attribute.</td>
+ </tr>
+<a name="istio.mixer.v1.config.descriptor.LogEntryDescriptor.log_template"></a>
+ <tr>
+  <td><code>log_template</code></td>
+  <td>string</td>
+  <td><p>The template that will be populated with labels at runtime to generate a log message; the labels describe the parameters for this template.</p><p>The template strings must conform to go's text/template syntax.</p></td>
+ </tr>
+<a name="istio.mixer.v1.config.descriptor.LogEntryDescriptor.labels"></a>
+ <tr>
+  <td><code>labels</code></td>
+  <td>repeated map&lt;string, <a href="#istio.mixer.v1.config.descriptor.ValueType">ValueType</a>&gt;</td>
+  <td>Labels describe the parameters of this log's template string. The log definition allows the user to map attribute expressions to actual values for these labels at run time; the result of the evaluation must be of the type described by the kind for each label.</td>
+ </tr>
+</table>
+
+<a name="istio.mixer.v1.config.descriptor.LogEntryDescriptor.PayloadFormat"></a>
+### PayloadFormat
+PayloadFormat details the currently supported logging payload formats.
+TEXT is the default payload format.
+
+
+<table>
+ <tr>
+  <th>Value</th>
+  <th>Description</th>
+ </tr>
+<a name="istio.mixer.v1.config.descriptor.LogEntryDescriptor.PayloadFormat.PAYLOAD_FORMAT_UNSPECIFIED"></a>
+ <tr>
+  <td>PAYLOAD_FORMAT_UNSPECIFIED</td>
+  <td>Invalid, default value.</td>
+ </tr>
+<a name="istio.mixer.v1.config.descriptor.LogEntryDescriptor.PayloadFormat.TEXT"></a>
+ <tr>
+  <td>TEXT</td>
+  <td>Indicates a payload format of raw text.</td>
+ </tr>
+<a name="istio.mixer.v1.config.descriptor.LogEntryDescriptor.PayloadFormat.JSON"></a>
+ <tr>
+  <td>JSON</td>
+  <td>Indicates that the payload is a serialized JSON object.</td>
+ </tr>
+</table>
+
+<a name="istio.mixer.v1.config.descriptor.MetricDescriptor"></a>
+### MetricDescriptor
+Defines a metric type and its schema.
+
+A metric is dimensioned by a set of labels whose values are derived at runtime from attributes.
+A given metric holds a unique value for potentially any combination of these dimensions.
+
+The following is an example descriptor for a metric capturing the number of RPCs served, dimensioned
+by the method being called and response code returned by the server:
+
+   metric_descriptor:
+     name: "response_code"
+     kind: COUNTER
+     value: I64
+     labels:
+       name: api_method
+       value_type: STRING
+     labels:
+       name: response_code
+       value_type: INT64
+
+To actually report metrics at run time a mapping from attributes to a metric's labels must be provided.
+This is provided in the aspect config; using our above descriptor we might describe the metric as:
+
+   metric:
+     descriptor: "response_code" # must match metric_descriptor.name
+     value: $requestCount        # Istio expression syntax for the attribute named "request_count"
+     labels:
+       # either the attribute named 'apiMethod' or the literal string 'unknown'; must eval to a string
+       api_method: $apiMethod | "unknown"
+       # either the attribute named 'responseCode' or the literal int64 500; must eval to an int64
+       response_code: $responseCode | 500
+
+<table>
+ <tr>
+  <th>Field</th>
+  <th>Type</th>
+  <th>Description</th>
+ </tr>
+<a name="istio.mixer.v1.config.descriptor.MetricDescriptor.name"></a>
+ <tr>
+  <td><code>name</code></td>
+  <td>string</td>
+  <td>The name of this descriptor. This is used to refer to this descriptor in other contexts.</td>
+ </tr>
+<a name="istio.mixer.v1.config.descriptor.MetricDescriptor.display_name"></a>
+ <tr>
+  <td><code>display_name</code></td>
+  <td>string</td>
+  <td>An optional concise name for the metric, which can be displayed in user interfaces. Use sentence case without an ending period, for example "Request count".</td>
+ </tr>
+<a name="istio.mixer.v1.config.descriptor.MetricDescriptor.description"></a>
+ <tr>
+  <td><code>description</code></td>
+  <td>string</td>
+  <td>An optional description of the metric, which should be used as the documentation for the metric.</td>
+ </tr>
+<a name="istio.mixer.v1.config.descriptor.MetricDescriptor.kind"></a>
+ <tr>
+  <td><code>kind</code></td>
+  <td><a href="#istio.mixer.v1.config.descriptor.MetricDescriptor.MetricKind">MetricKind</a></td>
+  <td>Whether the metric records instantaneous values, changes to a value, etc.</td>
+ </tr>
+<a name="istio.mixer.v1.config.descriptor.MetricDescriptor.value"></a>
+ <tr>
+  <td><code>value</code></td>
+  <td><a href="#istio.mixer.v1.config.descriptor.ValueType">ValueType</a></td>
+  <td>The type of data this metric records.</td>
+ </tr>
+<a name="istio.mixer.v1.config.descriptor.MetricDescriptor.labels"></a>
+ <tr>
+  <td><code>labels</code></td>
+  <td>repeated map&lt;string, <a href="#istio.mixer.v1.config.descriptor.ValueType">ValueType</a>&gt;</td>
+  <td>Labels that dimension the data recorded by this metric. The metric definition allows the user to map attribute expressions to actual values for these labels at run time; the result of the evaluation must be of the type described by the kind for each label.</td>
+ </tr>
+<a name="istio.mixer.v1.config.descriptor.MetricDescriptor.buckets"></a>
+ <tr>
+  <td><code>buckets</code></td>
+  <td><a href="#istio.mixer.v1.config.descriptor.MetricDescriptor.BucketsDefinition">BucketsDefinition</a></td>
+  <td>For metrics with a metric kind of DISTRIBUTION, this provides a mechanism for configuring the buckets that will be used to store the aggregated values. This field must be provided for metrics declared to be of type DISTRIBUTION. This field will be ignored for non-distribution metric kinds.</td>
+ </tr>
+</table>
+
+<a name="istio.mixer.v1.config.descriptor.MetricDescriptor.BucketsDefinition"></a>
+### BucketsDefinition
+
+<table>
+ <tr>
+  <th>Field</th>
+  <th>Type</th>
+  <th>Description</th>
+ </tr>
+<a name="istio.mixer.v1.config.descriptor.MetricDescriptor.BucketsDefinition.linear_buckets"></a>
+ <tr>
+  <td><code>linear_buckets</code></td>
+  <td><a href="#istio.mixer.v1.config.descriptor.MetricDescriptor.BucketsDefinition.Linear">Linear</a> (oneof )</td>
+  <td>The linear buckets.</td>
+ </tr>
+<a name="istio.mixer.v1.config.descriptor.MetricDescriptor.BucketsDefinition.exponential_buckets"></a>
+ <tr>
+  <td><code>exponential_buckets</code></td>
+  <td><a href="#istio.mixer.v1.config.descriptor.MetricDescriptor.BucketsDefinition.Exponential">Exponential</a> (oneof )</td>
+  <td>The exponential buckets.</td>
+ </tr>
+<a name="istio.mixer.v1.config.descriptor.MetricDescriptor.BucketsDefinition.explicit_buckets"></a>
+ <tr>
+  <td><code>explicit_buckets</code></td>
+  <td><a href="#istio.mixer.v1.config.descriptor.MetricDescriptor.BucketsDefinition.Explicit">Explicit</a> (oneof )</td>
+  <td>The explicit buckets.</td>
+ </tr>
+</table>
+
+<a name="istio.mixer.v1.config.descriptor.MetricDescriptor.BucketsDefinition.Explicit"></a>
+### Explicit
+Specifies a set of buckets with arbitrary widths.
+
+There are `size(bounds) + 1` (= N) buckets. Bucket `i` has the following
+boundaries:
+
+   Upper bound (0 <= i < N-1):     bounds[i]
+   Lower bound (1 <= i < N);       bounds[i - 1]
+
+The `bounds` field must contain at least one element. If `bounds` has
+only one element, then there are no finite buckets, and that single
+element is the common boundary of the overflow and underflow buckets.
+
+<table>
+ <tr>
+  <th>Field</th>
+  <th>Type</th>
+  <th>Description</th>
+ </tr>
+<a name="istio.mixer.v1.config.descriptor.MetricDescriptor.BucketsDefinition.Explicit.bounds"></a>
+ <tr>
+  <td><code>bounds[]</code></td>
+  <td>repeated double</td>
+  <td>The values must be monotonically increasing.</td>
+ </tr>
+</table>
+
+<a name="istio.mixer.v1.config.descriptor.MetricDescriptor.BucketsDefinition.Exponential"></a>
+### Exponential
+Specifies an exponential sequence of buckets that have a width that is
+proportional to the value of the lower bound. Each bucket represents a
+constant relative uncertainty on a specific value in the bucket.
+
+There are `num_finite_buckets + 2` (= N) buckets. The two additional
+buckets are the underflow and overflow buckets.
+
+Bucket `i` has the following boundaries:
+
+   Upper bound (0 <= i < N-1):     scale * (growth_factor ^ i).
+   Lower bound (1 <= i < N):       scale * (growth_factor ^ (i - 1)).
+
+<table>
+ <tr>
+  <th>Field</th>
+  <th>Type</th>
+  <th>Description</th>
+ </tr>
+<a name="istio.mixer.v1.config.descriptor.MetricDescriptor.BucketsDefinition.Exponential.num_finite_buckets"></a>
+ <tr>
+  <td><code>num_finite_buckets</code></td>
+  <td>int32</td>
+  <td>Must be greater than 0.</td>
+ </tr>
+<a name="istio.mixer.v1.config.descriptor.MetricDescriptor.BucketsDefinition.Exponential.growth_factor"></a>
+ <tr>
+  <td><code>growth_factor</code></td>
+  <td>double</td>
+  <td>Must be greater than 1.</td>
+ </tr>
+<a name="istio.mixer.v1.config.descriptor.MetricDescriptor.BucketsDefinition.Exponential.scale"></a>
+ <tr>
+  <td><code>scale</code></td>
+  <td>double</td>
+  <td>Must be greater than 0.</td>
+ </tr>
+</table>
+
+<a name="istio.mixer.v1.config.descriptor.MetricDescriptor.BucketsDefinition.Linear"></a>
+### Linear
+Specifies a linear sequence of buckets that all have the same width
+(except overflow and underflow). Each bucket represents a constant
+absolute uncertainty on the specific value in the bucket.
+
+There are `num_finite_buckets + 2` (= N) buckets. The two additional
+buckets are the underflow and overflow buckets.
+
+Bucket `i` has the following boundaries:
+
+   Upper bound (0 <= i < N-1):     offset + (width * i).
+   Lower bound (1 <= i < N):       offset + (width * (i - 1)).
+
+<table>
+ <tr>
+  <th>Field</th>
+  <th>Type</th>
+  <th>Description</th>
+ </tr>
+<a name="istio.mixer.v1.config.descriptor.MetricDescriptor.BucketsDefinition.Linear.num_finite_buckets"></a>
+ <tr>
+  <td><code>num_finite_buckets</code></td>
+  <td>int32</td>
+  <td>Must be greater than 0.</td>
+ </tr>
+<a name="istio.mixer.v1.config.descriptor.MetricDescriptor.BucketsDefinition.Linear.width"></a>
+ <tr>
+  <td><code>width</code></td>
+  <td>double</td>
+  <td>Must be greater than 0.</td>
+ </tr>
+<a name="istio.mixer.v1.config.descriptor.MetricDescriptor.BucketsDefinition.Linear.offset"></a>
+ <tr>
+  <td><code>offset</code></td>
+  <td>double</td>
+  <td>Lower bound of the first bucket.</td>
+ </tr>
+</table>
+
+<a name="istio.mixer.v1.config.descriptor.MetricDescriptor.MetricKind"></a>
+### MetricKind
+The kind of measurement. It describes how the data is recorded.
+
+
+<table>
+ <tr>
+  <th>Value</th>
+  <th>Description</th>
+ </tr>
+<a name="istio.mixer.v1.config.descriptor.MetricDescriptor.MetricKind.METRIC_KIND_UNSPECIFIED"></a>
+ <tr>
+  <td>METRIC_KIND_UNSPECIFIED</td>
+  <td>Do not use this default value.</td>
+ </tr>
+<a name="istio.mixer.v1.config.descriptor.MetricDescriptor.MetricKind.GAUGE"></a>
+ <tr>
+  <td>GAUGE</td>
+  <td>An instantaneous measurement of a value. For example, the number of VMs.</td>
+ </tr>
+<a name="istio.mixer.v1.config.descriptor.MetricDescriptor.MetricKind.COUNTER"></a>
+ <tr>
+  <td>COUNTER</td>
+  <td>A count of occurrences over an interval, always a positive integer. For example, the number of API requests.</td>
+ </tr>
+<a name="istio.mixer.v1.config.descriptor.MetricDescriptor.MetricKind.DISTRIBUTION"></a>
+ <tr>
+  <td>DISTRIBUTION</td>
+  <td><p>Summary statistics for a population of values. At the moment, only histograms representing the distribution of those values across a set of buckets are supported (configured via the buckets field).</p><p>Values for DISTRIBUTIONs will be reported in singular form. It will be up to the mixer adapters and backend systems to transform single reported values into the distribution form as needed (and as supported).</p></td>
+ </tr>
+</table>
+
+<a name="istio.mixer.v1.config.descriptor.MonitoredResourceDescriptor"></a>
+### MonitoredResourceDescriptor
+An object that describes the schema of a `MonitoredResource`. A
+`MonitoredResource` is used to define a type of resources for
+monitoring purpose. For example, the monitored resource "VM" refers
+to virtual machines, which requires 3 attributes "owner", "zone",
+"name" to uniquely identify a specific instance. When reporting
+a metric against a monitored resource, the metric attributes will
+be used to associate the right value with the right instance,
+such as memory usage of a VM.
+
+<table>
+ <tr>
+  <th>Field</th>
+  <th>Type</th>
+  <th>Description</th>
+ </tr>
+<a name="istio.mixer.v1.config.descriptor.MonitoredResourceDescriptor.name"></a>
+ <tr>
+  <td><code>name</code></td>
+  <td>string</td>
+  <td>The name of this descriptor</td>
+ </tr>
+<a name="istio.mixer.v1.config.descriptor.MonitoredResourceDescriptor.description"></a>
+ <tr>
+  <td><code>description</code></td>
+  <td>string</td>
+  <td>An optional detailed description of the monitored resource descriptor that might be used in documentation.</td>
+ </tr>
+<a name="istio.mixer.v1.config.descriptor.MonitoredResourceDescriptor.labels"></a>
+ <tr>
+  <td><code>labels</code></td>
+  <td>repeated map&lt;string, <a href="#istio.mixer.v1.config.descriptor.ValueType">ValueType</a>&gt;</td>
+  <td>Labels represent the dimensions that uniquely identify this monitored resource. At runtime expressions will be evaluated to provide values for each label. Label names are mapped to expressions as part of aspect configuration.</td>
+ </tr>
+</table>
+
+<a name="istio.mixer.v1.config.descriptor.PrincipalDescriptor"></a>
+### PrincipalDescriptor
+Defines a a security principal.
+
+A principal is described by a set of attributes.
+
+<table>
+ <tr>
+  <th>Field</th>
+  <th>Type</th>
+  <th>Description</th>
+ </tr>
+<a name="istio.mixer.v1.config.descriptor.PrincipalDescriptor.name"></a>
+ <tr>
+  <td><code>name</code></td>
+  <td>string</td>
+  <td>The name of this descriptor.</td>
+ </tr>
+<a name="istio.mixer.v1.config.descriptor.PrincipalDescriptor.labels"></a>
+ <tr>
+  <td><code>labels</code></td>
+  <td>repeated map&lt;string, <a href="#istio.mixer.v1.config.descriptor.ValueType">ValueType</a>&gt;</td>
+  <td>Labels represent the dimensions that uniquely identify this security principal. At runtime expressions will be evaluated to provide values for each label. Label names are mapped to expressions as part of aspect configuration.</td>
+ </tr>
+</table>
+
+<a name="istio.mixer.v1.config.descriptor.QuotaDescriptor"></a>
+### QuotaDescriptor
+Configuration state for a particular quota.
+
+Quotas are similar to metrics, except that they are mutated through method
+calls and there are limits on the allowed values.
+The descriptor below lets you define a quota and indicate the maximum
+amount values of this quota are allowed to hold.
+
+A given quota is described by a set of attributes. These attributes represent
+the different dimensions to associate with the quota. A given quota holds a
+unique value for potentially any combination of these attributes.
+
+<table>
+ <tr>
+  <th>Field</th>
+  <th>Type</th>
+  <th>Description</th>
+ </tr>
+<a name="istio.mixer.v1.config.descriptor.QuotaDescriptor.name"></a>
+ <tr>
+  <td><code>name</code></td>
+  <td>string</td>
+  <td>The name of this descriptor.</td>
+ </tr>
+<a name="istio.mixer.v1.config.descriptor.QuotaDescriptor.display_name"></a>
+ <tr>
+  <td><code>display_name</code></td>
+  <td>string</td>
+  <td>An optional concise name for the quota which can be displayed in user interfaces.</td>
+ </tr>
+<a name="istio.mixer.v1.config.descriptor.QuotaDescriptor.description"></a>
+ <tr>
+  <td><code>description</code></td>
+  <td>string</td>
+  <td>An optional description of the quota which can be used in documentation.</td>
+ </tr>
+<a name="istio.mixer.v1.config.descriptor.QuotaDescriptor.labels"></a>
+ <tr>
+  <td><code>labels</code></td>
+  <td>repeated map&lt;string, <a href="#istio.mixer.v1.config.descriptor.ValueType">ValueType</a>&gt;</td>
+  <td>The set of labels that are necessary to describe a specific value cell for a quota of this type.</td>
+ </tr>
+<a name="istio.mixer.v1.config.descriptor.QuotaDescriptor.rate_limit"></a>
+ <tr>
+  <td><code>rate_limit</code></td>
+  <td>bool</td>
+  <td>Indicates whether the quota represents a rate limit or represents a resource quota.</td>
+ </tr>
+</table>
+
+<a name="istio.mixer.v1.config.descriptor.ValueType"></a>
+### ValueType
+ValueType describes the types that values in the Istio system can take. These are used to describe the type of
+Attributes at run time, describe the type of the result of evaluating an expression, and to describe the runtime
+type of fields of other descriptors.
+
+
+<table>
+ <tr>
+  <th>Value</th>
+  <th>Description</th>
+ </tr>
+<a name="istio.mixer.v1.config.descriptor.ValueType.VALUE_TYPE_UNSPECIFIED"></a>
+ <tr>
+  <td>VALUE_TYPE_UNSPECIFIED</td>
+  <td>Invalid, default value.</td>
+ </tr>
+<a name="istio.mixer.v1.config.descriptor.ValueType.STRING"></a>
+ <tr>
+  <td>STRING</td>
+  <td>An undiscriminated variable-length string.</td>
+ </tr>
+<a name="istio.mixer.v1.config.descriptor.ValueType.INT64"></a>
+ <tr>
+  <td>INT64</td>
+  <td>An undiscriminated 64-bit signed integer.</td>
+ </tr>
+<a name="istio.mixer.v1.config.descriptor.ValueType.DOUBLE"></a>
+ <tr>
+  <td>DOUBLE</td>
+  <td>An undiscriminated 64-bit floating-point value.</td>
+ </tr>
+<a name="istio.mixer.v1.config.descriptor.ValueType.BOOL"></a>
+ <tr>
+  <td>BOOL</td>
+  <td>An undiscriminated boolean value.</td>
+ </tr>
+<a name="istio.mixer.v1.config.descriptor.ValueType.TIMESTAMP"></a>
+ <tr>
+  <td>TIMESTAMP</td>
+  <td>A point in time.</td>
+ </tr>
+<a name="istio.mixer.v1.config.descriptor.ValueType.IP_ADDRESS"></a>
+ <tr>
+  <td>IP_ADDRESS</td>
+  <td>An IP address.</td>
+ </tr>
+<a name="istio.mixer.v1.config.descriptor.ValueType.EMAIL_ADDRESS"></a>
+ <tr>
+  <td>EMAIL_ADDRESS</td>
+  <td>An email address.</td>
+ </tr>
+<a name="istio.mixer.v1.config.descriptor.ValueType.URI"></a>
+ <tr>
+  <td>URI</td>
+  <td>A URI.</td>
+ </tr>
+<a name="istio.mixer.v1.config.descriptor.ValueType.DNS_NAME"></a>
+ <tr>
+  <td>DNS_NAME</td>
+  <td>A DNS name.</td>
+ </tr>
+<a name="istio.mixer.v1.config.descriptor.ValueType.DURATION"></a>
+ <tr>
+  <td>DURATION</td>
+  <td>A span between two points in time.</td>
+ </tr>
+<a name="istio.mixer.v1.config.descriptor.ValueType.STRING_MAP"></a>
+ <tr>
+  <td>STRING_MAP</td>
+  <td>A map string -&gt; string, typically used by headers.</td>
+ </tr>
+</table>

--- a/_docs/reference/api/mixer-service.md
+++ b/_docs/reference/api/mixer-service.md
@@ -1,0 +1,499 @@
+---
+category: Reference
+title: Mixer Service
+overview: Generated documentation for Mixer's API Surface 
+              
+parent: API and Configuration Schemas
+order: 20
+
+bodyclass: docs
+layout: docs
+type: markdown
+---
+<a name="rpc_istio.mixer.v1"></a>
+## Package istio.mixer.v1
+
+<a name="rpc_istio.mixer.v1_index"></a>
+### Index
+* [Mixer](#istio.mixer.v1.Mixer) (interface)
+* [Attributes](#istio.mixer.v1.Attributes)
+(message)
+* [CheckRequest](#istio.mixer.v1.CheckRequest)
+(message)
+* [CheckResponse](#istio.mixer.v1.CheckResponse)
+(message)
+* [QuotaRequest](#istio.mixer.v1.QuotaRequest)
+(message)
+* [QuotaResponse](#istio.mixer.v1.QuotaResponse)
+(message)
+* [ReportRequest](#istio.mixer.v1.ReportRequest)
+(message)
+* [ReportResponse](#istio.mixer.v1.ReportResponse)
+(message)
+* [StringMap](#istio.mixer.v1.StringMap)
+(message)
+
+<a name="istio.mixer.v1.Mixer"></a>
+### Mixer
+The Mixer API
+
+<a name="istio.mixer.v1.Mixer.Check"></a>
+#### Check
+<pre>
+  rpc Check(<a href="#istio.mixer.v1.CheckRequest">CheckRequest</a>) returns (<a href="#istio.mixer.v1.CheckResponse">CheckResponse</a>)
+</pre>
+Checks preconditions before performing an operation.
+The preconditions enforced depend on the set of supplied attributes
+and the active configuration.
+
+<a name="istio.mixer.v1.Mixer.Quota"></a>
+#### Quota
+<pre>
+  rpc Quota(<a href="#istio.mixer.v1.QuotaRequest">QuotaRequest</a>) returns (<a href="#istio.mixer.v1.QuotaResponse">QuotaResponse</a>)
+</pre>
+Quota allocates and releases quota.
+
+<a name="istio.mixer.v1.Mixer.Report"></a>
+#### Report
+<pre>
+  rpc Report(<a href="#istio.mixer.v1.ReportRequest">ReportRequest</a>) returns (<a href="#istio.mixer.v1.ReportResponse">ReportResponse</a>)
+</pre>
+Reports telemetry, such as logs and metrics.
+The reported information depends on the set of supplied attributes
+and the active configuration.
+
+<a name="istio.mixer.v1.Attributes"></a>
+### Attributes
+An instance of this message is delivered to the mixer with every
+API call.
+
+The general idea is to leverage the stateful gRPC streams from the
+proxy to the mixer to keep to a minimum the 'attribute chatter'.
+Only delta attributes are sent over, multiple concurrent attribute
+contexts can be used to avoid thrashing, and attribute indices are used to
+keep the wire protocol maximally efficient.
+
+Producing this message is the responsibility of the mixer's client
+library which is linked into different proxy implementations.
+
+The processing order for this state in the mixer is:
+
+  * Any new dictionary is applied
+
+  * The requested attribute context is looked up. If no such context has been defined, a
+    new context is automatically created and initialized to the empty state. When a gRPC
+    stream is first created, there are no attribute contexts for the stream.
+
+  * If reset_context is true, then the attribute context is reset to the
+    empty state.
+
+  * All attributes to deleted are removed from the attribute context.
+
+  * All attribute changes are applied to the attribute context.
+
+<table>
+ <tr>
+  <th>Field</th>
+  <th>Type</th>
+  <th>Description</th>
+ </tr>
+<a name="istio.mixer.v1.Attributes.dictionary"></a>
+ <tr>
+  <td><code>dictionary</code></td>
+  <td>repeated map&lt;int32, string&gt;</td>
+  <td><p>A dictionary that provides a mapping of shorthand index values to attribute names.</p><p>This is intended to leverage the stateful gRPC stream from the proxy to the mixer. This dictionary is sent over only when a stream to the mixer is first established and when the proxy's configuration changes and different attributes may be produced.</p><p>Once a dictionary has been sent over, it stays in effect until a new dictionary is sent to replace it. The first request sent on a stream must include a dictionary, otherwise the mixer can't process any attribute updates.</p><p>Dictionaries are independent of the attribute context and are thus global to each gRPC stream.</p></td>
+ </tr>
+<a name="istio.mixer.v1.Attributes.attribute_context"></a>
+ <tr>
+  <td><code>attribute_context</code></td>
+  <td>int32</td>
+  <td><p>The attribute context against which to operate.</p><p>The mixer keeps different contexts live for any proxy gRPC stream. This allows the proxy to maintain multiple concurrent 'bags of attributes' within the mixer.</p><p>If the proxy doesn't want to leverage multiple contexts, it just passes 0 here for every request.</p><p>The proxy is configured to use a maximum number of attribute contexts in order to prevent an explosion of contexts in the mixer's memory space.</p></td>
+ </tr>
+<a name="istio.mixer.v1.Attributes.reset_context"></a>
+ <tr>
+  <td><code>reset_context</code></td>
+  <td>bool</td>
+  <td><p>When true, resets the current attribute context to the empty state before applying any incoming attributes.</p><p>Resetting contexts is useful to constrain the amount of resources used by the mixer. The proxy needs to intelligently manage a pool of contexts. It may be useful to reset a context when certain big events happen, such as when an HTTP2 connection into the proxy terminates.</p></td>
+ </tr>
+<a name="istio.mixer.v1.Attributes.string_attributes"></a>
+ <tr>
+  <td><code>string_attributes</code></td>
+  <td>repeated map&lt;int32, string&gt;</td>
+  <td>Attributes being updated within the specified attribute context. These maps add and/or overwrite the context's current set of attributes.</td>
+ </tr>
+<a name="istio.mixer.v1.Attributes.int64_attributes"></a>
+ <tr>
+  <td><code>int64_attributes</code></td>
+  <td>repeated map&lt;int32, int64&gt;</td>
+  <td></td>
+ </tr>
+<a name="istio.mixer.v1.Attributes.double_attributes"></a>
+ <tr>
+  <td><code>double_attributes</code></td>
+  <td>repeated map&lt;int32, double&gt;</td>
+  <td></td>
+ </tr>
+<a name="istio.mixer.v1.Attributes.bool_attributes"></a>
+ <tr>
+  <td><code>bool_attributes</code></td>
+  <td>repeated map&lt;int32, bool&gt;</td>
+  <td></td>
+ </tr>
+<a name="istio.mixer.v1.Attributes.timestamp_attributes"></a>
+ <tr>
+  <td><code>timestamp_attributes</code></td>
+  <td>repeated map&lt;int32, <a href="https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#timestamp">Timestamp</a>&gt;</td>
+  <td></td>
+ </tr>
+<a name="istio.mixer.v1.Attributes.duration_attributes"></a>
+ <tr>
+  <td><code>duration_attributes</code></td>
+  <td>repeated map&lt;int32, <a href="https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#duration">Duration</a>&gt;</td>
+  <td></td>
+ </tr>
+<a name="istio.mixer.v1.Attributes.bytes_attributes"></a>
+ <tr>
+  <td><code>bytes_attributes</code></td>
+  <td>repeated map&lt;int32, bytes&gt;</td>
+  <td></td>
+ </tr>
+<a name="istio.mixer.v1.Attributes.stringMap_attributes"></a>
+ <tr>
+  <td><code>stringMap_attributes</code></td>
+  <td>repeated map&lt;int32, <a href="#istio.mixer.v1.StringMap">StringMap</a>&gt;</td>
+  <td></td>
+ </tr>
+<a name="istio.mixer.v1.Attributes.deleted_attributes"></a>
+ <tr>
+  <td><code>deleted_attributes[]</code></td>
+  <td>repeated int32</td>
+  <td>Attributes that should be removed from the specified attribute context. Deleting attributes which aren't currently in the attribute context is not considered an error.</td>
+ </tr>
+<a name="istio.mixer.v1.Attributes.timestamp_attributes_HACK"></a>
+ <tr>
+  <td><code>timestamp_attributes_HACK</code></td>
+  <td>repeated map&lt;int32, <a href="https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#timestamp">Timestamp</a>&gt;</td>
+  <td></td>
+ </tr>
+<a name="istio.mixer.v1.Attributes.duration_attributes_HACK"></a>
+ <tr>
+  <td><code>duration_attributes_HACK</code></td>
+  <td>repeated map&lt;int32, <a href="https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#duration">Duration</a>&gt;</td>
+  <td></td>
+ </tr>
+</table>
+
+<a name="istio.mixer.v1.CheckRequest"></a>
+### CheckRequest
+Used to verify preconditions before performing an action.
+
+<table>
+ <tr>
+  <th>Field</th>
+  <th>Type</th>
+  <th>Description</th>
+ </tr>
+<a name="istio.mixer.v1.CheckRequest.request_index"></a>
+ <tr>
+  <td><code>request_index</code></td>
+  <td>int64</td>
+  <td>Index within the stream for this request, used to match to responses</td>
+ </tr>
+<a name="istio.mixer.v1.CheckRequest.attribute_update"></a>
+ <tr>
+  <td><code>attribute_update</code></td>
+  <td><a href="#istio.mixer.v1.Attributes">Attributes</a></td>
+  <td>The attributes to use for this request</td>
+ </tr>
+</table>
+
+<a name="istio.mixer.v1.CheckResponse"></a>
+### CheckResponse
+
+<table>
+ <tr>
+  <th>Field</th>
+  <th>Type</th>
+  <th>Description</th>
+ </tr>
+<a name="istio.mixer.v1.CheckResponse.request_index"></a>
+ <tr>
+  <td><code>request_index</code></td>
+  <td>int64</td>
+  <td>Index of the request this response is associated with</td>
+ </tr>
+<a name="istio.mixer.v1.CheckResponse.attribute_update"></a>
+ <tr>
+  <td><code>attribute_update</code></td>
+  <td><a href="#istio.mixer.v1.Attributes">Attributes</a></td>
+  <td>The attributes to use for this response</td>
+ </tr>
+<a name="istio.mixer.v1.CheckResponse.result"></a>
+ <tr>
+  <td><code>result</code></td>
+  <td><a href="#google.rpc.Status">Status</a></td>
+  <td>Indicates whether or not the preconditions succeeded</td>
+ </tr>
+<a name="istio.mixer.v1.CheckResponse.expiration"></a>
+ <tr>
+  <td><code>expiration</code></td>
+  <td><a href="https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#duration">Duration</a></td>
+  <td>The amount of time for which this result can be considered valid, given the same inputs</td>
+ </tr>
+</table>
+
+<a name="istio.mixer.v1.QuotaRequest"></a>
+### QuotaRequest
+
+<table>
+ <tr>
+  <th>Field</th>
+  <th>Type</th>
+  <th>Description</th>
+ </tr>
+<a name="istio.mixer.v1.QuotaRequest.request_index"></a>
+ <tr>
+  <td><code>request_index</code></td>
+  <td>int64</td>
+  <td>Index within the stream for this request, used to match to responses</td>
+ </tr>
+<a name="istio.mixer.v1.QuotaRequest.attribute_update"></a>
+ <tr>
+  <td><code>attribute_update</code></td>
+  <td><a href="#istio.mixer.v1.Attributes">Attributes</a></td>
+  <td>The attributes to use for this request</td>
+ </tr>
+<a name="istio.mixer.v1.QuotaRequest.deduplication_id"></a>
+ <tr>
+  <td><code>deduplication_id</code></td>
+  <td>string</td>
+  <td>Used for deduplicating quota allocation/free calls in the case of failed RPCs and retries. This should be a UUID per call, where the same UUID is used for retries of the same quota allocation call.</td>
+ </tr>
+<a name="istio.mixer.v1.QuotaRequest.quota"></a>
+ <tr>
+  <td><code>quota</code></td>
+  <td>string</td>
+  <td>The quota to allocate from.</td>
+ </tr>
+<a name="istio.mixer.v1.QuotaRequest.amount"></a>
+ <tr>
+  <td><code>amount</code></td>
+  <td>int64</td>
+  <td>The amount of quota to allocate.</td>
+ </tr>
+<a name="istio.mixer.v1.QuotaRequest.best_effort"></a>
+ <tr>
+  <td><code>best_effort</code></td>
+  <td>bool</td>
+  <td>If true, allows a response to return less quota than requested. When false, the exact requested amount is returned or 0 if not enough quota was available.</td>
+ </tr>
+</table>
+
+<a name="istio.mixer.v1.QuotaResponse"></a>
+### QuotaResponse
+
+<table>
+ <tr>
+  <th>Field</th>
+  <th>Type</th>
+  <th>Description</th>
+ </tr>
+<a name="istio.mixer.v1.QuotaResponse.request_index"></a>
+ <tr>
+  <td><code>request_index</code></td>
+  <td>int64</td>
+  <td>Index of the request this response is associated with.</td>
+ </tr>
+<a name="istio.mixer.v1.QuotaResponse.attribute_update"></a>
+ <tr>
+  <td><code>attribute_update</code></td>
+  <td><a href="#istio.mixer.v1.Attributes">Attributes</a></td>
+  <td>The attributes to use for this response</td>
+ </tr>
+<a name="istio.mixer.v1.QuotaResponse.result"></a>
+ <tr>
+  <td><code>result</code></td>
+  <td><a href="#google.rpc.Status">Status</a></td>
+  <td>Indicates whether the quota request was successfully processed.</td>
+ </tr>
+<a name="istio.mixer.v1.QuotaResponse.expiration"></a>
+ <tr>
+  <td><code>expiration</code></td>
+  <td><a href="https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#duration">Duration</a></td>
+  <td>The amount of time the returned quota can be considered valid, this is 0 for non-expiring quotas.</td>
+ </tr>
+<a name="istio.mixer.v1.QuotaResponse.amount"></a>
+ <tr>
+  <td><code>amount</code></td>
+  <td>int64</td>
+  <td>The total amount of quota returned, may be less than requested.</td>
+ </tr>
+</table>
+
+<a name="istio.mixer.v1.ReportRequest"></a>
+### ReportRequest
+Used to report telemetry after performing an action.
+
+<table>
+ <tr>
+  <th>Field</th>
+  <th>Type</th>
+  <th>Description</th>
+ </tr>
+<a name="istio.mixer.v1.ReportRequest.request_index"></a>
+ <tr>
+  <td><code>request_index</code></td>
+  <td>int64</td>
+  <td>Index within the stream for this request, used to match to responses</td>
+ </tr>
+<a name="istio.mixer.v1.ReportRequest.attribute_update"></a>
+ <tr>
+  <td><code>attribute_update</code></td>
+  <td><a href="#istio.mixer.v1.Attributes">Attributes</a></td>
+  <td>The attributes to use for this request</td>
+ </tr>
+</table>
+
+<a name="istio.mixer.v1.ReportResponse"></a>
+### ReportResponse
+
+<table>
+ <tr>
+  <th>Field</th>
+  <th>Type</th>
+  <th>Description</th>
+ </tr>
+<a name="istio.mixer.v1.ReportResponse.request_index"></a>
+ <tr>
+  <td><code>request_index</code></td>
+  <td>int64</td>
+  <td>Index of the request this response is associated with</td>
+ </tr>
+<a name="istio.mixer.v1.ReportResponse.attribute_update"></a>
+ <tr>
+  <td><code>attribute_update</code></td>
+  <td><a href="#istio.mixer.v1.Attributes">Attributes</a></td>
+  <td>The attributes to use for this response</td>
+ </tr>
+<a name="istio.mixer.v1.ReportResponse.result"></a>
+ <tr>
+  <td><code>result</code></td>
+  <td><a href="#google.rpc.Status">Status</a></td>
+  <td>Indicates whether the report was processed or not</td>
+ </tr>
+</table>
+
+<a name="istio.mixer.v1.StringMap"></a>
+### StringMap
+A map of string to string. The keys in these maps are from the current
+dictionary.
+
+<table>
+ <tr>
+  <th>Field</th>
+  <th>Type</th>
+  <th>Description</th>
+ </tr>
+<a name="istio.mixer.v1.StringMap.map"></a>
+ <tr>
+  <td><code>map</code></td>
+  <td>repeated map&lt;int32, string&gt;</td>
+  <td></td>
+ </tr>
+</table>
+
+<a name="rpc_google.rpc"></a>
+## Package google.rpc
+
+<a name="rpc_google.rpc_index"></a>
+### Index
+
+* [Status](#google.rpc.Status)
+(message)
+
+<a name="google.rpc.Status"></a>
+### Status
+The `Status` type defines a logical error model that is suitable for different
+programming environments, including REST APIs and RPC APIs. It is used by
+[gRPC](https://github.com/grpc). The error model is designed to be:
+
+- Simple to use and understand for most users
+- Flexible enough to meet unexpected needs
+
+
+
+<a name="rpc_google.rpc_google.rpc.Status_description_subsection"></a>
+#### Overview
+The `Status` message contains three pieces of data: error code, error message,
+and error details. The error code should be an enum value of
+[google.rpc.Code](#google.rpc.Code), but it may accept additional error codes if needed.  The
+error message should be a developer-facing English message that helps
+developers *understand* and *resolve* the error. If a localized user-facing
+error message is needed, put the localized message in the error details or
+localize it in the client. The optional error details may contain arbitrary
+information about the error. There is a predefined set of error detail types
+in the package `google.rpc` which can be used for common error conditions.
+
+
+
+<a name="rpc_google.rpc_google.rpc.Status_description_subsection_1"></a>
+#### Language mapping
+The `Status` message is the logical representation of the error model, but it
+is not necessarily the actual wire format. When the `Status` message is
+exposed in different client libraries and different wire protocols, it can be
+mapped differently. For example, it will likely be mapped to some exceptions
+in Java, but more likely mapped to some error codes in C.
+
+
+
+<a name="rpc_google.rpc_google.rpc.Status_description_subsection_2"></a>
+#### Other uses
+The error model and the `Status` message can be used in a variety of
+environments, either with or without APIs, to provide a
+consistent developer experience across different environments.
+
+Example uses of this error model include:
+
+- Partial errors. If a service needs to return partial errors to the client,
+    it may embed the `Status` in the normal response to indicate the partial
+    errors.
+
+- Workflow errors. A typical workflow has multiple steps. Each step may
+    have a `Status` message for error reporting purpose.
+
+- Batch operations. If a client uses batch request and batch response, the
+    `Status` message should be used directly inside batch response, one for
+    each error sub-response.
+
+- Asynchronous operations. If an API call embeds asynchronous operation
+    results in its response, the status of those operations should be
+    represented directly using the `Status` message.
+
+- Logging. If some API errors are stored in logs, the message `Status` could
+    be used directly after any stripping needed for security/privacy reasons.
+
+<table>
+ <tr>
+  <th>Field</th>
+  <th>Type</th>
+  <th>Description</th>
+ </tr>
+<a name="google.rpc.Status.code"></a>
+ <tr>
+  <td><code>code</code></td>
+  <td>int32</td>
+  <td>The status code, which should be an enum value of <a href="#google.rpc.Code">google.rpc.Code</a>.</td>
+ </tr>
+<a name="google.rpc.Status.message"></a>
+ <tr>
+  <td><code>message</code></td>
+  <td>string</td>
+  <td>A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the <a href="#google.rpc.Status.details">google.rpc.Status.details</a> field, or localized by the client.</td>
+ </tr>
+<a name="google.rpc.Status.details"></a>
+ <tr>
+  <td><code>details[]</code></td>
+  <td>repeated <a href="https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#any">Any</a></td>
+  <td>A list of messages that carry the error details. There will be a common set of message types for APIs to use.</td>
+ </tr>
+</table>

--- a/_docs/reference/api/proxy-config.md
+++ b/_docs/reference/api/proxy-config.md
@@ -1,7 +1,7 @@
 ---
 category: Reference
-title: Envoy Configuration Schema
-overview: Generated documentation for Envoy's Configuration Schema
+title: Proxy Configuration Schema
+overview: Generated documentation for the Istio Proxy's Configuration Schema
               
 parent: API and Configuration Schemas
 order: 60


### PR DESCRIPTION
Unfortunately this did require some manual touch-up, but nothing that'll
be impossible to automate I think.

See live examples of all the pages:
https://zackbutcher.github.io/istio.github.io/docs/reference/api/mixer-service.html
https://zackbutcher.github.io/istio.github.io/docs/reference/api/mixer-config.html
https://zackbutcher.github.io/istio.github.io/docs/reference/api/enovy-config.html

I still need to grab the mixer aspect config protos, which is a bit harder because they live in the mixer repo. @geeknoid do we want to generate docs for adapter config protos as well?