### PR TITLE
corrected filename typo for consul and eureka command

### DIFF
--- a/_docs/guides/bookinfo.md
+++ b/_docs/guides/bookinfo.md
@@ -183,12 +183,12 @@ To start the application, follow the instructions below corresponding to your Is
     1. To test with Consul, run the following command:
         ```bash
         docker-compose -f samples/bookinfo/consul/bookinfo.yaml up -d
-        docker-compose -f samples/bookinfo/consul/bookinfo.sidecar.yaml up -d
+        docker-compose -f samples/bookinfo/consul/bookinfo.sidecars.yaml up -d
         ```
     1. To test with Eureka, run the following command:
         ```bash
         docker-compose -f samples/bookinfo/eureka/bookinfo.yaml up -d
-        docker-compose -f samples/bookinfo/eureka/bookinfo.sidecar.yaml up -d
+        docker-compose -f samples/bookinfo/eureka/bookinfo.sidecars.yaml up -d
         ```
 
 1. Confirm that all docker containers are running:


### PR DESCRIPTION
filenames were wrongly specified and hence copy paste of the command was failing. 
corrected it. 