### PR TITLE
zindex of toc on docs pages

### DIFF
--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -10,19 +10,21 @@ layout: default
   <div class="row">
     <div class="col-md-11 nofloat center-block">
       <div class="row">
-          <div id="sidebar-container" class="col-sm-3">
-              {% include doc-side-nav.html %}
-          </div>
+        <div id="sidebar-container" class="col-sm-3">
+          {% include doc-side-nav.html %}
+        </div>
 
-          <div id="tab-container" class="col-xs-1 tab-neg-margin pull-left">
-              <span id="sidebar-tab" class="glyphicon glyphicon-chevron-left"></span>
-          </div>
+        <div id="tab-container" class="col-xs-1 tab-neg-margin pull-left">
+          <span id="sidebar-tab" class="glyphicon glyphicon-chevron-left"></span>
+        </div>
 
-          <div id="content-container" class="thin-left-border col-sm-9 {{ page.type }}">
-            <div id="toc" class="toc"></div>
+        <div id="content-container" class="thin-left-border col-sm-9 {{ page.type }}">
+          <div id="toc" class="toc"></div>
+          <div id="doc-content">
             <h1>{{page.title}}</h1>
             {{ content }}
           </div>
+        </div>
       </div>
     </div>
   </div>

--- a/_sass/modules/_toc.scss
+++ b/_sass/modules/_toc.scss
@@ -21,8 +21,9 @@ div.toc {
   display: none !important;
   padding: 15px;
   float: right;
-  right: 45px;
   margin-top: 15px;
+  z-index:1001;
+  position:relative;
 
   @media (min-width: 1024px) {
       display: block !important;
@@ -53,4 +54,9 @@ div.toc {
     display: block !important;
     border-left: 4px solid $light-gray;
   }
+}
+
+#doc-content{
+  z-index:1000;
+  position:relative;
 }


### PR DESCRIPTION
wrapped a div around the non-toc contents of the docs pages. used position:relative and zindex to make toc overlap other content

![image](https://cloud.githubusercontent.com/assets/1237156/26316424/3bff5aa6-3ee2-11e7-8ea6-cb7a7d61011a.png)
