### PR TITLE
Fixing remaining bad links and html errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,5 @@ source "https://rubygems.org"
 
 gem "github-pages", group: :jekyll_plugins
 gem "jekyll-include-cache", "~> 0.1"
+gem "html-proofer"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,6 +13,7 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     colorator (1.1.0)
+    colored (1.2)
     ethon (0.10.1)
       ffi (>= 1.3.0)
     execjs (2.7.0)
@@ -72,6 +73,15 @@ GEM
     html-pipeline (2.5.0)
       activesupport (>= 2)
       nokogiri (>= 1.4)
+    html-proofer (3.6.0)
+      activesupport (>= 4.2, < 6.0)
+      addressable (~> 2.3)
+      colored (~> 1.2)
+      mercenary (~> 0.3.2)
+      nokogiri (~> 1.5)
+      parallel (~> 1.3)
+      typhoeus (~> 0.7)
+      yell (~> 2.0)
     i18n (0.8.1)
     jekyll (3.4.3)
       addressable (~> 2.4)
@@ -170,6 +180,7 @@ GEM
       mini_portile2 (~> 2.1.0)
     octokit (4.7.0)
       sawyer (~> 0.8.0, >= 0.5.3)
+    parallel (1.11.2)
     pathutil (0.14.0)
       forwardable-extended (~> 2.6)
     public_suffix (2.0.5)
@@ -190,12 +201,14 @@ GEM
     tzinfo (1.2.3)
       thread_safe (~> 0.1)
     unicode-display_width (1.1.3)
+    yell (2.0.7)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   github-pages
+  html-proofer
   jekyll-include-cache (~> 0.1)
 
 BUNDLED WITH

--- a/README.md
+++ b/README.md
@@ -15,3 +15,12 @@ To run the site locally with Docker, use the following command:
 ```bash
 docker run --rm --label=jekyll --volume=$(pwd):/srv/jekyll  -it -p 127.0.0.1:4000:4000 jekyll/jekyll jekyll serve
 ```
+
+Make sure you are not introducing html errors or bad links:
+```bash
+docker run --rm --label=jekyll --volume=$(pwd):/srv/jekyll  -it  jekyll/jekyll sh -c "bundle install && rake test"
+```
+```
+HTML-Proofer finished successfully.
+```
+

--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,7 @@ require 'html-proofer'
 
 task :test do
   sh "bundle exec jekyll build"
-  options = { :assume_extension => true }
+  options = { :check_html => true, # :validation => { :report_missing_names, :report_invalid_tags => true, :report_script_embeds => true },
+              :assume_extension => true, :url_ignore => [/localhost/] }
   HTMLProofer.check_directory("./_site", options).run
 end

--- a/_docs/concepts/policy-and-control/mixer-aspect-config.md
+++ b/_docs/concepts/policy-and-control/mixer-aspect-config.md
@@ -159,4 +159,4 @@ Mixer provides default definitions for commonly used
 
 * Learn more about [Mixer](./mixer.html) and [Mixer Config](./mixer-config.html).
 
-* Discover the full [Attribute Vocabulary]({{home}}/docs/reference/api/mixer/attribute-vocabulary.html).
+* Discover the full [Attribute Vocabulary]({{home}}/docs/reference/config/mixer/attribute-vocabulary.html).

--- a/_docs/concepts/policy-and-control/mixer-config.md
+++ b/_docs/concepts/policy-and-control/mixer-config.md
@@ -452,7 +452,7 @@ manifests:
 ## Examples
 
 You can find fully formed examples of Mixer configuration by visiting the [Samples]({{home}}/docs/samples). As
