### PR TITLE
Revert "additional link to envoy doc to explain circuit breaker maxConnections etc"

### DIFF
--- a/_docs/reference/config/traffic-rules/destination-policies.md
+++ b/_docs/reference/config/traffic-rules/destination-policies.md
@@ -181,7 +181,7 @@ for more details.
 
 <a name="istio.proxy.v1.config.CircuitBreaker.SimpleCircuitBreakerPolicy"></a>
 #### SimpleCircuitBreakerPolicy
-Parameters to tune Envoy's [circuit breaker configuration](https://lyft.github.io/envoy/docs/intro/arch_overview/circuit_breaking.html). A simple
+Parameters to tune Envoy's circuit breaker configuration. A simple
 circuit breaker can be set based on a number of criteria such as
 connection and request limits. For example, the following destination
 policy sets a limit of 100 connections to "reviews" service version


### PR DESCRIPTION
Reverts istio/istio.github.io#395

While in Envoy, the concepts carry their own custom meaning, from Istio perspective, this was Envoy's CB and outlier detection were intentionally bundled into one unit. Linking to just circuit breaker is totally incorrect and just throws off the user, as our CB configuration talks about outlier detection as well.