### PR TITLE
Fix to run new htmlproofer from docker (https instead of ssh url needed)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,5 @@ source "https://rubygems.org"
 gem "github-pages", group: :jekyll_plugins
 gem "jekyll-include-cache", "~> 0.1"
 gem "nokogiri", ">= 1.8.1"
-gem "html-proofer", :git => "git@github.com:/ldemailly/html-proofer.git"
+gem "html-proofer", :git => "https://github.com/ldemailly/html-proofer.git"
 gem "rake"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git@github.com:/ldemailly/html-proofer.git
+  remote: https://github.com/ldemailly/html-proofer.git
   revision: a9fd7130ddf4bffc54ef938783d09a110e46574b
   specs:
     html-proofer (3.7.5)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ To run the site locally with Docker, use the following command from the toplevel
 
 ```bash
 # First time: (slow)
-docker run --name istio-jekyll --volume=$(pwd):/srv/jekyll  -it -p 127.0.0.1:4000:4000 jekyll/jekyll:3.5.2 sh -c "bundle install && rake test && jekyll serve"
+docker run --name istio-jekyll --volume=$(pwd):/srv/jekyll  -it -p 127.0.0.1:4000:4000 jekyll/jekyll:3.5.2 sh -c "bundle install && rake test && jekyll serve --incremental"
 # Then open browser with url 127.0.0.1:4000 to see the change.
 # Subsequent, each time you want to see a new change and you stopped the previous run by ctrl+c: (much faster)
 docker start istio-jekyll -a -i

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,7 @@
 require 'html-proofer'
 
 task :test do
-  sh "bundle exec jekyll build"
+  sh "bundle exec jekyll build --incremental"
   typhoeus_configuration = {
   :timeout => 30,
 #  :verbose => true

--- a/_docs/welcome/contribute/creating-a-pull-request.md
+++ b/_docs/welcome/contribute/creating-a-pull-request.md
@@ -1,7 +1,7 @@
 ---
 title: Creating a Pull Request
 overview: Shows you how to create a GitHub pull request in order to submit your docs for approval.
-              
+
 order: 20
 
 layout: docs
@@ -21,7 +21,7 @@ repository. This page shows the steps necessary to create a pull request.
 Documentation will be published under the [Apache 2.0](https://github.com/istio/istio.github.io/blob/master/LICENSE) license.
 
 ## Creating a fork
- 
+
 Before you can edit documentation, you need to create a fork of Istio's documentation GitHub repository:
 
 1. Go to the
@@ -44,7 +44,10 @@ that is the best fit for your content.
 ## Submitting a pull request
 
 To publish your changes, you must create a pull request against the master branch of Istio's
-documentation repositoryL
+documentation repository.
+
+1. Make sure your change produce valid html and links are valid, `rake test`
+will check this for you.
 
 1. In your GitHub account, in your new branch, create a pull request
 against the master branch of the istio/istio.github.io

--- a/_docs/welcome/contribute/staging-your-changes.md
+++ b/_docs/welcome/contribute/staging-your-changes.md
@@ -1,7 +1,7 @@
 ---
 title: Staging Your Changes
 overview: Explains how to test your changes locally before submitting them.
-              
+
 order: 40
 
 layout: docs
@@ -18,16 +18,9 @@ Create a fork of the Istio documentation repository as described in
 
 ## Staging locally
 
-To stage your changes, go to the top of your documentation repo and start Jekyll via the following
-docker command-line:
+See [Detailed instructions and options on GitHub](https://github.com/istio/istio.github.io/blob/master/README.md)
 
-```bash
-docker run --rm --label=jekyll --volume=$(pwd):/srv/jekyll  -it -p 127.0.0.1:4000:4000 jekyll/jekyll jekyll serve
-```
-
-If you don't have docker installed, get that first and the above should then just work.
-
-Once the docker command is running, you can open a web browser and go to `http://localhost:4000` to see your
+Once Jekyll is running, you can open a web browser and go to `http://localhost:4000` to see your
 changes. You can make further changes to the content in your repo and just refresh your browser page to see
 the results, no need to restart Jekyll all the time.
 


### PR DESCRIPTION
Also point to the readme for how to setup docker/jekyll

Fixed a typo (extra L)

Switch to incremental by default for faster refreshes

This fixes:
```
Fetching git@github.com:/ldemailly/html-proofer.git
fatal: cannot run ssh: No such file or directory
fatal: unable to fork
```