### PR TITLE
use type in proxy rule output

### DIFF
--- a/_docs/concepts/traffic-management/rules-configuration.md
+++ b/_docs/concepts/traffic-management/rules-configuration.md
@@ -93,14 +93,14 @@ match:
 ```
 
 _3. Select rule based on HTTP headers_. For example, the following rule will
-only apply to an incoming request if it includes a "Cookie" header that
+only apply to an incoming request if it includes a "cookie" header that
 contains the substring "user=jason".
 
 ```yaml
 destination: reviews.default.svc.cluster.local
 match:
   httpHeaders:
-    Cookie:
+    cookie:
       regex: "^(.*?;)?(user=jason)(;.*)?$"
 ```
 
@@ -109,7 +109,7 @@ corresponding headers must match for the rule to apply.
 
 Multiple criteria can be set simultaneously. In such a case, AND semantics
 apply. For example, the following rule only applies if the source of the
-request is "reviews:v2" AND the "Cookie" header containing "user=jason" is
+request is "reviews:v2" AND the "cookie" header containing "user=jason" is
 present.
 
 ```yaml
@@ -119,7 +119,7 @@ match:
   sourceTags:
     version: v2
   httpHeaders:
-    Cookie:
+    cookie:
       regex: "^(.*?;)?(user=jason)(;.*)?$"
 ```
 

--- a/_docs/tasks/fault-injection.md
+++ b/_docs/tasks/fault-injection.md
@@ -1,7 +1,7 @@
 ---
 title: Fault Injection
 overview: This task shows how to inject delays and test the resiliency of your application.
-            
+
 order: 60
 
 layout: docs
@@ -21,7 +21,7 @@ This task shows how to inject delays and test the resiliency of your application
 * Initialize the application version routing by either first doing the
   [request routing](./request-routing.html) task or by running following
   commands:
-  
+
   ```bash
   istioctl create -f route-rule-all-v1.yaml
   istioctl create -f route-rule-reviews-test-v2.yaml
@@ -39,9 +39,9 @@ continue without any errors.
    ```bash
    istioctl create -f destination-ratings-test-delay.yaml
    ```
-   
+
    Confirm the rule is created:
-   
+
    ```yaml
    istioctl get route-rule ratings-test-delay
    destination: ratings.default.svc.cluster.local
@@ -51,14 +51,14 @@ continue without any errors.
        percent: 100
    match:
      httpHeaders:
-       Cookie:
+       cookie:
          regex: "^(.*?;)?(user=jason)(;.*)?$"
    precedence: 2
    route:
    - tags:
        version: v1
    ```
-   
+
    Allow several seconds to account for rule propagation delay to all pods.
 
 1. Observe application behavior
@@ -87,11 +87,11 @@ continue without any errors.
   productpage timeout or decreasing the reviews to ratings service timeout,
   terminate and restart the fixed microservice, and then confirm that the `productpage`
   returns its response without any errors.
-  
+
   However, we already have this fix running in v3 of the reviews service, so we can simply
   fix the problem by migrating all
   traffic to `reviews:v3` as described in the [request routing task](./request-routing.html).
-         
+
   (Left as an exercise for the reader - change the delay rule to
   use a 2.8 second delay and then run it against the v3 version of reviews.)
 

--- a/_docs/tasks/request-routing.md
+++ b/_docs/tasks/request-routing.md
@@ -1,7 +1,7 @@
 ---
 title: Configuring Request Routing
 overview: This task shows you how to configure dynamic request routing based on weights and HTTP headers.
-            
+
 order: 50
 
 layout: docs
@@ -37,7 +37,7 @@ route requests to all available versions of a service in a random fashion.
 
    ```yaml
    istioctl get route-rules -o yaml
-   kind: route-rule
+   type: route-rule
    name: ratings-default
    namespace: default
    spec:
@@ -48,7 +48,7 @@ route requests to all available versions of a service in a random fashion.
          version: v1
        weight: 100
    ---
-   kind: route-rule
+   type: route-rule
    name: reviews-default
    namespace: default
    spec:
@@ -59,7 +59,7 @@ route requests to all available versions of a service in a random fashion.
          version: v1
        weight: 100
    ---
-   kind: route-rule
+   type: route-rule
    name: details-default
    namespace: default
    spec:
@@ -70,7 +70,7 @@ route requests to all available versions of a service in a random fashion.
          version: v1
        weight: 100
    ---
-   kind: route-rule
+   type: route-rule
    name: productpage-default
    namespace: default
    spec:
@@ -82,9 +82,9 @@ route requests to all available versions of a service in a random fashion.
        weight: 100
    ---
    ```
-   
+
    Since rule propagation to the proxies is asynchronous, you should wait a few seconds for the rules
-   to propagate to all pods before attempting to access the application.  
+   to propagate to all pods before attempting to access the application.
 
 1. Open the BookInfo URL (http://$GATEWAY_URL/productpage) in your browser
 
@@ -99,7 +99,7 @@ route requests to all available versions of a service in a random fashion.
    ```bash
    istioctl create -f route-rule-reviews-test-v2.yaml
    ```
-   
+
    Confirm the rule is created:
 
    ```yaml
@@ -114,8 +114,8 @@ route requests to all available versions of a service in a random fashion.
    - tags:
        version: v2
    ```
-   
-1. Log in as user "jason" at the `productpage` web page. 
+
+1. Log in as user "jason" at the `productpage` web page.
 
    You should now see ratings (1-5 stars) next to each review. Notice that if you log in as
    any other user, you will continue to see `reviews:v1`.
@@ -140,7 +140,7 @@ to `reviews:v3` in two steps as follows:
    ```bash
    istioctl replace -f route-rule-reviews-50-v3.yaml
    ```
-   
+
    Notice that we are using `istioctl replace` instead of `create`.
 
 2. To see the new version you need to either Log out as test user "jason" or delete the test rules
@@ -150,10 +150,10 @@ that we created exclusively for him:
    istioctl delete route-rule reviews-test-v2
    istioctl delete route-rule ratings-test-delay
    ```
-   
+
    You should now see *red* colored star ratings approximately 50% of the time when you refresh
    the `productpage`.
-   
+
    > Note: With the Envoy sidecar implementation, you may need to refresh the `productpage` multiple times
    > to see the proper distribution. You can modify the rules to route 90% of the traffic to v3 to see red stars more often.
 

--- a/_docs/tasks/request-routing.md
+++ b/_docs/tasks/request-routing.md
@@ -107,7 +107,7 @@ route requests to all available versions of a service in a random fashion.
    destination: reviews.default.svc.cluster.local
    match:
      httpHeaders:
-       Cookie:
+       cookie:
          regex: ^(.*?;)?(user=jason)(;.*)?$
    precedence: 2
    route:


### PR DESCRIPTION
Proxy config uses `type` instead of `kind`. Update the output examples in documentation in case a user copies that as an example. The PR for the corresponding update to istioctl is [here](https://github.com/istio/manager/pull/695).