### PR TITLE
Update overview's Pilot definition

### DIFF
--- a/_docs/concepts/what-is-istio/overview.md
+++ b/_docs/concepts/what-is-istio/overview.md
@@ -79,7 +79,7 @@ evaluation can be found in [Mixer Configuration]({{home}}/docs/concepts/policy-a
 
 ### Pilot
 
-[Pilot]({{home}}/docs/concepts/traffic-management/pilot.html) serves as an interface between the user and Istio, collecting and validating configuration and propagating it to the various Istio components.
+[Pilot]({{home}}/docs/concepts/traffic-management/pilot.html) is responsible for collecting and validating configuration and propagating it to the various Istio components.
 It abstracts environment-specific implementation details from Mixer and Envoy, providing them with an abstract representation of the user’s services 
 that is independent of the underlying platform. In addition, traffic management rules (i.e. generic layer-4 rules and layer-7 HTTP/gRPC routing rules) can 
 be programmed at runtime via Pilot.


### PR DESCRIPTION
Focus on responsibilities rather than position in the architecture ("user" in the sentence was ambiguous and a bit confusing -- it could be the user making a request to the service or the owner of the app doing the deploying of config).