### PR TITLE
Fix port naming rules.

### DIFF
--- a/_docs/setup/kubernetes/sidecar-injection.md
+++ b/_docs/setup/kubernetes/sidecar-injection.md
@@ -18,10 +18,11 @@ cluster must satisfy the following requirements:
   [Kubernetes Service](https://kubernetes.io/docs/concepts/services-networking/service/)
   (pods that belong to multiple services are not supported as of now).
 
-1. _**Named ports**:_ Service ports must be named. The port names must begin
-  with _http_, _http2_, _grpc_, or _mongo_ prefix in order to take advantage
-  of Istio's routing features. For example, `name: http2-foo` or `name: http`
-  are valid port names.  If the port name does not begin with a recognized
+1. _**Named ports**:_ Service ports must be named. The port names must be of
+  the form `<protocol>[-<suffix>]` with _http_, _http2_, _grpc_, or _mongo_
+  as the `<protocol>` in order to take advantage of Istio's routing features.
+  For example, `name: http2-foo` or `name: http` are valid port names, but
+  `name: http2foo` is not.  If the port name does not begin with a recognized
   prefix or if the port is unnamed, traffic on the port will be treated as
   plain TCP traffic (unless the port explicitly uses `Protocol: UDP` to
   signify a UDP port).

--- a/_docs/setup/kubernetes/sidecar-injection.md
+++ b/_docs/setup/kubernetes/sidecar-injection.md
@@ -19,7 +19,7 @@ cluster must satisfy the following requirements:
   (pods that belong to multiple services are not supported as of now).
 
 1. _**Named ports**:_ Service ports must be named. The port names must be of
-  the form `<protocol>[-<suffix>]` with _http_, _http2_, _grpc_, or _mongo_
+  the form `<protocol>[-<suffix>]` with _http_, _http2_, _grpc_, _mongo_, or _redis_
   as the `<protocol>` in order to take advantage of Istio's routing features.
   For example, `name: http2-foo` or `name: http` are valid port names, but
   `name: http2foo` is not.  If the port name does not begin with a recognized


### PR DESCRIPTION
Pilot logic is here: https://github.com/istio/pilot/blob/1ab60bb736f1ed072d4ef5941f80c63c766c3b32/platform/kube/conversion.go#L143

Fixes docs so they more clearly explain the format port names must follow.