### PR TITLE
additional link to envoy doc to explain circuit breaker maxConnections etc

### DIFF
--- a/_docs/reference/config/traffic-rules/destination-policies.md
+++ b/_docs/reference/config/traffic-rules/destination-policies.md
@@ -162,7 +162,7 @@ implementation is fine-grained in that it tracks the success/failure
 rates of individual hosts in the load balancing pool. Hosts that
 continually return errors for API calls are ejected from the pool for a
 pre-defined period of time. See Envoy's [outlier
-detection](https://lyft.github.io/envoy/docs/intro/arch_overview/outlier.html)
+detection](https://lyft.github.io/envoy/docs/intro/arch_overview/circuit_breaking.html)
 for more details.
 
 <table>

--- a/_docs/reference/config/traffic-rules/destination-policies.md
+++ b/_docs/reference/config/traffic-rules/destination-policies.md
@@ -162,7 +162,7 @@ implementation is fine-grained in that it tracks the success/failure
 rates of individual hosts in the load balancing pool. Hosts that
 continually return errors for API calls are ejected from the pool for a
 pre-defined period of time. See Envoy's [outlier
-detection](https://lyft.github.io/envoy/docs/intro/arch_overview/circuit_breaking.html)
+detection](https://lyft.github.io/envoy/docs/intro/arch_overview/outlier.html)
 for more details.
 
 <table>
@@ -181,7 +181,7 @@ for more details.
 
 <a name="istio.proxy.v1.config.CircuitBreaker.SimpleCircuitBreakerPolicy"></a>
 #### SimpleCircuitBreakerPolicy
-Parameters to tune Envoy's circuit breaker configuration. A simple
+Parameters to tune Envoy's [circuit breaker configuration]((https://lyft.github.io/envoy/docs/intro/arch_overview/circuit_breaking.html). A simple
 circuit breaker can be set based on a number of criteria such as
 connection and request limits. For example, the following destination
 policy sets a limit of 100 connections to "reviews" service version

--- a/_docs/reference/config/traffic-rules/destination-policies.md
+++ b/_docs/reference/config/traffic-rules/destination-policies.md
@@ -181,7 +181,7 @@ for more details.
 
 <a name="istio.proxy.v1.config.CircuitBreaker.SimpleCircuitBreakerPolicy"></a>
 #### SimpleCircuitBreakerPolicy
-Parameters to tune Envoy's [circuit breaker configuration]((https://lyft.github.io/envoy/docs/intro/arch_overview/circuit_breaking.html). A simple
+Parameters to tune Envoy's [circuit breaker configuration](https://lyft.github.io/envoy/docs/intro/arch_overview/circuit_breaking.html). A simple
 circuit breaker can be set based on a number of criteria such as
 connection and request limits. For example, the following destination
 policy sets a limit of 100 connections to "reviews" service version


### PR DESCRIPTION
that explains why we have the fields we do unlike the previous link