### PR TITLE
Put `Prometheus install` first before `Collect Metrics`.

### DIFF
--- a/_docs/tasks/telemetry/metrics-logs.md
+++ b/_docs/tasks/telemetry/metrics-logs.md
@@ -3,7 +3,7 @@ title: Collecting Metrics and Logs
 
 overview: This task shows you how to configure Istio to collect metrics and logs.
 
-order: 20
+order: 30
 
 layout: docs
 type: markdown
@@ -23,12 +23,8 @@ as the example application throughout this task.
   (`--configDefaultNamespace=istio-system`). If you use a different
   value, update the configuration and commands in this task to match the value.
 
-* Install the Prometheus add-on. Prometheus
-  will be used to verify task success. 
-  ```bash
-  kubectl apply -f install/kubernetes/addons/prometheus.yaml
-  ```
-  See [Prometheus](https://prometheus.io) for details.
+* [Install the Prometheus add-on]({{home}}/docs/tasks/telemetry/querying-metrics.html).
+  Prometheus will be used to verify task success.
 
 ## Collecting new telemetry data
 

--- a/_docs/tasks/telemetry/querying-metrics.md
+++ b/_docs/tasks/telemetry/querying-metrics.md
@@ -3,7 +3,7 @@ title: Querying Metrics from Prometheus
 
 overview: This task shows you how to query for Istio Metrics using Prometheus.
 
-order: 30
+order: 20
 
 layout: docs
 type: markdown
@@ -24,6 +24,7 @@ the example application throughout this task.
 ## Querying Istio Metrics
 
 1. To query the metrics provided by Mixer, first install the Prometheus add-on.
+   See [Prometheus](https://prometheus.io) for details.
 
     In Kubernetes environments, execute the following command:
 

--- a/_docs/tasks/telemetry/tcp-metrics.md
+++ b/_docs/tasks/telemetry/tcp-metrics.md
@@ -26,12 +26,8 @@ as the example application throughout this task.
   namespace. If you use a different namespace, you will need to update the
   example configuration and commands.
 
-* Install the Prometheus add-on. Prometheus
-  will be used to verify task success. 
-  ```bash
-  kubectl apply -f install/kubernetes/addons/prometheus.yaml
-  ```
-  See [Prometheus](https://prometheus.io) for details.
+* [Install the Prometheus add-on]({{home}}/docs/tasks/telemetry/querying-metrics.html).
+  Prometheus will be used to verify task success.
 
 ## Collecting new telemetry data
 


### PR DESCRIPTION
As the `Collect Metrics` topics depend on `Prometheus install`, so
we need to have the `Prometheus install` topic first.