### PR TITLE
Refresh auto-generated command line reference docs

### DIFF
--- a/_docs/reference/commands/index.md
+++ b/_docs/reference/commands/index.md
@@ -1,6 +1,6 @@
 ---
-title: Commands
-overview: Describes usage and options of the Istio CLI.
+title: CLI
+overview: Describes usage and options of the Istio CLI and other utilities.
 order: 30
 layout: docs
 type: markdown

--- a/_docs/reference/commands/index.md
+++ b/_docs/reference/commands/index.md
@@ -1,6 +1,6 @@
 ---
-title: CLI
-overview: Describes usage and options of the Istio CLI and other utilities.
+title: Commands
+overview: Describes usage and options of the Istio CLI.
 order: 30
 layout: docs
 type: markdown

--- a/_docs/reference/commands/istioctl.md
+++ b/_docs/reference/commands/istioctl.md
@@ -17,10 +17,14 @@ Istio control interface
 
 Istio configuration command line utility.
 
-Create, list, modify, and delete configuration resources in the Istio system.
+Create, list, modify, and delete configuration resources in the Istio
+system.
 
-Available routing and traffic management configuration types: [destination-policy ingress-rule route-rule]. See
-https://istio.io/docs/reference/routing-and-traffic-management.html
+Available routing and traffic management configuration types:
+
+	[destination-policy ingress-rule route-rule]
+
+See https://istio.io/docs/reference/routing-and-traffic-management.html
 for an overview of the routing and traffic DSL.
 
 More information on the mixer API configuration can be found under the
@@ -30,9 +34,11 @@ istioctl mixer command documentation.
 ### Options
 
 ```
+      --istioNamespace string            Namespace where Istio system resides
+      --kube                             Use Kubernetes client to send API requests to manager service (default true)
   -c, --kubeconfig string                Use a Kubernetes configuration file instead of in-cluster configuration
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-  -m, --managerAddr string               Set your Istio manager address
+      --managerAPIService string         Name of istio-manager service. When --kube=false this sets the address of the manager service (default "istio-manager:8081")
   -n, --namespace string                 Select a Kubernetes namespace (default "default")
   -v, --v Level                          log level for V logs
       --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
@@ -51,26 +57,31 @@ Output shell completion code for the bash shell. The shell output must
 be evaluated to provide interactive completion of istioctl
 commands.
 
-Examples:
-
-    # Add the following to .bash_profile.
-    source <(istioctl completion)
-
-    # Create a separate completion file and source that from .bash_profile
-    istioctl completion > ~/.istioctl-complete.bash
-    echo "source ~/.istioctl-complete.bash" >> ~/.bash_profile
-
-
 ```
 istioctl completion
+```
+
+### Examples
+
+```
+
+# Add the following to .bash_profile.
+source <(istioctl completion)
+
+# Create a separate completion file and source that from .bash_profile
+istioctl completion > ~/.istioctl-complete.bash
+echo "source ~/.istioctl-complete.bash" >> ~/.bash_profile
+
 ```
 
 ### Options inherited from parent commands
 
 ```
+      --istioNamespace string            Namespace where Istio system resides
+      --kube                             Use Kubernetes client to send API requests to manager service (default true)
   -c, --kubeconfig string                Use a Kubernetes configuration file instead of in-cluster configuration
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-  -m, --managerAddr string               Set your Istio manager address
+      --managerAPIService string         Name of istio-manager service. When --kube=false this sets the address of the manager service (default "istio-manager:8081")
   -n, --namespace string                 Select a Kubernetes namespace (default "default")
   -v, --v Level                          log level for V logs
       --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
@@ -84,15 +95,18 @@ Create policies and rules
 ### Synopsis
 
 
-
-Example usage:
-
-	# Create a rule using the definition in example-routing.yaml.
-	$ istioctl create -f example-routing.yaml
-
+Create policies and rules
 
 ```
 istioctl create
+```
+
+### Examples
+
+```
+
+istioctl create -f example-routing.yaml
+
 ```
 
 ### Options
