### PR TITLE
versioned docs: add build scripts to be driven thru jenkins

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,0 +1,6 @@
+{
+  "projects": {
+    "default": "istio-io",
+    "v01": "istiodocs-v01"
+  }
+}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "repos/istio"]
-	path = repos/istio
-	url = https://github.com/istio/istio.git

--- a/_docs/reference/contribute/writing-a-new-topic.md
+++ b/_docs/reference/contribute/writing-a-new-topic.md
@@ -228,15 +228,14 @@ display a config file or a test file. To do so, you can't use normal markup and 
 use direct HTML. For example:
 
 ```
-{% raw %}<pre data-src="{{home}}/repos/istio/BUILD"></pre>{% endraw %}
+{% raw %}<pre data-src="https://raw.githubusercontent.com/istio/istio/master/BUILD"></pre>{% endraw %}
 ```
 
 which produces the following result:
 
-<pre data-src="{{home}}/repos/istio/BUILD"></pre>
+<pre data-src="https://raw.githubusercontent.com/istio/istio/master/BUILD"></pre>
 
-The `data-src` attribute specifies the path to the file to display. This has to be a file within the
-current site, it cannot come from a different site.
+The `data-src` attribute specifies the path to the file to display.
 
 ### Highlighting lines
 

--- a/_docs/reference/contribute/writing-a-new-topic.md
+++ b/_docs/reference/contribute/writing-a-new-topic.md
@@ -235,7 +235,9 @@ which produces the following result:
 
 <pre data-src="https://raw.githubusercontent.com/istio/istio/master/BUILD"></pre>
 
-The `data-src` attribute specifies the path to the file to display.
+The `data-src` attribute specifies the path to the file to display. [PrismJS](http://prismjs.com/) fetches 
+ the file using XMLHttpRequest. If the file is from a different origin site, CORS should be enabled on that site.
+Note that the github raw content site (`raw.githubusercontent.com`) is CORS enabled so it may be used here.
 
 ### Highlighting lines
 

--- a/_docs/tasks/metrics-logs.md
+++ b/_docs/tasks/metrics-logs.md
@@ -37,7 +37,7 @@ as the example application throughout this task.
    automatically.
 
    Save the following as `new_rule.yaml`:
-   <pre data-src="{{home}}/repos/istio/samples/apps/bookinfo/mixer-rule-additional-telemetry.yaml"></pre>
+   <pre data-src="https://raw.githubusercontent.com/istio/istio/release-0.1/samples/apps/bookinfo/mixer-rule-additional-telemetry.yaml"></pre>
 
 1. Pick a target service for the new rule.
 

--- a/_includes/home.html
+++ b/_includes/home.html
@@ -1,4 +1,1 @@
-{% assign home = "" %}
-{% if site.github.environment == "dotcom" %}
 {% assign home = site.baseurl %}
-{% endif %}

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,5 @@
+{
+  "hosting": {
+    "public": "_site"
+  }
+}

--- a/js/navtree.js
+++ b/js/navtree.js
@@ -2,12 +2,7 @@
 sitemap_exclude: y
 ---
 
-/*
-{% assign home = "" %}
-{% if site.github.environment == "dotcom" %}
 {% assign home = site.baseurl %}
-{% endif %}
-*/
 
 // Given an array of documents, constructs a tree of items
 //

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# This script builds and pushes the current branch
+# to a firebase project
+# The ci token produced by 'firebase login:ci'
+# MUST have access to the given projects
+
+PROJECT_ID=${PROJECT_ID:?"PROJECT_ID required"}
+FIREBASE_TOKEN=${FIREBASE_TOKEN:?"FIREBASE_TOKEN required"}
+
+if [[ -z ${INDOCKER} ]];then
+	docker run --rm --label=jekyll --volume=$(pwd):/srv/jekyll \
+		-e PROJECT_ID=$PROJECT_ID \
+		-e FIREBASE_TOKEN=$FIREBASE_TOKEN \
+		-e INDOCKER=true \
+		jekyll/jekyll scripts/build.sh
+else
+	set -e
+	# The directory now is /srv/jekyll inside the container
+	# TODO bake a new docker image with correct versions from bundler 
+	jekyll build
+	npm install -g firebase-tools
+	firebase use $PROJECT_ID --non-interactive --token $FIREBASE_TOKEN
+	firebase deploy --public _site --non-interactive --token $FIREBASE_TOKEN
+fi
+

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+#example: PROJECT_ID=istiodocs-v01 RELEASE=0.1 FIREBASE_TOKEN=aabbccdd ./scripts/build.sh
+
 # This script builds and pushes the current branch
 # to a firebase project
 # The ci token produced by 'firebase login:ci'
@@ -7,20 +9,27 @@
 
 PROJECT_ID=${PROJECT_ID:?"PROJECT_ID required"}
 FIREBASE_TOKEN=${FIREBASE_TOKEN:?"FIREBASE_TOKEN required"}
+RELEASE=${RELEASE:?"RELEASE is required"}
 
 if [[ -z ${INDOCKER} ]];then
 	docker run --rm --label=jekyll --volume=$(pwd):/srv/jekyll \
 		-e PROJECT_ID=$PROJECT_ID \
 		-e FIREBASE_TOKEN=$FIREBASE_TOKEN \
 		-e INDOCKER=true \
+		-e RELEASE=${RELEASE} \
 		jekyll/jekyll scripts/build.sh
 else
 	set -e
 	# The directory now is /srv/jekyll inside the container
-	# TODO bake a new docker image with correct versions from bundler 
-	jekyll build
+	# TODO bake a new docker image with correct versions from bundler
+        PUBLIC=_static_site	
+	rm -Rf ${PUBLIC}
+	mkdir -p ${PUBLIC}
+	mv _site "${PUBLIC}/v-${RELEASE}"
+	echo "baseurl: /v-${RELEASE}" > config_verride.yml
+	jekyll build --config _config.yml,config_verride.yml
 	npm install -g firebase-tools
 	firebase use $PROJECT_ID --non-interactive --token $FIREBASE_TOKEN
-	firebase deploy --public _site --non-interactive --token $FIREBASE_TOKEN
+	firebase deploy --public ${PUBLIC} --non-interactive --token $FIREBASE_TOKEN
 fi
 


### PR DESCRIPTION
publishes the checked out branch to firebase hosting.

https://istiodocs-v01.firebaseapp.com/v-0.1/

Firebase hosting was chosen because
1. It is hosted :-)
2. easy to setup
3. automagic ssl cert provisioning. 

This should be attached to the jenkins framework to work automagically. 

Every maintained branch build will be hosted such that fron't end routing rule should be 
`istio.io/v-{version}  --> https://istiodocs-v-{version}.firebaseapp.com/v-{version}/`