### PR TITLE
Further improve list formatting

### DIFF
--- a/_sass/base/_markdown.scss
+++ b/_sass/base/_markdown.scss
@@ -31,7 +31,7 @@
 
   // Paragraphs inside list items whether you want them or not (thanks, Markdown)
   li p {
-    margin: 5px;
+    margin: 5px 0px;
   }
 
   // Lists


### PR DESCRIPTION
...so we don't get inconsistent padding when Markdown inexplicably decides to add the random paragraph element to just *one* list item