### PR TITLE
Simplify how FAQ categories and blog posts are hsndled.

### DIFF
--- a/_blog/index.html
+++ b/_blog/index.html
@@ -1,15 +1,15 @@
 ---
 layout: compress
 ---
-{% include home.html %}
+{% include latest_blog_post.html %}
 
 <!DOCTYPE html>
 <html lang="en-US">
   <meta charset="utf-8">
   <title>Redirecting…</title>
-  <link rel="canonical" href="{{home}}/blog/posts/{{site.data.istio.latest_blog_post}}">
-  <meta http-equiv="refresh" content="0; url={{home}}/blog/posts/{{site.data.istio.latest_blog_post}}">
+  <link rel="canonical" href="{{latest_blog_post}}">
+  <meta http-equiv="refresh" content="0; url={{latest_blog_post}}">
   <h1>Redirecting…</h1>
-  <a href="{{home}}/blog/posts/{{site.data.istio.latest_blog_post}}">Click here if you are not redirected.</a>
-  <script>location="{{home}}/blog/posts/{{site.data.istio.latest_blog_post}}"</script>
+  <a href="{{latest_blog_post}}">Click here if you are not redirected.</a>
+  <script>location="{{latest_blog_post}}"</script>
 </html>

--- a/_blog/posts/index.md
+++ b/_blog/posts/index.md
@@ -1,7 +1,6 @@
 ---
 title: The Istio Blog
 overview: Istio blog posts
-order: 10
 layout: blog
 type: markdown
 ---

--- a/_config.yml
+++ b/_config.yml
@@ -28,8 +28,6 @@ compress_html:
 collections:
   faq:
     output: false
-  faq_categories:
-    output: false
   glossary:
     output: false
   blog:

--- a/_data/istio.yml
+++ b/_data/istio.yml
@@ -1,2 +1,1 @@
 version: 0.4.0
-latest_blog_post: 2017/mixer-spof-myth.html

--- a/_docs/welcome/contribute/writing-a-new-topic.md
+++ b/_docs/welcome/contribute/writing-a-new-topic.md
@@ -62,7 +62,6 @@ is the best fit for your content:
     <td>Blog Post</td>
     <td>
       A blog post is a timely article on Istio or products and technologies related to it.
-      See <a href="#blog-posts">below</a> for additional information about creating blog posts.
     </td>
   </tr>
 </table>
@@ -126,13 +125,6 @@ Depending on your page type, put your new file in a subdirectory of one of these
 You can put your file in an existing subdirectory, or you can create a new
 subdirectory. For blog posts, put the file into a subdirectory for the current
 year (2017, 2018, etc)
-
-### Blog Posts
-
-When adding a new blog post, you need to go change the latest_blog_post value that's defined
-in the file _data/istio.yml to point to your post. This makes it so references to the latest
-blog post throughout the site point to the right place. For example, the Blog link in the
-top navigation area of the web site uses this value.
 
 ## Adding images to a topic
 

--- a/_docs/welcome/faq.md
+++ b/_docs/welcome/faq.md
@@ -11,6 +11,9 @@ toc: false
 ---
 {% include home.html %}
 
+{% assign faq_category_dirs = "general,setup,security,mixer,traffic-management" | split: ',' %}
+{% assign faq_category_names = "General,Setup,Security,Mixer,Traffic Management" | split: ',' %}
+
 Here are some frequently asked questions about Istio.
  
 > <img src="{{home}}/img/bulb.svg" alt="Bulb" title="Help" style="width: 32px; display:inline" />
