### PR TITLE
Change default to example in Config doc

### DIFF
--- a/_docs/concepts/policy-and-control/mixer-config.md
+++ b/_docs/concepts/policy-and-control/mixer-config.md
@@ -300,5 +300,6 @@ manifests:
 
 ## Examples
 
-You can find fully formed examples of Mixer configuration by visiting the [Guides]({{home}}/docs/guides). As
-a specific example, here is the [Default configuration](https://github.com/istio/mixer/blob/master/testdata/config).
+You can find fully-formed examples of Mixer configuration by visiting the
+[Guides]({{home}}/docs/guides). Here is some [example
+configuration](https://github.com/istio/mixer/blob/master/testdata/config).


### PR DESCRIPTION
The config in: `mixer/testdata/config/` is not the default config for Mixer. While that may be the long-term intention, it is not the case currently.

This PR updates the wording in the config documentation to reflect the status of the config in `mixer/testdata/config/`.