### PR TITLE
Replace 'criterion' with 'criteria'

### DIFF
--- a/_docs/concepts/traffic-management/request-routing.md
+++ b/_docs/concepts/traffic-management/request-routing.md
@@ -47,7 +47,7 @@ model enables the application code to decouple itself from the evolution of its 
 services, while providing other benefits as well (see
 [Mixer]({{home}}/docs/concepts/policy-and-control/mixer.html)). Routing
 rules allow Envoy to select a version based
-on criterion such as headers, tags associated with
+on criteria such as headers, tags associated with
 source/destination, and/or by weights assigned to each version.
 
 Istio also provides load balancing for traffic to multiple instances of

--- a/_docs/reference/config/traffic-rules/routing-rules.md
+++ b/_docs/reference/config/traffic-rules/routing-rules.md
@@ -96,7 +96,7 @@ For example, a simple rule to send 100% of incoming traffic for a
 
 <a name="istio.proxy.v1.config.MatchCondition"></a>
 ### MatchCondition
-Match condition specifies a set of criterion to be met in order for the
+Match condition specifies a set of criteria to be met in order for the
 route rule to be applied to the connection or HTTP request.  The
 condition provides distinct set of conditions for each protocol with the
 intention that conditions apply only to the service ports that match the

--- a/_glossary/service-version.md
+++ b/_glossary/service-version.md
@@ -8,6 +8,6 @@ variants of the application binary or config. These variants are not necessarily
 different API versions. They could be iterative changes to the same service,
 deployed in different environments (prod, staging, dev, etc.). Common
 scenarios where this occurs include A/B testing, canary rollouts, etc. The
-choice of a particular version can be decided based on various criterion
+choice of a particular version can be decided based on various criteria
 (headers, url, etc.) and/or by weights assigned to each version.  Each
 service has a default version consisting of all its instances.


### PR DESCRIPTION
Criterion is the singular form of criteria, but each example is being used in a plural context.