### PR TITLE
Remove unsightly gap on the home page on mobile.

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,6 +89,10 @@ title: Istio
     }
 
     body {
-        padding-top: 5rem;
+        padding-top: 2.8rem;
+
+        @media (min-width: $bp-sm) {
+            padding-top: 5rem;
+        }
     }
 </style>


### PR DESCRIPTION
I made a last minute change to shrink the header height when on mobile,
but I forgot to compensate for that on the home page, which left a white
gap on the screen. Yuck.

Staging site: https://geeknoid.github.io/istio.github.io/