### PR TITLE
improve commands output

### DIFF
--- a/_docs/tasks/istio-auth.md
+++ b/_docs/tasks/istio-auth.md
@@ -49,10 +49,10 @@ Istio CA is up if the "AVAILABLE" column is 1.
 1. Verify AuthPolicy setting in ConfigMap.
 
    ```bash
-   kubectl get configmap istio -o yaml | grep authPolicy
+   kubectl get configmap istio -o yaml | grep authPolicy | head -1
    ```
 
-   Istio Auth is enabled if the line "authPolicy: MUTUAL\_TLS" is uncommented.
+   Istio Auth is enabled if the line `    authPolicy: MUTUAL_TLS` is uncommented.
 
 1. Check Istio Auth is enabled on Envoy proxies.
 


### PR DESCRIPTION
adding `|head -1 ` because without it the output is confusing:
```
ldemailly-macbookpro:istio-0.1.5 ldemailly$ kubectl get configmap istio -o yaml | grep authPolicy
    authPolicy: MUTUAL_TLS
      {"apiVersion":"v1","data":{"mesh":"# Uncomment the following line to enable mutual TLS between proxies\nauthPolicy: MUTUAL_TLS\nmixerAddress: istio-mixer:9091\ndiscoveryAddress: istio-manager:8080\ningressService: istio-ingress\nzipkinAddress: zipkin:9411"},"kind":"ConfigMap","metadata":{"annotations":{},"name":"istio","namespace":"default"}}
```