### PR TITLE
292 mobile left nav

### DIFF
--- a/_sass/modules/_doc-nav.scss
+++ b/_sass/modules/_doc-nav.scss
@@ -101,4 +101,11 @@
 .tree-toggle {
     cursor: pointer;
     margin-left: -1em;
+
+	.tree-toggle-link{
+		&, &:focus, &:hover{
+			color:#535f61 !important;
+			text-decoration: none;
+		}
+	}
 }

--- a/js/navtree.js
+++ b/js/navtree.js
@@ -101,11 +101,13 @@ function outputNavBarTree(items) {
             document.writeln("<li class='doc-side-nav-list-item'>");
             document.writeln("<label class='tree-toggle'>");
             document.writeln("<i class='fa fa-lg fa-caret-down'></i>");
+            document.writeln("<a class='tree-toggle-link' href='javascript:void 0;'>");
             if (item.doc == null) {
                 document.writeln(item.name);
             } else {
                 document.writeln(item.doc.title);
             }
+            document.writeln("</a>");
             document.writeln("</label>");
 
             if (item.doc.order == 9999) {

--- a/js/sidemenu.js
+++ b/js/sidemenu.js
@@ -12,9 +12,10 @@
       //  sidebar.height($('footer').position().top + 50);
     
       // 992 is the default breakpoint set in Bootstrap 3 for col-md
+      var width = $(document).width();
       if (width < 992) {
-        sidebar.toggle();
-        sidebarOpen = !sidebarOpen;
+        sidebar.hide();
+        sidebarOpen = false;
       }
     }
 


### PR DESCRIPTION
-fixed a jumping of the nav if you resize. i believe this was causing the nav to show/hide on scroll on phones
-made leftnav items easier to click on ipads

https://github.com/istio/istio.github.io/issues/292