### PR TITLE
Remove the TOC from the FAQ page.

### DIFF
--- a/_docs/welcome/faq.md
+++ b/_docs/welcome/faq.md
@@ -7,6 +7,7 @@ order: 20
 layout: faq
 type: markdown
 redirect_from: /faq
+toc: false
 ---
 {% include home.html %}
 


### PR DESCRIPTION
It sneaked on there when I changed the FAQ page template to include the sidebar.
I wanted the sidebar, but not the TOC.