### PR TITLE
Remove the duplicated namespace argument

### DIFF
--- a/_docs/guides/bookinfo.md
+++ b/_docs/guides/bookinfo.md
@@ -171,7 +171,7 @@ To start the application, follow the instructions below corresponding to your Is
 1. _Minikube:_ External load balancers are not supported in Minikube. You can use the host IP of the ingress service, along with the NodePort, to access the ingress.
    
    ```bash
-   export GATEWAY_URL=$(kubectl get po -n istio-system -l istio=ingress -n istio-system -o 'jsonpath={.items[0].status.hostIP}'):$(kubectl get svc istio-ingress -n istio-system -n istio-system -o 'jsonpath={.spec.ports[0].nodePort}')
+   export GATEWAY_URL=$(kubectl get po -l istio=ingress -n istio-system -o 'jsonpath={.items[0].status.hostIP}'):$(kubectl get svc istio-ingress -n istio-system -o 'jsonpath={.spec.ports[0].nodePort}')
    ```
 
 ### Running on Docker with Consul or Eureka


### PR DESCRIPTION
This change removes the duplicated namespace arguments to find the gateway URL of bookinfo on minikube.
Our original conversation: https://github.com/istio/istio.github.io/pull/730#issuecomment-350497087

My thanks for maintaining this introduction to istio!