### PR TITLE
Add information about grafana not displaying metrics

### DIFF
--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -57,6 +57,17 @@ server {
 }
 ```
 
+## No grafana output when connecting from a local web client to Istio remotely hosted
+
+Validate the client and server date and time match.
+
+The time of the web client (e.g. Chrome) affects the output from Grafana. A simple solution
+to this problem is to verify a time synchronization service is running correctly within the
+Kubernetes cluster and the web client machine also is correctly using a time synchronization
+service. Some common time synchronization systems are NTP and Chrony. This is especially
+problematic is engineering labs with firewalls. In these scenarios, NTP may not be configured
+properly to point at the lab-based NTP services.
+
 ## Where are the metrics for my service?
 
 The expected flow of metrics is:


### PR DESCRIPTION
If the server time is behind the client time at minimum 6 minutes,
the Grafana dashboard will not display metrics to the web client (e.g. Chrome).

This is clearly some type of bug - the time of the client should have
zero bearing on the metrics displayed by the server.  Note the metrics
are recorded.  I am unclear if the metric timestamps are recorded correctly
in the server.

See: https://github.com/istio/istio/issues/1954 for more details.