### PR TITLE
310 fixed browser chrome covering the down arrow on mobile browsers

### DIFF
--- a/_sass/layouts/_landing.scss
+++ b/_sass/layouts/_landing.scss
@@ -78,7 +78,7 @@
       }
       .hero-lead {
         position: absolute;
-        top: 75%;
+        top: 70%;
         width: 100%;
         text-align: center;
         transform: translate(0, -50%);
@@ -86,7 +86,7 @@
       }
       .hero-down-arrow {
         position: absolute;
-        bottom: 25px;
+        bottom: 75px;
         left: 50%;
         transform: translate(-50%, 0);
       }


### PR DESCRIPTION
before:
![image](https://cloud.githubusercontent.com/assets/1237156/26379217/fcecea4a-3fe5-11e7-9f28-fd7b1ff827a4.png)



with fix:
![image](https://cloud.githubusercontent.com/assets/1237156/26379192/e62793a0-3fe5-11e7-8131-7bc5d7bb21dd.png)


https://github.com/istio/istio.github.io/issues/310