@@ -104,9 +118,11 @@ istioctl create
 ### Options inherited from parent commands
 
 ```
+      --istioNamespace string            Namespace where Istio system resides
+      --kube                             Use Kubernetes client to send API requests to manager service (default true)
   -c, --kubeconfig string                Use a Kubernetes configuration file instead of in-cluster configuration
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-  -m, --managerAddr string               Set your Istio manager address
+      --managerAPIService string         Name of istio-manager service. When --kube=false this sets the address of the manager service (default "istio-manager:8081")
   -n, --namespace string                 Select a Kubernetes namespace (default "default")
   -v, --v Level                          log level for V logs
       --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
@@ -120,18 +136,22 @@ Delete policies or rules
 ### Synopsis
 
 
-
-Example usage:
-
-	# Delete a rule using the definition in example-routing.yaml.
-	$ istioctl delete -f example-routing.yaml
-
-	# Delete the rule productpage-default
-	$ istioctl delete route-rule productpage-default
-
+Delete policies or rules
 
 ```
 istioctl delete
+```
+
+### Examples
+
+```
+
+# Delete a rule using the definition in example-routing.yaml.
+istioctl delete -f example-routing.yaml
+
+# Delete the rule productpage-default
+istioctl delete route-rule productpage-default
+
 ```
 
 ### Options
@@ -143,9 +163,11 @@ istioctl delete
 ### Options inherited from parent commands
 
 ```
+      --istioNamespace string            Namespace where Istio system resides
+      --kube                             Use Kubernetes client to send API requests to manager service (default true)
   -c, --kubeconfig string                Use a Kubernetes configuration file instead of in-cluster configuration
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-  -m, --managerAddr string               Set your Istio manager address
+      --managerAPIService string         Name of istio-manager service. When --kube=false this sets the address of the manager service (default "istio-manager:8081")
   -n, --namespace string                 Select a Kubernetes namespace (default "default")
   -v, --v Level                          log level for V logs
       --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
@@ -159,21 +181,25 @@ Retrieve policies and rules
 ### Synopsis
 
 
-
-Example usage:
-
-	# List all route rules
-	istioctl get route-rules
-
-	# List all destination policies
-	istioctl get destination-policies
-
-	# Get a specific rule named productpage-default
-	istioctl get route-rule productpage-default
-
+Retrieve policies and rules
 
 ```
 istioctl get
+```
+
+### Examples
+
+```
+
+# List all route rules
+istioctl get route-rules
+
+# List all destination policies
+istioctl get destination-policies
+
+# Get a specific rule named productpage-default
+istioctl get route-rule productpage-default
+
 ```
 
 ### Options
@@ -185,9 +211,11 @@ istioctl get
 ### Options inherited from parent commands
 
 ```
+      --istioNamespace string            Namespace where Istio system resides
+      --kube                             Use Kubernetes client to send API requests to manager service (default true)
   -c, --kubeconfig string                Use a Kubernetes configuration file instead of in-cluster configuration
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-  -m, --managerAddr string               Set your Istio manager address
+      --managerAPIService string         Name of istio-manager service. When --kube=false this sets the address of the manager service (default "istio-manager:8081")
   -n, --namespace string                 Select a Kubernetes namespace (default "default")
   -v, --v Level                          log level for V logs
       --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
@@ -220,23 +248,26 @@ The Istio project is continually evolving so the Istio sidecar
 configuration may change unannounced. When in doubt re-run istioctl
 kube-inject on deployments to get the most up-to-date changes.
 
-Example usage:
-
-	# Update resources on the fly before applying.
-	kubectl apply -f <(istioctl kube-inject -f <resource.yaml>)
-
-	# Create a persistent version of the deployment with Envoy sidecar
-	# injected. This is particularly useful to understand what is
-	# being injected before committing to Kubernetes API server.
-	istioctl kube-inject -f deployment.yaml -o deployment-with-istio.yaml
-
-	# Update an existing deployment.
-	kubectl get deployment -o yaml | istioctl kube-inject -f - | kubectl apply -f -
-
-
 
 ```
 istioctl kube-inject
+```
+
+### Examples
+
+```
+
+# Update resources on the fly before applying.
+kubectl apply -f <(istioctl kube-inject -f <resource.yaml>)
+
+# Create a persistent version of the deployment with Envoy sidecar
+# injected. This is particularly useful to understand what is
+# being injected before committing to Kubernetes API server.
+istioctl kube-inject -f deployment.yaml -o deployment-with-istio.yaml
+
+# Update an existing deployment.
+kubectl get deployment -o yaml | istioctl kube-inject -f - | kubectl apply -f -
+
 ```
 
 ### Options
@@ -244,22 +275,24 @@ istioctl kube-inject
 ```
       --coreDump                  Enable/Disable core dumps in injected Envoy sidecar (--coreDump=true affects all pods in a node and should only be used the cluster admin) (default true)
   -f, --filename string           Input Kubernetes resource filename
