### PR TITLE
Update sidecar-injection.md

### DIFF
--- a/_docs/setup/kubernetes/sidecar-injection.md
+++ b/_docs/setup/kubernetes/sidecar-injection.md
@@ -144,7 +144,6 @@ different environments as follows:
 
   ```bash
   gcloud container clusters create NAME \
-      --cluster-version=1.7.5 \
       --enable-kubernetes-alpha \
       --machine-type=n1-standard-2 \
       --num-nodes=4 \


### PR DESCRIPTION
1.7.5 does not work for new clusters anymore. If we skip this line it should pick up the default - which is now at 1.7.8.gke