### PR TITLE
Update basic access control task with new configs

### DIFF
--- a/_docs/concepts/policy-and-control/mixer-aspect-config.md
+++ b/_docs/concepts/policy-and-control/mixer-aspect-config.md
@@ -107,7 +107,7 @@ The following table enumerates valid combinations of the `aspects`, the `descrip
 |-----------------------------------------------
 |[Quota enforcement]({{aspectConfig}}/quotas.html ) | [QuotaDescriptor]({{mixerConfig}}#istio.mixer.v1.config.descriptor.QuotaDescriptor) |  [memQuota]({{adapterConfig}}/memQuota.html), [redisQuota]({{adapterConfig}}/redisquota.html)
 |[Metrics collection]({{aspectConfig}}/metrics.html)| [MetricDescriptor]({{mixerConfig}}#metricdescriptor) |[prometheus]({{adapterConfig}}/prometheus.html),[statsd]({{adapterConfig}}/statsd.html)
-|[Whitelist/Blacklist]({{aspectConfig}}/lists.html)| None |[genericListChecker]({{adapterConfig}}/genericListChecker.html),[ipListChecker]({{adapterConfig}}/list.html)
+|[Whitelist/Blacklist]({{aspectConfig}}/lists.html)| None |[genericListChecker]({{adapterConfig}}/genericListChecker.html),[listchecker]({{adapterConfig}}/list.html)
 |[Access logs]({{aspectConfig}}/accessLogs.html)|[LogEntryDescriptor]({{mixerConfig}}#logentrydescriptor)  |[stdioLogger]({{adapterConfig}}/stdioLogger.html)
 |[Application logs]({{aspectConfig}}/applicationLogs.html)|[LogEntryDescriptor]({{mixerConfig}}#logentrydescriptor)  |[stdioLogger]({{adapterConfig}}/stdioLogger.html)
 |[Deny Request]({{aspectConfig}}/denials.html)| None |[denyChecker]({{adapterConfig}}/denier.html)

--- a/_docs/concepts/policy-and-control/mixer-aspect-config.md
+++ b/_docs/concepts/policy-and-control/mixer-aspect-config.md
@@ -107,10 +107,10 @@ The following table enumerates valid combinations of the `aspects`, the `descrip
 |-----------------------------------------------
 |[Quota enforcement]({{aspectConfig}}/quotas.html ) | [QuotaDescriptor]({{mixerConfig}}#istio.mixer.v1.config.descriptor.QuotaDescriptor) |  [memQuota]({{adapterConfig}}/memQuota.html), [redisQuota]({{adapterConfig}}/redisquota.html)
 |[Metrics collection]({{aspectConfig}}/metrics.html)| [MetricDescriptor]({{mixerConfig}}#metricdescriptor) |[prometheus]({{adapterConfig}}/prometheus.html),[statsd]({{adapterConfig}}/statsd.html)
-|[Whitelist/Blacklist]({{aspectConfig}}/lists.html)| None |[genericListChecker]({{adapterConfig}}/genericListChecker.html),[ipListChecker]({{adapterConfig}}/ipListChecker.html)
+|[Whitelist/Blacklist]({{aspectConfig}}/lists.html)| None |[genericListChecker]({{adapterConfig}}/genericListChecker.html),[ipListChecker]({{adapterConfig}}/list.html)
 |[Access logs]({{aspectConfig}}/accessLogs.html)|[LogEntryDescriptor]({{mixerConfig}}#logentrydescriptor)  |[stdioLogger]({{adapterConfig}}/stdioLogger.html)
 |[Application logs]({{aspectConfig}}/applicationLogs.html)|[LogEntryDescriptor]({{mixerConfig}}#logentrydescriptor)  |[stdioLogger]({{adapterConfig}}/stdioLogger.html)
-|[Deny Request]({{aspectConfig}}/denials.html)| None |[denyChecker]({{adapterConfig}}/denyChecker.html)
+|[Deny Request]({{aspectConfig}}/denials.html)| None |[denyChecker]({{adapterConfig}}/denier.html)
 
 Istio uses [`protobufs`](https://developers.google.com/protocol-buffers/) to define configuration schemas. The [Writing Configuration]({{home}}/docs/reference/writing-config.html) document explains how to express `proto` definitions as `yaml`.
 

--- a/_docs/reference/config/mixer/adapters/denier.md
+++ b/_docs/reference/config/mixer/adapters/denier.md
@@ -1,6 +1,6 @@
 ---
-title: denyChecker
-overview: denyChecker adapter configuration schema
+title: denier
+overview: denier adapter configuration schema
 
 order: 0
 
@@ -17,9 +17,9 @@ type: markdown
   <th>Type</th>
   <th>Description</th>
  </tr>
-<a name="adapter.denyChecker.Params.error"></a>
+<a name="adapter.denier.Params.status"></a>
  <tr>
-  <td><code>error</code></td>
+  <td><code>status</code></td>
   <td><a href="/docs/reference/api/mixer/status.html">Status</a></td>
   <td>The error to return when denying a request.</td>
  </tr>

--- a/_docs/reference/config/mixer/adapters/list.md
+++ b/_docs/reference/config/mixer/adapters/list.md
@@ -1,6 +1,6 @@
 ---
-title: ipListChecker
-overview: ipListChecker adapter configuration schema
+title: listchecker
+overview: listchecker adapter configuration schema
 
 order: 20
 
@@ -9,7 +9,7 @@ type: markdown
 ---
 
 
-<a name="adapter.ipListChecker.Params"></a>
+<a name="adapter.listchecker.Params"></a>
 ### Params
 
 <table>
@@ -18,19 +18,31 @@ type: markdown
   <th>Type</th>
   <th>Description</th>
  </tr>
-<a name="adapter.ipListChecker.Params.providerUrl"></a>
+<a name="adapter.listchecker.Params.providerUrl"></a>
  <tr>
   <td><code>providerUrl</code></td>
   <td>string</td>
   <td>Where to find the list to check against</td>
  </tr>
-<a name="adapter.ipListChecker.Params.refreshInterval"></a>
+<a name="adapter.listchecker.Params.overrides"></a>
+ <tr>
+  <td><code>overrides</code></td>
+  <td>repeated string</td>
+  <td>List entries that are consulted first, before the list from the server</td>
+ </tr>
+<a name="adapter.listchecker.Params.blacklist"></a>
+ <tr>
+  <td><code>blacklist</code></td>
+  <td>bool</td>
+  <td>Whether the list operates as a blacklist or a whitelist.</td>
+ </tr>
+<a name="adapter.listchecker.Params.refreshInterval"></a>
  <tr>
   <td><code>refreshInterval</code></td>
   <td><a href="https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#duration">Duration</a></td>
   <td>Determines how often the provider is polled for an updated list</td>
  </tr>
-<a name="adapter.ipListChecker.Params.ttl"></a>
+<a name="adapter.listchecker.Params.ttl"></a>
  <tr>
   <td><code>ttl</code></td>
   <td><a href="https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#duration">Duration</a></td>

--- a/_docs/reference/config/mixer/template/listentry.md
+++ b/_docs/reference/config/mixer/template/listentry.md
@@ -1,0 +1,27 @@
+---
+title: listentry
+overview: listentry template configuration schema
+
+order: 0
+
+layout: docs
+type: markdown
+---
+
+
+### Params
+
+<table>
+ <tr>
+  <th>Field</th>
+  <th>Type</th>
+  <th>Description</th>
+ </tr>
+<a name="template.listentry.InstanceParam.value"></a>
+ <tr>
+  <td><code>value</code></td>
+  <td>Value</td>
+  <td>Specifies the entry to verify in the list.</td>
+ </tr>
+</table>
+

--- a/_docs/tasks/basic-access-control.md
+++ b/_docs/tasks/basic-access-control.md
@@ -112,7 +112,7 @@ Istio also supports attribute-based whitelists and blacklists.
    adapter that lists versions `v1, v2`:
 
    ```yaml
-   apiVersion: "config.istio.io/v1alpha2"
+   apiVersion: config.istio.io/v1alpha2
    kind: listchecker
    metadata:
      name: staticversion
@@ -127,7 +127,7 @@ Istio also supports attribute-based whitelists and blacklists.
 2. Extract the version label by creating an instance of the [`listentry`]({{home}}/docs/reference/config/mixer/template/listentry.html) template:
 
    ```yaml
-   apiVersion: "config.istio.io/v1alpha2"
+   apiVersion: config.istio.io/v1alpha2
    kind: listentry
    metadata:
      name: appversion
@@ -139,7 +139,7 @@ Istio also supports attribute-based whitelists and blacklists.
 3. Enable `whitelist` checking for the ratings service:
 
    ```yaml
-   apiVersion: "config.istio.io/v1alpha2"
+   apiVersion: config.istio.io/v1alpha2
    kind: rule
    metadata:
      name: checkversion

--- a/_docs/tasks/basic-access-control.md
+++ b/_docs/tasks/basic-access-control.md
@@ -45,31 +45,56 @@ of the `reviews` service. We would like to cut off access to version `v3` of the
    If you log in as any other user (or logout) you should see red ratings stars with each review,
    indicating that the `ratings` service is being called by the "v3" version of the `reviews` service.
 
-1. Explicitly deny access to version `v3` of the `reviews` service. 
+1. Explicitly deny access to version `v3` of the `reviews` service.
 
-   ```bash
-   istioctl mixer rule create global ratings.default.svc.cluster.local -f samples/apps/bookinfo/mixer-rule-ratings-denial.yaml
-   ```
-
-   This command sets configuration for `subject=ratings.default.svc.cluster.local`. 
-   You can display the current configuration with the following command:
-
-   ```
-   istioctl mixer rule get global ratings.default.svc.cluster.local
-   ```
-
-   which should produce:
-
+   Before setting up the deny rule, we must create a handler and an instance definition that can be used in the deny rule.
+   Replace `metadata.namespace` with the appropriate value.
    ```yaml
-   rules:
-   - aspects:
-     - kind: denials
-     selector: source.labels["app"]=="reviews" && source.labels["version"] == "v3"
+   apiVersion: "config.istio.io/v1alpha2"
+   kind: denier
+   metadata:
+     name: handler
+     namespace: default
+   spec:
+     status:
+       code: 7
+       message: Not allowed  # This message is sent back the client
+   ---
+   apiVersion: "config.istio.io/v1alpha2"
+   kind: checknothing
+   metadata:
+     name: denyrequest
+     namespace: default
+   spec:
+   ---
+   ```
+   Save the file as mixer-rule-ratings-denial.yaml and run
+   ```bash
+   kubectl apply -f istioctl mixer-rule-ratings-denial.yaml
+   ```
+   You can expect to see the following output
+   ```bash
+   denier "denyall" created
+   checknothing "denyrequest" created
    ```
 
-   This rule uses the `denials` aspect to deny requests coming from version `v3` of the reviews service.
-   The `denials` aspect always denies requests with a pre-configured status code and message.
-   The status code and the message is specified in the [DenyChecker]({{home}}/docs/reference/config/mixer/adapters/denyChecker.html)
+   Now create the following rule using the above method
+   ```yaml
+   apiVersion: "config.istio.io/v1alpha2"
+   kind: rule
+   metadata:
+     name: denyreviewsv3
+     namespace: default
+   spec:
+     match: destination.labels["app"] == "ratings" && source.labels["app"]=="reviews" && source.labels["version"] == "v3"
+     actions:
+     - handler: denyall.denier
+       instances: [ denyrequest.checknothing ]
+   ```
+
+   This rule uses the `denier` adapter to deny requests coming from version `v3` of the reviews service.
+   The adapter always denies requests with a pre-configured status code and message.
+   The status code and the message is specified in the [denier]({{home}}/docs/reference/config/mixer/adapters/denier.html)
    adapter configuration.
   
 1. Refresh the `productpage` in your browser.
@@ -81,45 +106,57 @@ of the `reviews` service. We would like to cut off access to version `v3` of the
 
 ## Access control using _whitelists_ 
 
-Istio also supports attribute-based white and blacklists.
-Using a whitelist is a two step process.
+Istio also supports attribute-based whitelists and blacklists.
 
-1. Add an adapter definition for the [`genericListChecker`]({{home}}/docs/reference/config/mixer/adapters/genericListChecker.html) 
+1. Add an adapter definition for the [`listchecker`]({{home}}/docs/reference/config/mixer/adapters/list.html)
    adapter that lists versions `v1, v2`:
 
    ```yaml
-   - name: versionList
-     impl: genericListChecker
-     params:
-       listEntries: ["v1", "v2"]
+   apiVersion: "config.istio.io/v1alpha2"
+   kind: listchecker
+   metadata:
+     name: staticversion
+     namespace: default
+   spec:
+     # providerUrl: ordinarily black and white lists are maintained
+     # externally and fetched asynchronously using the providerUrl.
+     overrides: ["v1", "v2"]  # overrides provide a static list
+     blacklist: false
    ```
 
-2. Enable `whitelist` checking by using the [`lists`]({{home}}/docs/reference/config/mixer/aspects/lists.html) aspect:
+2. Extract the version label by creating an instance of the [`listentry`]({{home}}/docs/reference/config/mixer/template/listentry.html) template:
 
    ```yaml
-   rules:
-     aspects:
-     - kind: lists
-       adapter: versionList
-       params:
-         blacklist: false
-         checkExpression: source.labels["version"] 
-   ``` 
+   apiVersion: "config.istio.io/v1alpha2"
+   kind: listentry
+   metadata:
+     name: appversion
+     namespace: default
+   spec:
+     value: source.labels["version"]
+   ```
 
-   `checkExpression` is evaluated and checked against the list `[v1, v2]`. The check behavior can be changed to a blacklist by specifying
-   `blacklist: true`. The expression evaluator returns the value of the `version` label as specified by the `checkExpression` key.
+3. Enable `whitelist` checking for the ratings service:
 
-The current version of `istioctl` does not yet support
-pushing adapter configurations like the one in step 1.
-There is, however, a [workaround]({{home}}/docs/concepts/policy-and-control/mixer-aspect-config.html#pushing-configuration)
-that you can use if you want to try it out anyway.
+   ```yaml
+   apiVersion: "config.istio.io/v1alpha2"
+   kind: rule
+   metadata:
+     name: checkversion
+     namespace: istio-config-default
+   spec:
+     match: destination.labels["app"] == "ratings"
+     actions:
+     - handler: staticversion.listchecker
+       instances: [ appversion.listentry ]
+   ```
 
 ## Cleanup
 
-* Remove the mixer configuration rule:
+* Remove the mixer configuration:
 
   ```bash
-  istioctl mixer rule delete global ratings.default.svc.cluster.local
+  kubectl delete -f /path/to/file.yaml
   ```
 
 * Remove the application routing rules:


### PR DESCRIPTION
This PR updates basic access control tasks with new configs.

At present the new adapter and template links are broken because those artifacts have not been generated yet. 