-      --hub string                Docker hub (default "docker.io/istio")
+      --hub string                Docker hub
       --includeIPRanges string    Comma separated list of IP ranges in CIDR form. If set, only redirect outbound traffic to Envoy for IP ranges. Otherwise all outbound traffic is redirected
       --meshConfig string         ConfigMap name for Istio mesh configuration, key should be "mesh" (default "istio")
   -o, --output string             Modified output Kubernetes resource filename
       --setVersionString string   Override version info injected into resource
       --sidecarProxyUID int       Envoy sidecar UID (default 1337)
-      --tag string                Docker tag (default "2017-05-01-19.24.52")
+      --tag string                Docker tag
       --verbosity int             Runtime verbosity (default 2)
 ```
 
 ### Options inherited from parent commands
 
 ```
+      --istioNamespace string            Namespace where Istio system resides
+      --kube                             Use Kubernetes client to send API requests to manager service (default true)
   -c, --kubeconfig string                Use a Kubernetes configuration file instead of in-cluster configuration
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-  -m, --managerAddr string               Set your Istio manager address
+      --managerAPIService string         Name of istio-manager service. When --kube=false this sets the address of the manager service (default "istio-manager:8081")
   -n, --namespace string                 Select a Kubernetes namespace (default "default")
   -v, --v Level                          log level for V logs
       --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
@@ -280,29 +313,22 @@ Mixer.
 See https://istio.io/docs/concepts/policy-and-control/mixer-config.html
 for a description of Mixer configuration's scope, subject, and rules.
 
-Example usage:
-
-	# The Mixer config server can be accessed from outside the
-    # Kubernetes cluster using port forwarding.
-    CONFIG_PORT=$(kubectl get pod -l istio=mixer \
-		-o jsonpath='{.items[0].spec.containers[0].ports[1].containerPort}')
-    export ISTIO_MIXER_API_SERVER=localhost:${CONFIG_PORT}
-    kubectl port-forward $(kubectl get pod -l istio=mixer \
-		-o jsonpath='{.items[0].metadata.name}') ${CONFIG_PORT}:${CONFIG_PORT} &
-
 
 ### Options
 
 ```
-      --mixer string   Address of the Mixer configuration server as <host>:<port>
+      --mixer string             (deprecated) Address of the Mixer configuration server as <host>:<port>
+      --mixerAPIService string   Name of istio-mixer service. When --kube=false this sets the address of the mixer service (default "istio-mixer:9094")
 ```
 
 ### Options inherited from parent commands
 
 ```
+      --istioNamespace string            Namespace where Istio system resides
+      --kube                             Use Kubernetes client to send API requests to manager service (default true)
   -c, --kubeconfig string                Use a Kubernetes configuration file instead of in-cluster configuration
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-  -m, --managerAddr string               Set your Istio manager address
+      --managerAPIService string         Name of istio-manager service. When --kube=false this sets the address of the manager service (default "istio-manager:8081")
   -n, --namespace string                 Select a Kubernetes namespace (default "default")
   -v, --v Level                          log level for V logs
       --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
@@ -316,15 +342,19 @@ Create Istio Mixer rules
 ### Synopsis
 
 
-
-Example usage:
-
-    # Create a new Mixer rule for the given scope and subject.
-    istioctl mixer rule create global myservice.ns.svc.cluster.local -f mixer-rule.yml
-
+Create Istio Mixer rules
 
 ```
 istioctl mixer rule create
+```
+
+### Examples
+
+```
+
+# Create a new Mixer rule for the given scope and subject.
+istioctl mixer rule create global myservice.ns.svc.cluster.local -f mixer-rule.yml
+
 ```
 
 ### Options
@@ -336,10 +366,13 @@ istioctl mixer rule create
 ### Options inherited from parent commands
 
 ```
