### PR TITLE
remove stackoverflow from footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -31,7 +31,6 @@
             <div class="col-md-3 col-sm-4 col-xs-12 center-block">
                 <ul class="toggle">
                     <p class="header">Community</p>
-                    <li><a href="https://stackoverflow.com/questions/tagged/istio" target="_blank"><span class="stack-overflow">Stack Overflow</span></a></li>
                     <li><a href="https://groups.google.com/forum/#!forum/istio-users" target="_blank"><span class="group">User</span></a> | <a href="https://groups.google.com/forum/#!forum/istio-dev" target="_blank">Dev Mailing Lists</a></li>
                     <li><a href="https://twitter.com/IstioMesh" target="_blank"><span class="twitter">Twitter</span></a></li>
                     <li><a href="https://github.com/istio/istio" target="_blank"><span class="github">GitHub</span></a></li>


### PR DESCRIPTION
most questions on stackoverflow are support questions better suited for the mailing list or the issues

(people will still be able to reach so from community/)