### PR TITLE
Point OPA Adapter documentation at official repo

### DIFF
--- a/_about/feature-stages.md
+++ b/_about/feature-stages.md
@@ -75,7 +75,7 @@ Below is our list of existing features and their current phases. This informatio
 | [Service-to-service mutual TLS](https://istio.io/docs/concepts/security/mutual-tls.html)         | Beta
 | [Incremental Enablement of service-to-service mutual TLS](https://istio.io/docs/tasks/security/per-service-mtls.html)  | Alpha
 | [VM: Service Credential Distribution](https://istio.io/docs/concepts/security/mutual-tls.html)         | Alpha
-| [OPA Checker](https://github.com/mangchiandjjoe/istio/blob/d5390f6e436225949907d77ad3e9747a9bc26722/mixer/adapter/opa/README.md)  - **New to 0.4**      | Alpha
+| [OPA Checker](https://github.com/istio/istio/blob/41a8aa4f75f31bf0c1911d844a18da4cff8ac584/mixer/adapter/opa/README.md)  - **New to 0.4**      | Alpha
 
 
 


### PR DESCRIPTION
The new link should point to the same content but the link is in the official github.com/istio/istio
repository instead of a fork.