+      --istioNamespace string            Namespace where Istio system resides
+      --kube                             Use Kubernetes client to send API requests to manager service (default true)
   -c, --kubeconfig string                Use a Kubernetes configuration file instead of in-cluster configuration
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-  -m, --managerAddr string               Set your Istio manager address
-      --mixer string                     Address of the Mixer configuration server as <host>:<port>
+      --managerAPIService string         Name of istio-manager service. When --kube=false this sets the address of the manager service (default "istio-manager:8081")
+      --mixer string                     (deprecated) Address of the Mixer configuration server as <host>:<port>
+      --mixerAPIService string           Name of istio-mixer service. When --kube=false this sets the address of the mixer service (default "istio-mixer:9094")
   -n, --namespace string                 Select a Kubernetes namespace (default "default")
   -v, --v Level                          log level for V logs
       --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
@@ -356,23 +389,30 @@ Get Istio Mixer rules
 
 Get a Mixer rule for a given scope and subject.
 
-Example usage:
-
-	# Get the Mixer rule with scope='global' and subject='myservice.ns.svc.cluster.local'
-    istioctl mixer rule get global myservice.ns.svc.cluster.local
-
 
 ```
 istioctl mixer rule get
 ```
 
+### Examples
+
+```
+
+# Get the Mixer rule with scope='global' and subject='myservice.ns.svc.cluster.local'
+istioctl mixer rule get global myservice.ns.svc.cluster.local
+
+```
+
 ### Options inherited from parent commands
 
 ```
+      --istioNamespace string            Namespace where Istio system resides
+      --kube                             Use Kubernetes client to send API requests to manager service (default true)
   -c, --kubeconfig string                Use a Kubernetes configuration file instead of in-cluster configuration
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-  -m, --managerAddr string               Set your Istio manager address
-      --mixer string                     Address of the Mixer configuration server as <host>:<port>
+      --managerAPIService string         Name of istio-manager service. When --kube=false this sets the address of the manager service (default "istio-manager:8081")
+      --mixer string                     (deprecated) Address of the Mixer configuration server as <host>:<port>
+      --mixerAPIService string           Name of istio-mixer service. When --kube=false this sets the address of the mixer service (default "istio-mixer:9094")
   -n, --namespace string                 Select a Kubernetes namespace (default "default")
   -v, --v Level                          log level for V logs
       --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
@@ -393,10 +433,13 @@ Create and list Mixer rules in the configuration server.
 ### Options inherited from parent commands
 
 ```
+      --istioNamespace string            Namespace where Istio system resides
+      --kube                             Use Kubernetes client to send API requests to manager service (default true)
   -c, --kubeconfig string                Use a Kubernetes configuration file instead of in-cluster configuration
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-  -m, --managerAddr string               Set your Istio manager address
-      --mixer string                     Address of the Mixer configuration server as <host>:<port>
+      --managerAPIService string         Name of istio-manager service. When --kube=false this sets the address of the manager service (default "istio-manager:8081")
+      --mixer string                     (deprecated) Address of the Mixer configuration server as <host>:<port>
+      --mixerAPIService string           Name of istio-mixer service. When --kube=false this sets the address of the mixer service (default "istio-mixer:9094")
   -n, --namespace string                 Select a Kubernetes namespace (default "default")
   -v, --v Level                          log level for V logs
       --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
@@ -410,15 +453,18 @@ Replace existing policies and rules
 ### Synopsis
 
 
-
-Example usage:
-
-	# Create a rule using the definition in example-routing.yaml.
-	$ istioctl replace -f example-routing.yaml
-
+Replace existing policies and rules
 
 ```
 istioctl replace
+```
+
+### Examples
+
+```
+
+istioctl replace -f example-routing.yaml
+
 ```
 
 ### Options
@@ -430,9 +476,11 @@ istioctl replace
 ### Options inherited from parent commands
 
 ```
+      --istioNamespace string            Namespace where Istio system resides
+      --kube                             Use Kubernetes client to send API requests to manager service (default true)
   -c, --kubeconfig string                Use a Kubernetes configuration file instead of in-cluster configuration
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-  -m, --managerAddr string               Set your Istio manager address
+      --managerAPIService string         Name of istio-manager service. When --kube=false this sets the address of the manager service (default "istio-manager:8081")
   -n, --namespace string                 Select a Kubernetes namespace (default "default")
   -v, --v Level                          log level for V logs
       --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
@@ -455,9 +503,11 @@ istioctl version
 ### Options inherited from parent commands
 
 ```
