### PR TITLE
istio-ingress-certs is the tls secretName for ingress

### DIFF
--- a/_docs/tasks/traffic-management/ingress.md
+++ b/_docs/tasks/traffic-management/ingress.md
@@ -309,7 +309,7 @@ We also showed how to control the ingress traffic using an Istio route rule.
    ```bash
    istioctl delete routerule httpbin-3s-rule
    kubectl delete ingress simple-ingress secured-ingress 
-   kubectl delete secret istio-ingress-certs
+   kubectl delete -n istio-system secret istio-ingress-certs
    ```
 
 1. Shutdown the [httpbin](https://github.com/istio/istio/tree/master/samples/httpbin) service.

--- a/_docs/tasks/traffic-management/ingress.md
+++ b/_docs/tasks/traffic-management/ingress.md
@@ -156,7 +156,7 @@ to configure ingress behavior.
        kubernetes.io/ingress.class: istio
    spec:
      tls:
-       - secretName: ingress-secret
+       - secretName: istio-ingress-certs # currently ignored
      rules:
      - http:
          paths:
@@ -309,7 +309,7 @@ We also showed how to control the ingress traffic using an Istio route rule.
    ```bash
    istioctl delete routerule httpbin-3s-rule
    kubectl delete ingress simple-ingress secured-ingress 
-   kubectl delete secret ingress-secret
+   kubectl delete secret istio-ingress-certs
    ```
 
 1. Shutdown the [httpbin](https://github.com/istio/istio/tree/master/samples/httpbin) service.


### PR DESCRIPTION
Use proper tls secretName so when SNI is supported this example still works. Added comment for clarity. I spent time trying to figure out how this worked before seeing the note below the example. Fixed cleanup