### PR TITLE
Add external url cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,5 +31,13 @@ jobs:
             - ./vendor/bundle
           key: v1-dependencies-{{ checksum "Gemfile.lock" }}
 
+      - restore_cache:
+          keys:
+          - htmlproofer-cache
       # Run the test/html checker
       - run: bundle exec rake test
+      # save the external URLs cache
+      - save_cache:
+          key: htmlproofer-cache
+          paths:
+            - tmp/.htmlproofer

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ config_override.yml
 *.iml
 .idea/
 .bundle/
+tmp/

--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,7 @@ require 'html-proofer'
 task :test do
   sh "bundle exec jekyll build"
   options = { :check_html => true, # :validation => { :report_missing_names, :report_invalid_tags => true, :report_script_embeds => true },
+              :cache => { :timeframe => '2d'},
               :assume_extension => true, :url_ignore => [/localhost|github\.com\/istio\/istio\.github\.io\/edit\/master\//] }
   HTMLProofer.check_directory("./_site", options).run
 end


### PR DESCRIPTION
That should help avoid the spurious failures or at least make “rebuild”
work if the remote site isn’t actually down