+      --istioNamespace string            Namespace where Istio system resides
+      --kube                             Use Kubernetes client to send API requests to manager service (default true)
   -c, --kubeconfig string                Use a Kubernetes configuration file instead of in-cluster configuration
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-  -m, --managerAddr string               Set your Istio manager address
+      --managerAPIService string         Name of istio-manager service. When --kube=false this sets the address of the manager service (default "istio-manager:8081")
   -n, --namespace string                 Select a Kubernetes namespace (default "default")
   -v, --v Level                          log level for V logs
       --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging

--- a/_docs/reference/commands/istioctl.md
+++ b/_docs/reference/commands/istioctl.md
@@ -24,7 +24,7 @@ Available routing and traffic management configuration types:
 
 	[destination-policy ingress-rule route-rule]
 
-See https://istio.io/docs/reference/routing-and-traffic-management.html
+See [routing-and-traffic-management]({{home}}/docs/reference/routing-and-traffic-management.html)
 for an overview of the routing and traffic DSL.
 
 More information on the mixer API configuration can be found under the
@@ -310,7 +310,7 @@ Istio Mixer configuration
 The Mixer configuration API allows users to configure all facets of the
 Mixer.
 
-See https://istio.io/docs/concepts/policy-and-control/mixer-config.html
+See [mixer-config]({{home}}/docs/concepts/policy-and-control/mixer-config.html)
 for a description of Mixer configuration's scope, subject, and rules.
 
 

--- a/_docs/reference/commands/istioctl.md
+++ b/_docs/reference/commands/istioctl.md
@@ -24,11 +24,8 @@ Available routing and traffic management configuration types:
 
 	[destination-policy ingress-rule route-rule]
 
-See
-[routing-rules]({{home}}/docs/reference/api/traffic-rules/routing-rules.html)
-and
-[destination-policies]({{home}}/docs/reference/api/traffic-rules/destination-policies.html)
-for an overview of routing rules and destination policies.
+See http://istio.io/docs/reference for an overview of routing rules
+and destination policies.
 
 More information on the mixer API configuration can be found under the
 istioctl mixer command documentation.
@@ -37,7 +34,6 @@ istioctl mixer command documentation.
 ### Options
 
 ```
-      --istioNamespace string            Namespace where Istio system resides
       --kube                             Use Kubernetes client to send API requests to manager service (default true)
   -c, --kubeconfig string                Use a Kubernetes configuration file instead of in-cluster configuration
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
@@ -80,7 +76,6 @@ echo "source ~/.istioctl-complete.bash" >> ~/.bash_profile
 ### Options inherited from parent commands
 
 ```
-      --istioNamespace string            Namespace where Istio system resides
       --kube                             Use Kubernetes client to send API requests to manager service (default true)
   -c, --kubeconfig string                Use a Kubernetes configuration file instead of in-cluster configuration
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
@@ -121,7 +116,6 @@ istioctl create -f example-routing.yaml
 ### Options inherited from parent commands
 
 ```
-      --istioNamespace string            Namespace where Istio system resides
       --kube                             Use Kubernetes client to send API requests to manager service (default true)
   -c, --kubeconfig string                Use a Kubernetes configuration file instead of in-cluster configuration
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
@@ -166,7 +160,6 @@ istioctl delete route-rule productpage-default
 ### Options inherited from parent commands
 
 ```
-      --istioNamespace string            Namespace where Istio system resides
       --kube                             Use Kubernetes client to send API requests to manager service (default true)
   -c, --kubeconfig string                Use a Kubernetes configuration file instead of in-cluster configuration
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
@@ -214,7 +207,6 @@ istioctl get route-rule productpage-default
 ### Options inherited from parent commands
 
 ```
-      --istioNamespace string            Namespace where Istio system resides
       --kube                             Use Kubernetes client to send API requests to manager service (default true)
   -c, --kubeconfig string                Use a Kubernetes configuration file instead of in-cluster configuration
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
@@ -291,7 +283,6 @@ kubectl get deployment -o yaml | istioctl kube-inject -f - | kubectl apply -f -
 ### Options inherited from parent commands
 
 ```
