### PR TITLE
Fixing a broken link on istio.io

### DIFF
--- a/_docs/welcome/feature-stages.md
+++ b/_docs/welcome/feature-stages.md
@@ -6,8 +6,9 @@ order: 10
 
 layout: docs
 type: markdown
-redirect_from: "/docs/reference/release-roadmap.html"
-redirect_from: "/docs/reference/feature-stages.html"
+redirect_from:
+  - "/docs/reference/release-roadmap.html"
+  - "/docs/reference/feature-stages.html"
 draft: true
 ---
 {% include home.html %}

--- a/_docs/welcome/feature-stages.md
+++ b/_docs/welcome/feature-stages.md
@@ -7,6 +7,7 @@ order: 10
 layout: docs
 type: markdown
 redirect_from: "/docs/reference/release-roadmap.html"
+redirect_from: "/docs/reference/feature-stages.html"
 draft: true
 ---
 {% include home.html %}


### PR DESCRIPTION
Adding redirect from https://istio.io/docs/reference/feature-stages.html. 
I understand the content needs to be updated but that's orthogonal to fixing a broken link.