@@ -20,14 +23,14 @@ If you don't find what you're looking for here, check out our [help page]({{home
   <div class="col-md-2">
     <ul class="list-group help-group">
       <div class="faq-list list-group nav nav-tabs">
-        {% assign cats = site.faq_categories | sort: "order" %}
+        {% assign cats = faq_category_dirs %}
         {% for cat in cats %}
           {% assign active = "" %}
           {% if forloop.index == 1 %}
             {% assign active = "active" %}
           {% endif %}
           
-          <a href="#tab{{forloop.index}}" class="list-group-item {{active}}" role="tab" data-toggle="tab">{{cat.title}}</a>
+          <a href="#tab{{forloop.index}}" class="list-group-item {{active}}" role="tab" data-toggle="tab">{{faq_category_names[forloop.index0]}}</a>
         {% endfor %}
       </div>
     </ul>
@@ -36,7 +39,7 @@ If you don't find what you're looking for here, check out our [help page]({{home
   <div class="col-md-8">
     <div class="tab-content panels-faq">    
 
-      {% assign cats = site.faq_categories | sort: "order" %}
+      {% assign cats = faq_category_dirs %}
       {% for cat in cats %}
         {% assign catIndex = forloop.index %}
         
@@ -52,7 +55,7 @@ If you don't find what you're looking for here, check out our [help page]({{home
             {% for q in faqs %}
               {% assign comp = q.path | split: '/' %}
               {% assign qcat = comp[1] %}
-              {% if cat.name == qcat %}
+              {% if cat == qcat %}
        	        {% assign name = q.path | downcase | split: '/' | last | remove: ".md" %}
 
                 <div id="{{name}}" class="panel panel-default">

--- a/_faq_categories/general.txt
+++ b/_faq_categories/general.txt
@@ -1,5 +1,0 @@
----
-title: General
-order: 10
-name: general
----

--- a/_faq_categories/mixer.txt
+++ b/_faq_categories/mixer.txt
@@ -1,5 +1,0 @@
----
-title: Mixer
-order: 40
-name: mixer
----

--- a/_faq_categories/security.txt
+++ b/_faq_categories/security.txt
@@ -1,5 +1,0 @@
----
-title: Security
-order: 30
-name: security
----

--- a/_faq_categories/setup.txt
+++ b/_faq_categories/setup.txt
@@ -1,5 +1,0 @@
----
-title: Setup
-order: 20
-name: setup
----

--- a/_faq_categories/traffic-management.txt
+++ b/_faq_categories/traffic-management.txt
@@ -1,5 +1,0 @@
----
-title: Traffic Management
-order: 50
-name: traffic-management
----

--- a/_includes/latest_blog_post.html
+++ b/_includes/latest_blog_post.html
@@ -1,0 +1,25 @@
+{% comment %}
+Assigns the latest_blog_post variable the URL of the latest blog post on the site
+{% endcomment %}
+
+{% include home.html %}
+{% assign latest_year = "0" %}
+
+{% assign sorted = site.blog | sort: "order" %}
+{% for d in sorted %}
+  {% if d.draft == true %}
+    {% continue %}
+  {% endif %}
+
+  {% assign path_components = d.path | downcase | split: '/' %}
+  {% assign last = path_components | last %}
+  {% if last == "index.html" or last == "index.md" %}
+    {% continue %}
+  {% endif %}
+
+  {% assign year = path_components[2] %}
+  {% if year > latest_year %}
+    {% assign latest_year = year %}
+    {% assign latest_blog_post = home | append: d.url %}
+  {% endif %}
+{% endfor %}

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,3 +1,5 @@
+{% include latest_blog_post.html %}
+
 {% assign current = page.url | downcase | split: '/' %}
 
 {% if page.url == "/index.html" or page.url == "/" %}
@@ -32,7 +34,7 @@
           <div class="collapse navbar-collapse" id="navbar-collapse-1">
             <ul class="nav navbar-nav navbar-right">
               <li><a href="{{home}}/about" {% if current[1] == 'about.html' %}class='current'{% endif %}>About</a></li>
-              <li><a href="{{home}}/blog/posts/{{site.data.istio.latest_blog_post}}" {% if current[1] == 'blog' %}class='current'{% endif %}>Blog</a></li>
+              <li><a href="{{latest_blog_post}}" {% if current[1] == 'blog' %}class='current'{% endif %}>Blog</a></li>
               <li><a href="{{home}}/docs/welcome" {% if current[1] == 'docs' %}class='current'{% endif %}>Docs</a></li>
               <li><a href="{{home}}/help" {% if current[1] == 'help.html' %}class='current'{% endif %}>Help</a></li>
               <li><a href="{{home}}/community" {% if current[1] == 'community.html' %}class='current'{% endif %}>Community</a></li>


### PR DESCRIPTION
- The latest_blog_post variable is now computed instead of
needing to be set explicitly when a new post is added.

- FAQ categories are now specified in a much denser format directly
in the FAQ markdown rather than with a bunch of files.

Staging site: https://geeknoid.github.io/istio.github.io/