### PR TITLE
Automate generation of mixer CLI collateral docs

### DIFF
--- a/_docs/reference/mixercli/index.md
+++ b/_docs/reference/mixercli/index.md
@@ -1,0 +1,9 @@
+---
+title: The Mixer CLI
+overview: Options showing how to use the Mixer's CLIs.
+order: 30
+layout: docs
+type: markdown
+---
+{% include section-index.html %}
+

--- a/_docs/reference/mixercli/mixc.md
+++ b/_docs/reference/mixercli/mixc.md
@@ -1,0 +1,231 @@
+---
+title: mixc
+overview: Utility to trigger direct calls to Mixer's API
+layout: docs
+order: 1
+type: markdown
+---
+
+<a name="mixc"></a>
+## mixc
+
+Utility to trigger direct calls to Mixer's API
+
+### Synopsis
+
+
+This command lets you interact with a running instance of
+Mixer. Note that you need a pretty good understanding of Mixer's
+API in order to use this command.
+
+### Options
+
+```
+      --alsologtostderr                  log to standard error as well as files
+  -a, --attributes string                List of name/value auto-sensed attributes specified as name1=value1,name2=value2,...
+  -b, --bool_attributes string           List of name/value bool attributes specified as name1=value1,name2=value2,...
+      --bytes_attributes string          List of name/value bytes attributes specified as name1=b0:b1:b3,name2=b4:b5:b6,...
+  -d, --double_attributes string         List of name/value float64 attributes specified as name1=value1,name2=value2,...
+      --duration_attributes string       List of name/value duration attributes specified as name1=value1,name2=value2,...
+  -i, --int64_attributes string          List of name/value int64 attributes specified as name1=value1,name2=value2,...
+      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
+      --log_dir string                   If non-empty, write log files in this directory
+      --logtostderr                      log to standard error instead of files
+  -m, --mixer string                     Address and port of a running Mixer instance (default "localhost:9091")
+  -r, --repeat int                       Sends the specified number of requests in quick succession (default 1)
+      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
+  -s, --string_attributes string         List of name/value string attributes specified as name1=value1,name2=value2,...
+      --stringmap_attributes string      List of name/value string map attributes specified as name1=k1:v1;k2:v2,name2=k3:v3...
+  -t, --timestamp_attributes string      List of name/value timestamp attributes specified as name1=value1,name2=value2,...
+      --trace                            Whether to trace rpc executions
+  -v, --v Level                          log level for V logs
+      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+```
+
+### SEE ALSO
+* [mixc check](#mixc_check)	 - Invokes Mixer's Check API to perform precondition checks.
+* [mixc quota](#mixc_quota)	 - Invokes Mixer's Quota API in order to perform quota management.
+* [mixc report](#mixc_report)	 - Invokes Mixer's Report API to generate telemetry.
+* [mixc version](#mixc_version)	 - Prints out build version information
+
+<a name="mixc_check"></a>
+## mixc check
+
+Invokes Mixer's Check API to perform precondition checks.
+
+### Synopsis
+
+
+The Check method is used to perform precondition checks. Mixer
+expects a set of attributes as input, which it uses, along with
+its configuration, to determine which adapters to invoke and with
+which parameters in order to perform the precondition check.
+
+```
+mixc check
+```
+
+### Options inherited from parent commands
+
+```
+      --alsologtostderr                  log to standard error as well as files
+  -a, --attributes string                List of name/value auto-sensed attributes specified as name1=value1,name2=value2,...
+  -b, --bool_attributes string           List of name/value bool attributes specified as name1=value1,name2=value2,...
+      --bytes_attributes string          List of name/value bytes attributes specified as name1=b0:b1:b3,name2=b4:b5:b6,...
+  -d, --double_attributes string         List of name/value float64 attributes specified as name1=value1,name2=value2,...
+      --duration_attributes string       List of name/value duration attributes specified as name1=value1,name2=value2,...
+  -i, --int64_attributes string          List of name/value int64 attributes specified as name1=value1,name2=value2,...
+      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
+      --log_dir string                   If non-empty, write log files in this directory
+      --logtostderr                      log to standard error instead of files
+  -m, --mixer string                     Address and port of a running Mixer instance (default "localhost:9091")
+  -r, --repeat int                       Sends the specified number of requests in quick succession (default 1)
+      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
+  -s, --string_attributes string         List of name/value string attributes specified as name1=value1,name2=value2,...
+      --stringmap_attributes string      List of name/value string map attributes specified as name1=k1:v1;k2:v2,name2=k3:v3...
+  -t, --timestamp_attributes string      List of name/value timestamp attributes specified as name1=value1,name2=value2,...
+      --trace                            Whether to trace rpc executions
+  -v, --v Level                          log level for V logs
+      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+```
+
+### SEE ALSO
+* [mixc](#mixc)	 - Utility to trigger direct calls to Mixer's API
+
+<a name="mixc_quota"></a>
+## mixc quota
+
+Invokes Mixer's Quota API in order to perform quota management.
+
+### Synopsis
+
+
+The Quota method is used to perform quota management. Mixer
+expects a set of attributes as input, which it uses, along with
+its configuration, to determine which adapters to invoke and with
+which parameters in order to perform the quota operations.
+
+```
+mixc quota
+```
+
+### Options
+
+```
+      --amount int    The amount of quota to request (default 1)
+      --bestEffort    Whether to use all-or-nothing or best effort semantics
+      --name string   The name of the quota to allocate
+```
+
+### Options inherited from parent commands
+
+```
+      --alsologtostderr                  log to standard error as well as files
+  -a, --attributes string                List of name/value auto-sensed attributes specified as name1=value1,name2=value2,...
+  -b, --bool_attributes string           List of name/value bool attributes specified as name1=value1,name2=value2,...
+      --bytes_attributes string          List of name/value bytes attributes specified as name1=b0:b1:b3,name2=b4:b5:b6,...
+  -d, --double_attributes string         List of name/value float64 attributes specified as name1=value1,name2=value2,...
+      --duration_attributes string       List of name/value duration attributes specified as name1=value1,name2=value2,...
+  -i, --int64_attributes string          List of name/value int64 attributes specified as name1=value1,name2=value2,...
+      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
+      --log_dir string                   If non-empty, write log files in this directory
+      --logtostderr                      log to standard error instead of files
+  -m, --mixer string                     Address and port of a running Mixer instance (default "localhost:9091")
+  -r, --repeat int                       Sends the specified number of requests in quick succession (default 1)
+      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
+  -s, --string_attributes string         List of name/value string attributes specified as name1=value1,name2=value2,...
+      --stringmap_attributes string      List of name/value string map attributes specified as name1=k1:v1;k2:v2,name2=k3:v3...
+  -t, --timestamp_attributes string      List of name/value timestamp attributes specified as name1=value1,name2=value2,...
+      --trace                            Whether to trace rpc executions
+  -v, --v Level                          log level for V logs
+      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+```
+
+### SEE ALSO
+* [mixc](#mixc)	 - Utility to trigger direct calls to Mixer's API
+
+<a name="mixc_report"></a>
+## mixc report
+
+Invokes Mixer's Report API to generate telemetry.
+
+### Synopsis
+
+
+The Report method is used to produce telemetry. Mixer
+expects a set of attributes as input, which it uses, along with
+its configuration, to determine which adapters to invoke and with
+which parameters in order to output the telemetry.
+
+```
+mixc report
+```
+
+### Options inherited from parent commands
+
+```
+      --alsologtostderr                  log to standard error as well as files
+  -a, --attributes string                List of name/value auto-sensed attributes specified as name1=value1,name2=value2,...
+  -b, --bool_attributes string           List of name/value bool attributes specified as name1=value1,name2=value2,...
+      --bytes_attributes string          List of name/value bytes attributes specified as name1=b0:b1:b3,name2=b4:b5:b6,...
+  -d, --double_attributes string         List of name/value float64 attributes specified as name1=value1,name2=value2,...
+      --duration_attributes string       List of name/value duration attributes specified as name1=value1,name2=value2,...
+  -i, --int64_attributes string          List of name/value int64 attributes specified as name1=value1,name2=value2,...
+      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
+      --log_dir string                   If non-empty, write log files in this directory
+      --logtostderr                      log to standard error instead of files
+  -m, --mixer string                     Address and port of a running Mixer instance (default "localhost:9091")
+  -r, --repeat int                       Sends the specified number of requests in quick succession (default 1)
+      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
+  -s, --string_attributes string         List of name/value string attributes specified as name1=value1,name2=value2,...
+      --stringmap_attributes string      List of name/value string map attributes specified as name1=k1:v1;k2:v2,name2=k3:v3...
+  -t, --timestamp_attributes string      List of name/value timestamp attributes specified as name1=value1,name2=value2,...
+      --trace                            Whether to trace rpc executions
+  -v, --v Level                          log level for V logs
+      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+```
+
+### SEE ALSO
+* [mixc](#mixc)	 - Utility to trigger direct calls to Mixer's API
+
+<a name="mixc_version"></a>
+## mixc version
+
+Prints out build version information
+
+### Synopsis
+
+
+Prints out build version information
+
+```
+mixc version
+```
+
+### Options inherited from parent commands
+
+```
+      --alsologtostderr                  log to standard error as well as files
+  -a, --attributes string                List of name/value auto-sensed attributes specified as name1=value1,name2=value2,...
+  -b, --bool_attributes string           List of name/value bool attributes specified as name1=value1,name2=value2,...
+      --bytes_attributes string          List of name/value bytes attributes specified as name1=b0:b1:b3,name2=b4:b5:b6,...
+  -d, --double_attributes string         List of name/value float64 attributes specified as name1=value1,name2=value2,...
+      --duration_attributes string       List of name/value duration attributes specified as name1=value1,name2=value2,...
+  -i, --int64_attributes string          List of name/value int64 attributes specified as name1=value1,name2=value2,...
+      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
+      --log_dir string                   If non-empty, write log files in this directory
+      --logtostderr                      log to standard error instead of files
+  -m, --mixer string                     Address and port of a running Mixer instance (default "localhost:9091")
+  -r, --repeat int                       Sends the specified number of requests in quick succession (default 1)
+      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
+  -s, --string_attributes string         List of name/value string attributes specified as name1=value1,name2=value2,...
+      --stringmap_attributes string      List of name/value string map attributes specified as name1=k1:v1;k2:v2,name2=k3:v3...
+  -t, --timestamp_attributes string      List of name/value timestamp attributes specified as name1=value1,name2=value2,...
+      --trace                            Whether to trace rpc executions
+  -v, --v Level                          log level for V logs
+      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+```
+
+### SEE ALSO
+* [mixc](#mixc)	 - Utility to trigger direct calls to Mixer's API
+

--- a/_docs/reference/mixercli/mixc.md
+++ b/_docs/reference/mixercli/mixc.md
@@ -42,7 +42,7 @@ API in order to use this command.
       --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
 ```
 
-### SEE ALSO
+### See Also
 * [mixc check](#mixc_check)	 - Invokes Mixer's Check API to perform precondition checks.
 * [mixc quota](#mixc_quota)	 - Invokes Mixer's Quota API in order to perform quota management.
 * [mixc report](#mixc_report)	 - Invokes Mixer's Report API to generate telemetry.
@@ -89,7 +89,7 @@ mixc check
       --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
 ```
 
-### SEE ALSO
+### See Also
 * [mixc](#mixc)	 - Utility to trigger direct calls to Mixer's API
 
 <a name="mixc_quota"></a>
@@ -141,7 +141,7 @@ mixc quota
       --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
 ```
 
-### SEE ALSO
+### See Also
 * [mixc](#mixc)	 - Utility to trigger direct calls to Mixer's API
 
 <a name="mixc_report"></a>
@@ -185,7 +185,7 @@ mixc report
       --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
 ```
 
-### SEE ALSO
+### See Also
 * [mixc](#mixc)	 - Utility to trigger direct calls to Mixer's API
 
 <a name="mixc_version"></a>
@@ -226,6 +226,6 @@ mixc version
       --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
 ```
 
-### SEE ALSO
+### See Also
 * [mixc](#mixc)	 - Utility to trigger direct calls to Mixer's API
 

--- a/_docs/reference/mixercli/mixs.md
+++ b/_docs/reference/mixercli/mixs.md
@@ -16,7 +16,7 @@ Mixer provides control plane functionality to the Istio proxy and services
 
 Mixer provides control plane functionality to the Istio proxy and services
 
-### SEE ALSO
+### See Also
 * [mixs inventory](#mixs_inventory)	 - Inventory of available adapters and aspects in Mixer
 * [mixs server](#mixs_server)	 - Starts Mixer as a server
 * [mixs version](#mixs_version)	 - Prints out build version information
@@ -35,7 +35,7 @@ List available adapter builders
 mixs inventory adapter
 ```
 
-### SEE ALSO
+### See Also
 * [mixs inventory](#mixs_inventory)	 - Inventory of available adapters and aspects in Mixer
 
 <a name="mixs_inventory_aspect"></a>
@@ -52,7 +52,7 @@ List available aspects
 mixs inventory aspect
 ```
 
-### SEE ALSO
+### See Also
 * [mixs inventory](#mixs_inventory)	 - Inventory of available adapters and aspects in Mixer
 
 <a name="mixs_inventory"></a>
@@ -65,7 +65,7 @@ Inventory of available adapters and aspects in Mixer
 
 Inventory of available adapters and aspects in Mixer
 
-### SEE ALSO
+### See Also
 * [mixs](#mixs)	 - Mixer provides control plane functionality to the Istio proxy and services
 * [mixs inventory adapter](#mixs_inventory_adapter)	 - List available adapter builders
 * [mixs inventory aspect](#mixs_inventory_aspect)	 - List available aspects
@@ -105,7 +105,7 @@ mixs server
       --trace                       Whether to trace rpc executions
 ```
 
-### SEE ALSO
+### See Also
 * [mixs](#mixs)	 - Mixer provides control plane functionality to the Istio proxy and services
 
 <a name="mixs_version"></a>
@@ -122,6 +122,6 @@ Prints out build version information
 mixs version
 ```
 
-### SEE ALSO
+### See Also
 * [mixs](#mixs)	 - Mixer provides control plane functionality to the Istio proxy and services
 

--- a/_docs/reference/mixercli/mixs.md
+++ b/_docs/reference/mixercli/mixs.md
@@ -1,0 +1,127 @@
+---
+title: mixs
+overview: Mixer provides control plane functionality to the Istio proxy and services
+layout: docs
+order: 2
+type: markdown
+---
+
+<a name="mixs"></a>
+## mixs
+
+Mixer provides control plane functionality to the Istio proxy and services
+
+### Synopsis
+
+
+Mixer provides control plane functionality to the Istio proxy and services
+
+### SEE ALSO
+* [mixs inventory](#mixs_inventory)	 - Inventory of available adapters and aspects in Mixer
+* [mixs server](#mixs_server)	 - Starts Mixer as a server
+* [mixs version](#mixs_version)	 - Prints out build version information
+
+<a name="mixs_inventory_adapter"></a>
+## mixs inventory adapter
+
+List available adapter builders
+
+### Synopsis
+
+
+List available adapter builders
+
+```
+mixs inventory adapter
+```
+
+### SEE ALSO
+* [mixs inventory](#mixs_inventory)	 - Inventory of available adapters and aspects in Mixer
+
+<a name="mixs_inventory_aspect"></a>
+## mixs inventory aspect
+
+List available aspects
+
+### Synopsis
+
+
+List available aspects
+
+```
+mixs inventory aspect
+```
+
+### SEE ALSO
+* [mixs inventory](#mixs_inventory)	 - Inventory of available adapters and aspects in Mixer
+
+<a name="mixs_inventory"></a>
+## mixs inventory
+
+Inventory of available adapters and aspects in Mixer
+
+### Synopsis
+
+
+Inventory of available adapters and aspects in Mixer
+
+### SEE ALSO
+* [mixs](#mixs)	 - Mixer provides control plane functionality to the Istio proxy and services
+* [mixs inventory adapter](#mixs_inventory_adapter)	 - List available adapter builders
+* [mixs inventory aspect](#mixs_inventory_aspect)	 - List available aspects
+
+<a name="mixs_server"></a>
+## mixs server
+
+Starts Mixer as a server
+
+### Synopsis
+
+
+Starts Mixer as a server
+
+```
+mixs server
+```
+
+### Options
+
+```
+      --adapterWorkerPoolSize int   Max # of goroutines in the adapter worker pool (default 1024)
+      --apiWorkerPoolSize int       Max # of goroutines in the API worker pool (default 1024)
+      --clientCertFiles string      A set of comma-separated client X509 cert files
+      --compressedPayload           Whether to compress gRPC messages
+      --configAPIPort uint16        HTTP port to use for Mixer's Configuration API (default 9094)
+      --configFetchInterval uint    Configuration fetch interval in seconds (default 5)
+      --configStoreURL string       URL of the config store. May be fs:// for file system, or redis:// for redis url
+      --globalConfigFile string     Global Config
+      --maxConcurrentStreams uint   Maximum supported number of concurrent gRPC streams (default 32)
+      --maxMessageSize uint         Maximum size of individual gRPC messages (default 1048576)
+  -p, --port uint16                 TCP port to use for Mixer's gRPC API (default 9091)
+      --serverCertFile string       The TLS cert file
+      --serverKeyFile string        The TLS key file
+      --serviceConfigFile string    Combined Service Config
+      --singleThreaded              Whether to run Mixer in single-threaded mode (useful for debugging)
+      --trace                       Whether to trace rpc executions
+```
+
+### SEE ALSO
+* [mixs](#mixs)	 - Mixer provides control plane functionality to the Istio proxy and services
+
+<a name="mixs_version"></a>
+## mixs version
+
+Prints out build version information
+
+### Synopsis
+
+
+Prints out build version information
+
+```
+mixs version
+```
+
+### SEE ALSO
+* [mixs](#mixs)	 - Mixer provides control plane functionality to the Istio proxy and services
+

--- a/scripts/auto-generate-mixer-cli.sh
+++ b/scripts/auto-generate-mixer-cli.sh
@@ -1,0 +1,102 @@
+#!/bin/sh
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if [[ -z "${MIXCOL_CLI}" ]]; then
+    echo "No mixcol command defined via the environment variable MIXCOL_CLI"
+    exit 1
+fi
+
+ISTIO_BASE=$(cd "$(dirname "$0")" ; pwd -P)/..
+MIXER_CLI_DIR=$(readlink -f ${ISTIO_BASE}/_docs/reference/mixercli/)
+WORKING_DIR=$(mktemp -d)
+
+function pageHeader() {
+    title=${1}
+    overview=${2}
+    order=${3}
+    cat <<EOF
+---
+title: ${title}
+overview: ${overview}
+layout: docs
+order: ${order}
+type: markdown
+---
+
+EOF
+}
+
+function generateIndex() {
+    cat <<EOF
+---
+title: The Mixer CLI
+overview: Options showing how to use the Mixer's CLIs.
+order: 30
+layout: docs
+type: markdown
+---
+{% include section-index.html %}
+
+EOF
+}
+
+# combines the collateral files of a single binary, updating links
+function processPerBinaryFiles() {
+    # mixcol produces a top level markdown file named ${commandName}.md which
+    # serves as our base file. We'll cat the other files into it after
+    # processing.
+    commandName=${1}
+    order=${2}
+    primaryFile=${WORKING_DIR}/${commandName}.md
+    if [[ -z ${primaryFile} ]]; then
+        echo "could not find ${primaryFile}, skipping processing ${commandName}"
+        return
+    fi
+
+    out=$(mktemp)
+    overview=$(sed -n '/^[^#]/ {p;q;}' ${primaryFile})
+    pageHeader "${commandName}" "${overview}" "${order}" > ${out}
+
+    # insert an anchor and remove the last line of the file, which is a note
+    # that its auto generated
+    echo "<a name=\"${commandName}\"></a>" >> ${out}
+    head -n -1 ${primaryFile} >> ${out}
+    # this pattern matches only subcommands of ${commandName}, and not
+    # ${commandName}'s output file itself
+    for file in ${WORKING_DIR}/${commandName}_*.md; do
+        fullFileName=$(basename ${file})
+        noext=${fullFileName%%.*}
+        # synthesize an anchor to replace the generated links to separate pages
+        echo "<a name=\"${noext}\"></a>" >> ${out}
+        head -n -1 ${file} >> ${out}
+    done
+    # We can't rely on ordering, so we need to iterate over the files twice to be sure
+    # we update all links.
+    for file in ${WORKING_DIR}/${commandName}_*.md; do
+        fullFileName=$(basename ${file})
+        noext=${fullFileName%%.*}
+        # change links to refer to anchors
+        sed -i "s,${fullFileName},#${noext},g" ${out};
+    done
+    # final pass updating the subcommand's "SEE ALSO" links to the command itself
+    sed "s,${commandName}.md,#${commandName},g" ${out};
+}
+
+# Generate markdown files with mixcol. We create a subdirectory so we can grab
+# all *.md files out of it without having to worry about random *.md files
+# added to the root of the mixer git repo.
+mkdir -p ${WORKING_DIR}
+${MIXCOL_CLI} -o ${WORKING_DIR}
+
+# Clean up the target directory
+mkdir -p ${MIXER_CLI_DIR}
+rm -f ${MIXER_CLI_DIR}/*
+
+generateIndex > ${MIXER_CLI_DIR}/index.md
+processPerBinaryFiles "mixc" 1 >  ${MIXER_CLI_DIR}/mixc.md
+processPerBinaryFiles "mixs" 2 >  ${MIXER_CLI_DIR}/mixs.md
+
+rm -rfd ${WORKING_DIR}

--- a/scripts/auto-generate-mixer-cli.sh
+++ b/scripts/auto-generate-mixer-cli.sh
@@ -82,7 +82,7 @@ function processPerBinaryFiles() {
         sed -i "s,${fullFileName},#${noext},g" ${out};
     done
     # final pass updating the subcommand's "SEE ALSO" links to the command itself
-    sed "s,${commandName}.md,#${commandName},g" ${out};
+    sed "s,${commandName}.md,#${commandName},g;s/SEE ALSO/See Also/g" ${out};
 }
 
 # Generate markdown files with mixcol. We create a subdirectory so we can grab


### PR DESCRIPTION
Big difference between this and istioctl generation is that we mung all the docs for subcommands into a single markdown file, rather than generate a ton of files. @ayj we should probably do the same with istioctl too.