### PR TITLE
Fixes transposed params in intergrating_vms guide

### DIFF
--- a/_docs/guides/integrating-vms.md
+++ b/_docs/guides/integrating-vms.md
@@ -71,7 +71,7 @@ On the DB machine:
   Run istioctl to configure the service (on your admin machine):
 
   ```bash
-  istioctl register mysql PORT IP
+  istioctl register mysql IP PORT
   ```
 
   Note that the 'db' machine does not need and should not have special kubernetes priviledges.


### PR DESCRIPTION
The istoctl register command had the port and IP fields
transposed.   This fixes that and closes:
https://github.com/istio/istio.github.io/issues/691