### PR TITLE
Include traffic-shifting routerule yaml on the doc page

### DIFF
--- a/_docs/tasks/traffic-management/traffic-shifting.md
+++ b/_docs/tasks/traffic-management/traffic-shifting.md
@@ -57,6 +57,30 @@ two steps: 50%, 100%.
 
    Notice that we are using `istioctl replace` instead of `create`.
 
+   Confirm the rule was replaced:
+
+   ```bash
+   istioctl get routerule reviews-default -o yaml
+   ```
+   ```yaml
+   apiVersion: config.istio.io/v1alpha2
+   kind: RouteRule
+   metadata:
+     name: reviews-default
+     namespace: default
+   spec:
+     destination:
+       name: reviews
+     precedence: 1
+     route:
+     - labels:
+         version: v1
+       weight: 50
+     - labels:
+         version: v3
+       weight: 50
+   ```
+
 1. Refresh the `productpage` in your browser and you should now see *red* colored star ratings approximately 50% of the time.
 
    > Note: With the current Envoy sidecar implementation, you may need to refresh the `productpage` very many times


### PR DESCRIPTION
Problem:
The traffic shifting guide task asks readers to replace the route rules without showing them what is happening. The task only asks readers to refresh the product page a number of times to see the change.

What is expected:
The page should follow all of the previous tasks and have readers confirm the rule. This should also show them the rule that has been changed and make it clear that the routing now shifts traffic.