### PR TITLE
Fixing site errors, and ignore repos/*.{html,md} for generation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -52,4 +52,6 @@ exclude:
   - scripts/
   - Rakefile
   - Jenkinsfile
+  - repos/*.html
+  - repos/*.md
 

--- a/_docs/concepts/what-is-istio/overview.md
+++ b/_docs/concepts/what-is-istio/overview.md
@@ -69,7 +69,7 @@ Istio uses an extended version of the [Envoy](https://lyft.github.io/envoy/) pro
 Istio leverages Envoy’s many built-in features such as dynamic service discovery, load balancing, TLS termination, HTTP/2 & gRPC proxying, circuit breakers,
 health checks, staged rollouts with %-based traffic split, fault injection, and rich metrics.
 
-Envoy is deployed as a **sidecar** to the relevant service in the same Kubernetes pod. This allows Istio to extract a wealth of signals about traffic behavior as [attributes]({{home}}/docs/concepts/policy-and-control/attributes.html), which in turn it can use in [Mixer]({{home}}/docs/concepts/policy-and-control/mixer.html) to enforce policy decisions, and be sent to monitoring systems to provide information about the behavior of the entire mesh. The sidecar proxy model also allows you to add Istio capabilities to an existing deployment with no need to rearchitect or rewrite code. You can read more about why we chose this approach in our [Design Goals]({{home}}/docs/concepts/goals.html).
+Envoy is deployed as a **sidecar** to the relevant service in the same Kubernetes pod. This allows Istio to extract a wealth of signals about traffic behavior as [attributes]({{home}}/docs/concepts/policy-and-control/attributes.html), which in turn it can use in [Mixer]({{home}}/docs/concepts/policy-and-control/mixer.html) to enforce policy decisions, and be sent to monitoring systems to provide information about the behavior of the entire mesh. The sidecar proxy model also allows you to add Istio capabilities to an existing deployment with no need to rearchitect or rewrite code. You can read more about why we chose this approach in our [Design Goals]({{home}}/docs/concepts/what-is-istio/goals.html).
 
 ### Mixer
 


### PR DESCRIPTION
Fixes #298
Turns out most of the errors were from repos/