-      --istioNamespace string            Namespace where Istio system resides
       --kube                             Use Kubernetes client to send API requests to manager service (default true)
   -c, --kubeconfig string                Use a Kubernetes configuration file instead of in-cluster configuration
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
@@ -327,7 +318,6 @@ for a description of Mixer configuration's scope, subject, and rules.
 ### Options inherited from parent commands
 
 ```
-      --istioNamespace string            Namespace where Istio system resides
       --kube                             Use Kubernetes client to send API requests to manager service (default true)
   -c, --kubeconfig string                Use a Kubernetes configuration file instead of in-cluster configuration
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
@@ -369,7 +359,6 @@ istioctl mixer rule create global myservice.ns.svc.cluster.local -f mixer-rule.y
 ### Options inherited from parent commands
 
 ```
-      --istioNamespace string            Namespace where Istio system resides
       --kube                             Use Kubernetes client to send API requests to manager service (default true)
   -c, --kubeconfig string                Use a Kubernetes configuration file instead of in-cluster configuration
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
@@ -409,7 +398,6 @@ istioctl mixer rule get global myservice.ns.svc.cluster.local
 ### Options inherited from parent commands
 
 ```
-      --istioNamespace string            Namespace where Istio system resides
       --kube                             Use Kubernetes client to send API requests to manager service (default true)
   -c, --kubeconfig string                Use a Kubernetes configuration file instead of in-cluster configuration
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
@@ -436,7 +424,6 @@ Create and list Mixer rules in the configuration server.
 ### Options inherited from parent commands
 
 ```
-      --istioNamespace string            Namespace where Istio system resides
       --kube                             Use Kubernetes client to send API requests to manager service (default true)
   -c, --kubeconfig string                Use a Kubernetes configuration file instead of in-cluster configuration
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
@@ -479,7 +466,6 @@ istioctl replace -f example-routing.yaml
 ### Options inherited from parent commands
 
 ```
-      --istioNamespace string            Namespace where Istio system resides
       --kube                             Use Kubernetes client to send API requests to manager service (default true)
   -c, --kubeconfig string                Use a Kubernetes configuration file instead of in-cluster configuration
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
@@ -506,7 +492,6 @@ istioctl version
 ### Options inherited from parent commands
 
 ```
-      --istioNamespace string            Namespace where Istio system resides
       --kube                             Use Kubernetes client to send API requests to manager service (default true)
   -c, --kubeconfig string                Use a Kubernetes configuration file instead of in-cluster configuration
       --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)

--- a/_docs/reference/commands/istioctl.md
+++ b/_docs/reference/commands/istioctl.md
@@ -24,8 +24,11 @@ Available routing and traffic management configuration types:
 
 	[destination-policy ingress-rule route-rule]
 
-See [routing-and-traffic-management]({{home}}/docs/reference/routing-and-traffic-management.html)
-for an overview of the routing and traffic DSL.
+See
+[routing-rules]({{home}}/docs/reference/api/traffic-rules/routing-rules.html)
+and
+[destination-policies]({{home}}/docs/reference/api/traffic-rules/destination-policies.html)
+for an overview of routing rules and destination policies.
 
 More information on the mixer API configuration can be found under the
 istioctl mixer command documentation.

--- a/_docs/reference/commands/mixs.md
+++ b/_docs/reference/commands/mixs.md
@@ -72,22 +72,23 @@ mixs server
 ### Options
 
 ```
-      --adapterWorkerPoolSize int   Max # of goroutines in the adapter worker pool (default 1024)
-      --apiWorkerPoolSize int       Max # of goroutines in the API worker pool (default 1024)
-      --clientCertFiles string      A set of comma-separated client X509 cert files
-      --compressedPayload           Whether to compress gRPC messages
-      --configAPIPort uint16        HTTP port to use for Mixer's Configuration API (default 9094)
-      --configFetchInterval uint    Configuration fetch interval in seconds (default 5)
-      --configStoreURL string       URL of the config store. May be fs:// for file system, or redis:// for redis url
-      --globalConfigFile string     Global Config
-      --maxConcurrentStreams uint   Maximum supported number of concurrent gRPC streams (default 32)
-      --maxMessageSize uint         Maximum size of individual gRPC messages (default 1048576)
-  -p, --port uint16                 TCP port to use for Mixer's gRPC API (default 9091)
-      --serverCertFile string       The TLS cert file
-      --serverKeyFile string        The TLS key file
-      --serviceConfigFile string    Combined Service Config
-      --singleThreaded              Whether to run Mixer in single-threaded mode (useful for debugging)
-      --trace                       Whether to trace rpc executions
+      --adapterWorkerPoolSize int     Max # of goroutines in the adapter worker pool (default 1024)
+      --apiWorkerPoolSize int         Max # of goroutines in the API worker pool (default 1024)
+      --clientCertFiles string        A set of comma-separated client X509 cert files
+      --compressedPayload             Whether to compress gRPC messages
+      --configAPIPort uint16          HTTP port to use for Mixer's Configuration API (default 9094)
+      --configFetchInterval uint      Configuration fetch interval in seconds (default 5)
+      --configStoreURL string         URL of the config store. May be fs:// for file system, or redis:// for redis url
+      --expressionEvalCacheSize int   Number of entries in the expression cache (default 1024)
+      --globalConfigFile string       Global Config
+      --maxConcurrentStreams uint     Maximum supported number of concurrent gRPC streams (default 32)
+      --maxMessageSize uint           Maximum size of individual gRPC messages (default 1048576)
+  -p, --port uint16                   TCP port to use for Mixer's gRPC API (default 9091)
+      --serverCertFile string         The TLS cert file
+      --serverKeyFile string          The TLS key file
+      --serviceConfigFile string      Combined Service Config
+      --singleThreaded                Whether to run Mixer in single-threaded mode (useful for debugging)
+      --trace                         Whether to trace rpc executions
 ```
 
 <a name="mixs_version"></a>

