### PR TITLE
fixing the version in quickstart

### DIFF
--- a/_docs/setup/kubernetes/quick-start.md
+++ b/_docs/setup/kubernetes/quick-start.md
@@ -71,7 +71,7 @@ with UID 0 for Istio's service accounts for ingress and egress:
   ```bash
   oc adm policy add-scc-to-user privileged -z default -n <target-namespace>
   ```
-    
+
 ## Installation steps
 
 Starting with the 0.2 release, Istio is installed in its own `istio-system`
@@ -93,7 +93,7 @@ run the following command to download and extract the latest release automatical
 
 1. Change directory to istio package. For example, if the package is istio-{{ site.data.istio.version }}
   ```bash
-  cd {{ site.data.istio.version }}
+  cd istio-{{ site.data.istio.version }}
   ```
 
 1. Add the `istioctl` client to your PATH.

--- a/_docs/setup/kubernetes/quick-start.md
+++ b/_docs/setup/kubernetes/quick-start.md
@@ -74,7 +74,7 @@ with UID 0 for Istio's service accounts for ingress and egress:
     
 ## Installation steps
 
-Starting with the {{ site.data.istio.version }} release, Istio is installed in its own `istio-system`
+Starting with the 0.2 release, Istio is installed in its own `istio-system`
 namespace, and can manage micro-services from all other namespaces.
 
 1. Go to the [Istio release](https://github.com/istio/istio/releases) page to download the
@@ -91,9 +91,9 @@ run the following command to download and extract the latest release automatical
     * The `istioctl` client binary in the `bin/` directory. `istioctl` is used when manually injecting Envoy as a sidecar proxy and for creating routing rules and policies.
     * The `istio.VERSION` configuration file
 
-1. Change directory to istio package. For example, if the package is istio-0.2.7
+1. Change directory to istio package. For example, if the package is istio-{{ site.data.istio.version }}
   ```bash
-  cd istio-0.2.7
+  cd {{ site.data.istio.version }}
   ```
 
 1. Add the `istioctl` client to your PATH.


### PR DESCRIPTION
ps: I wonder if the hardcoded 0.2.7 is why we still get reports of people with 0.2.7 even though 0.2.12 was out for weeks