### PR TITLE
Avoid serving javascript and favicons over http 

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -2,9 +2,9 @@
 layout: default
 ---
 {% assign home = "" %}
-{% if site.github.environment == "dotcom" %}
-    {% assign home = site.github.url %}
-{% endif %}
+<!-- {% if site.github.environment == "dotcom" %} -->
+    {% assign home = site.github.url | replace: 'http://', //' %}
+<!-- {% endif %} -->
 
 <!DOCTYPE html>
 <html lang="en" itemscope itemtype="https://schema.org/WebPage">
@@ -58,7 +58,7 @@ layout: default
 
     <!-- metadata -->
     <meta name="og:title" content="istio / {{page.title}}"/>
-    <meta name="og:image" content="http://istio.io/img/logo.png"/>
+    <meta name="og:image" content="https://istio.io/img/logo.png"/>
     <meta name="og:description" content="An open platform to connect, manage, and secure microservices."/>
   </head>
   <body class={{page.bodyclass}}>
@@ -82,9 +82,9 @@ layout: default
     {% if page.path == 'blog/index.html' %}
       <script src="{{ home }}/js/mc-validate.js"></script>
     {% endif %}
-    
+
     <!-- insert custom GA code here -->
-    
+
     {% if page.customjs %}
       <script  async="" defer="" type="text/javascript" src="{{ page.customjs }}"></script>
     {% endif %}


### PR DESCRIPTION
Commit 41145599 changed the base path for referencing resources based
on site.github.environment. As a result, most of the javascript
resources and some images were served over http instead of https which
some browsers won't load (e.g. Chrome). Fix the problem by stripping
the protocol prefix from site.github.url such that content
is always served over the original protocol, i.e. https. Fix taken 
from https://github.com/github/pages-gem/issues/238#issuecomment-206964532.

Note:  The value of `home` various based on whether we're using istio.io or a staging site. This means I couldn't test 100% that this fixes the problem. However, I was able to test the reverse by replacing `https` with `http` in my staging site and verifying my staging site starting serving javascript/images over http.