### PR TITLE
279 fixed code segments overlapping on toc

### DIFF
--- a/_sass/base/_common.scss
+++ b/_sass/base/_common.scss
@@ -102,3 +102,10 @@ th {
 .ui-widget-content a:hover, a:focus {
   color: $linkHoverColor !important;
 }
+
+#content-container{
+  /* overrides overflow:visible, which overlays on top of floating elements, i.e. the toc on /docs/reference/commands/istioctl.html */
+  code[class*="language-"], pre[class*="language-"]{
+    overflow:scroll;
+  }
+}


### PR DESCRIPTION
fixed code segments overlapping on toc in http://localhost:4000/docs/reference/commands/istioctl.html

Before:
![image](https://cloud.githubusercontent.com/assets/1237156/26261928/1c057c6e-3ca1-11e7-802f-0553ecb85d90.png)


After:
![image](https://cloud.githubusercontent.com/assets/1237156/26261888/ee6ecd96-3ca0-11e7-8d24-d4d2fe9646b1.png)

Might also want to see how this looks on a non-mac, given how mac does scrollbars differently than everyone else. I dont have anything to test on tho...