### PR TITLE
SCSS cleanup.

### DIFF
--- a/_sass/base/_constants.scss
+++ b/_sass/base/_constants.scss
@@ -32,7 +32,6 @@ $linkColor: $mainBrandColor;
 $linkHoverColor: lighten($linkColor, 20%);
 $linkDisabledColor: #CCCCCC;
 $textColor: #535f61;
-$titleColor: #555555;
 $dividerBarColor: rgba(0, 0, 0, .1);
 
 // General Colors

--- a/_sass/modules/_header.scss
+++ b/_sass/modules/_header.scss
@@ -35,14 +35,6 @@ header {
             }
         }
 
-        a.nav-link {
-            color: $white;
-
-            &::hover {
-                color: $popBrandColor;
-            }
-        }
-
         a.active {
             border-bottom: solid 3px $white;
             border-radius: 2px;
@@ -70,7 +62,7 @@ header {
         color: white;
 
         &:hover {
-            color: cyan;
+            color: $linkHoverColor;
         }
 
         &:active {


### PR DESCRIPTION
- Delete some unused CSS definitions

- Switch the nav bar link hover color from cyan to the site's overall
$linkHoverColor.

<img width="163" alt="screen shot 2018-01-08 at 10 03 53" src="https://user-images.githubusercontent.com/22780957/34684865-68217338-f45b-11e7-9a18-6d0698cdfe7b.png">