--- a/scripts/generate-cli-docs.sh
+++ b/scripts/generate-cli-docs.sh
@@ -87,8 +87,9 @@ function processPerBinaryFiles() {
 
     # Command line help text output must use full path but
     # pre-processed istio.io pages should use relative paths.
-    #
-    # sed -i "s,https://istio.io/\(.*/\)\(.*\).html,[\2]({{home}}/\1\2.html),g" ${out};
+    sed -i ${out} \
+	-e "s,https://istio.io/\(.*/\)\(.*\).html,[\2]({{home}}/\1\2.html),g" \
+	-e "s,http://istio.io/\(.*/\)\(.*\).html,[\2]({{home}}/\1\2.html),g"
 
     # final pass updating the subcommand's "SEE ALSO" links to the command itself
     sed "s,${commandName}.md,#${commandName},g" ${out};

--- a/scripts/generate-cli-docs.sh
+++ b/scripts/generate-cli-docs.sh
@@ -88,8 +88,8 @@ function processPerBinaryFiles() {
     # Command line help text output must use full path but
     # pre-processed istio.io pages should use relative paths.
     sed -i ${out} \
-	-e "s,https://istio.io/\(.*/\)\(.*\).html,[\2]({{home}}/\1\2.html),g" \
-	-e "s,http://istio.io/\(.*/\)\(.*\).html,[\2]({{home}}/\1\2.html),g"
+        -e "s,https://istio.io/\(.*/\)\(.*\).html,[\2]({{home}}/\1\2.html),g" \
+        -e "s,http://istio.io/\(.*/\)\(.*\).html,[\2]({{home}}/\1\2.html),g"
 
     # final pass updating the subcommand's "SEE ALSO" links to the command itself
     sed "s,${commandName}.md,#${commandName},g" ${out};

--- a/scripts/generate-cli-docs.sh
+++ b/scripts/generate-cli-docs.sh
@@ -34,8 +34,8 @@ EOF
 function generateIndex() {
     cat <<EOF
 ---
-title: Commands
-overview: Describes usage and options of the Istio CLI.
+title: CLI
+overview: Describes usage and options of the Istio CLI and other utilities.
 order: 30
 layout: docs
 type: markdown

--- a/scripts/generate-cli-docs.sh
+++ b/scripts/generate-cli-docs.sh
@@ -84,6 +84,12 @@ function processPerBinaryFiles() {
         # change links to refer to anchors
         sed -i "s,${fullFileName},#${noext},g" ${out};
     done
+
+    # Command line help text output must use full path but
+    # pre-processed istio.io pages should use relative paths.
+    #
+    # sed -i "s,https://istio.io/\(.*/\)\(.*\).html,[\2]({{home}}/\1\2.html),g" ${out};
+
     # final pass updating the subcommand's "SEE ALSO" links to the command itself
     sed "s,${commandName}.md,#${commandName},g" ${out};
 }


### PR DESCRIPTION
* Update auto-generate script to convert absolute to relative paths
* Refresh istioctl docs which now use `cobra.Command::Example` instead of overloading the `Long` command help text field.