-a specific example, here is the [BookInfo configuration](https://raw.githubusercontent.com/istio/istio/master/samples/mixer-config-quota-bookinfo.yaml).
+a specific example, here is the [BookInfo configuration](https://github.com/istio/istio/tree/master/samples/apps/bookinfo).
 
 ## Configuration API
 

--- a/_docs/reference/api/mixer/mixer-service.md
+++ b/_docs/reference/api/mixer/mixer-service.md
@@ -387,7 +387,7 @@ Used to report telemetry after performing an action.
 <a name="istio.mixer.v1.ReportResponse.result"></a>
  <tr>
   <td><code>result</code></td>
-  <td><a href="./status.status.html">Status</a></td>
+  <td><a href="./status.html">Status</a></td>
   <td>Indicates whether the report was processed or not</td>
  </tr>
 </table>

--- a/_docs/reference/api/mixer/status.md
+++ b/_docs/reference/api/mixer/status.md
@@ -29,7 +29,7 @@ programming environments, including REST APIs and RPC APIs. It is used by
 #### Overview
 The `Status` message contains three pieces of data: error code, error message,
 and error details. The error code should be an enum value of
-[google.rpc.Code](#google.rpc.Code), but it may accept additional error codes if needed.  The
+`google.rpc.Code`, but it may accept additional error codes if needed.  The
 error message should be a developer-facing English message that helps
 developers *understand* and *resolve* the error. If a localized user-facing
 error message is needed, put the localized message in the error details or
@@ -85,7 +85,7 @@ Example uses of this error model include:
  <tr>
   <td><code>code</code></td>
   <td>int32</td>
-  <td>The status code, which should be an enum value of <a href="#google.rpc.Code">google.rpc.Code</a>.</td>
+  <td>The status code, which should be an enum value of `google.rpc.Code`.</td>
  </tr>
 <a name="google.rpc.Status.message"></a>
  <tr>

--- a/_docs/reference/commands/istioctl.md
+++ b/_docs/reference/commands/istioctl.md
@@ -6,7 +6,7 @@ order: 1
 type: markdown
 ---
 
-<a name="istioctl"></a>
+<a name="istioctl_cmd"></a>
 ## istioctl
 
 Istio control interface

--- a/_docs/reference/commands/mixc.md
+++ b/_docs/reference/commands/mixc.md
@@ -6,7 +6,7 @@ order: 101
 type: markdown
 ---
 
-<a name="mixc"></a>
+<a name="mixc_cmd"></a>
 ## mixc
 
 Utility to trigger direct calls to Mixer's API.

--- a/_docs/reference/commands/mixs.md
+++ b/_docs/reference/commands/mixs.md
@@ -6,7 +6,7 @@ order: 201
 type: markdown
 ---
 
-<a name="mixs"></a>
+<a name="mixs_cmd"></a>
 ## mixs
 
 Mixer is Istio's abstraction on top of infrastructure backends.

--- a/_docs/reference/config/traffic-rules/destination-policies.md
+++ b/_docs/reference/config/traffic-rules/destination-policies.md
@@ -115,7 +115,7 @@ service version indicated in the destination policy.
 ### LoadBalancing
 Load balancing policy to use when forwarding traffic. These policies
 directly correlate to [load balancer
-types](https://lyft.github.io/envoy/docs/intro/archOverview/loadBalancing.html)
+types](https://lyft.github.io/envoy/docs/intro/arch_overview/load_balancing.html)
 supported by Envoy. Example,
 
 
@@ -172,7 +172,7 @@ implementation is fine-grained in that it tracks the success/failure
 rates of individual hosts in the load balancing pool. Hosts that
 continually return errors for API calls are ejected from the pool for a
 pre-defined period of time. See Envoy's [outlier
-detection](https://lyft.github.io/envoy/docs/intro/archOverview/outlier.html)
+detection](https://lyft.github.io/envoy/docs/intro/arch_overview/outlier.html)
 for more details.
 
 <table>

--- a/_docs/reference/contribute/writing-a-new-topic.md
+++ b/_docs/reference/contribute/writing-a-new-topic.md
@@ -61,7 +61,7 @@ Choose a title for your topic that has the keywords you want search engines to f
 Create a filename for your topic that uses the words in your title, separated by hyphens,
 all in lower case.
 
-For example, the topic with title [TBD](/docs/tasks/tbd.html)
+For example, the topic with title TBD (`[TBD](/docs/tasks/tbd.html)`)
 has filename `tbd.md`. You don't need to put
 "Istio" in the filename, because "Istio" is already in the
 URL for the topic, for example:

--- a/_docs/tasks/istio-auth.md
+++ b/_docs/tasks/istio-auth.md
@@ -25,8 +25,7 @@ This task assumes you have:
 
 * Read the [Istio Auth concepts]({{home}}/docs/concepts/network-and-auth/index.html).
 
-* Cloned https://github.com/istio/istio to your local machine
-  (Step 1 in [the Istio installation guide](./installing-istio.html#installing-on-an-existing-cluster)).
+* [Installed Istio](./installing-istio.html#installation-steps).
 
 In real world systems, only a single Istio CA should be present in a Kubernetes cluster,
 which is always deployed in a dedicated namespace. The Istio CA issues certificates/keys to

--- a/_glossary/istio-auth.md
+++ b/_glossary/istio-auth.md
@@ -5,4 +5,4 @@ type: markdown
 {% include home.html %}
 
 Istio-Auth provides strong service-to-service and end-user authentication using mutual TLS, with built-in identity and
-credential management. Learn more about Istio-Auth [here]({{home}}/docs/concepts/network-and-auth/auth.html).
+credential management. Learn more about Istio-Auth [here](../concepts/network-and-auth/auth.html).

--- a/_glossary/mixer.md
+++ b/_glossary/mixer.md
@@ -5,4 +5,4 @@ type: markdown
 {% include home.html %}
 
 Mixer is an Istio component responsible for enforcing access control and usage policies across the service mesh and collecting telemetry data
-from the Envoy proxy and other services. Learn more about Mixer [here]({{home}}/docs/concepts/policy-and-control/mixer.html).
+from the Envoy proxy and other services. Learn more about Mixer [here](../../concepts/policy-and-control/mixer.html).

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -37,7 +37,7 @@
     <link rel="icon" type="image/png" href="{{home}}/favicons/android-chrome-96x96.png" sizes="96x96" >
     <link rel="icon" type="image/png" href="{{home}}/favicons/favicon-32x32.png" sizes="32x32">
     <link rel="icon" type="image/png" href="{{home}}/favicons/favicon-16x16.png" sizes="16x16">
-    <link rel="manifest" href="{{home}}/favicons/manifest.json"">
+    <link rel="manifest" href="{{home}}/favicons/manifest.json">
     <link rel="mask-icon" href="{{home}}/favicons/safari-pinned-tab.svg" color="#2DA6B0">
     <meta name="msapplication-TileColor" content="#ffffff">
     <meta name="msapplication-TileImage" content="{{home}}/favicons/mstile-150x150.png">

--- a/_posts/2017-05-01-0.1-announcement.md
+++ b/_posts/2017-05-01-0.1-announcement.md
@@ -29,7 +29,7 @@ Here’s a list of some of the capabilities Istio provides out of the box:
 
 - Automatic encryption of service-to-service communication with strong identity assertions between services leveraging mutual TLS and SPIFFE specification.
 
-- Intelligent per-request load balancing for HTTP/1.1, HTTP/2 & [gRPC](https://grpc.io) in addition to connection-based load balancing for TCP.
+- Intelligent per-request load balancing for HTTP/1.1, HTTP/2 & [gRPC](http://grpc.io) in addition to connection-based load balancing for TCP.
 
 - Precise control over traffic routing with expressive rules. Retry budgets, circuit breakers and fault injection to improve and test resiliency.
 


### PR DESCRIPTION
Fix all the issues found by html-proofer. Follow up issue #238 to check it for all changes.

Couldn't find google.rpc.Code so not a link anymore, and the quota issues has been changed in master since

Was still left :
#google.rpc.Code in reference/api/mixer/status

And the mixer-config-quota-bookinfo.yaml is missing in
https://github.com/istio/istio/tree/master/samples/apps/bookinfo

Issue #226 