### PR TITLE
Fix 404 link to service discovery api

### DIFF
--- a/_docs/concepts/traffic-management/pilot.md
+++ b/_docs/concepts/traffic-management/pilot.md
@@ -24,7 +24,7 @@ resources, and third party resources that store traffic management rules.
 This data is translated into the canonical representation. Envoy-specific
 configuration is generated based on the canonical representation.
 
-Pilot exposes APIs for [service discovery](https://www.envoyproxy.io/docs/envoy/latest/api-v1/cluster_manager/cds),
+Pilot exposes APIs for [service discovery](https://www.envoyproxy.io/docs/envoy/latest/api-v1/cluster_manager/sds),
 dynamic updates to [load balancing pools](https://www.envoyproxy.io/docs/envoy/latest/configuration/cluster_manager/cds)
 and [routing tables](https://www.envoyproxy.io/docs/envoy/latest/configuration/http_conn_man/rds).
 These APIs decouple Envoy from platform-specific nuances, simplifying the

--- a/_docs/concepts/traffic-management/pilot.md
+++ b/_docs/concepts/traffic-management/pilot.md
@@ -24,7 +24,7 @@ resources, and third party resources that store traffic management rules.
 This data is translated into the canonical representation. Envoy-specific
 configuration is generated based on the canonical representation.
 
-Pilot exposes APIs for [service discovery](https://www.envoyproxy.io/docs/envoy/latest/configuration/cluster_manager/sds_api),
+Pilot exposes APIs for [service discovery](https://www.envoyproxy.io/docs/envoy/latest/api-v1/cluster_manager/cds),
 dynamic updates to [load balancing pools](https://www.envoyproxy.io/docs/envoy/latest/configuration/cluster_manager/cds)
 and [routing tables](https://www.envoyproxy.io/docs/envoy/latest/configuration/http_conn_man/rds).
 These APIs decouple Envoy from platform-specific nuances, simplifying the


### PR DESCRIPTION
Currently master's circleci build is failing with:

```
[...]
Found 166 links in the cache...
Adding 14 links to the cache...
Removing 0 links from the cache...
Checking 15 external links...
Ran on 139 files!


- ./_site/docs/concepts/traffic-management/pilot.html
  *  External link https://www.envoyproxy.io/docs/envoy/latest/configuration/cluster_manager/sds_api failed: 404 No error
rake aborted!
HTML-Proofer found 1 failure!
```

This change corrects the broken link to (what I believe is) the correct API page. Note that this failure is preventing #743 from passing.