### PR TITLE
Fixed a couple rendering bugs I introduced, and improve loading perf.

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -63,13 +63,13 @@ layout: compress
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
     <link rel="stylesheet" href="{{home}}/css/all.css">
     <link rel="stylesheet" href="{{home}}/css/prism.css">
-
-    <!-- jQuery - note that moving to version 3 and beyond of jquery causes the prism-related code in common.js to not execute
-     properly, leading to rendering differences in code blocks -->
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
   </head>
 
   <body class="language-unknown">
+    <!-- jQuery - note that moving to version 3 and beyond of jquery causes the prism-related code in common.js to not execute
+     properly, leading to rendering differences in code blocks -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
+
     <!-- this is a trick to avoid content shifting as the page loads. See https://stackoverflow.com/questions/1417934/how-to-prevent-scrollbar-from-repositioning-web-page -->
     {{ content }}
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,12 +3,10 @@ layout: base
 ---
 {% include home.html %}
 
-<div id="wrap">
 <div class="nav-hero-container">
 	{% include nav.html %}
 </div>
 
 {{ content }}
-</div>
 
 {% include footer.html %}

--- a/_sass/base/_common.scss
+++ b/_sass/base/_common.scss
@@ -82,14 +82,6 @@ th {
   }
 }
 
-html, body {
-    height: 100%;
-    margin: 0;
-}
-
-// voodoo to glue the footer to the bottom of the page when the content is short
-#wrap {
-    min-height: -webkit-calc(100% - 250px);     /* Chrome */
-    min-height: -moz-calc(100% - 250px);     /* Firefox */
-    min-height: calc(100% - 250px);     /* native */
+html {
+    background-color: $mainBrandColor;
 }


### PR DESCRIPTION
- I left a debugging string ("Chevron") in the text, which
would show up on screen. Oops.

- The trick I used to glue the footer to the bottom of the browser window ended up causing trouble with the
vertical scroll bar positioning. I reverted this trick, in favor of a simpler approach. Instead of gluing
the footer to the bottom of the window, I simply make it so the bottom of the page is already rendered in the
same blue as the footer.

- Move a script from loading in the header to loading in the body. According to the Chrome profiler, this
saves a bunch of time blocking rendering during page load.