### PR TITLE
Improve styling for <code> blocks.

### DIFF
--- a/_sass/base/_common.scss
+++ b/_sass/base/_common.scss
@@ -286,6 +286,12 @@ blockquote {
     background-color: $light-gray;
 }
 
+code {
+    color: #d14;
+    font-size: 75%;
+    word-break: normal;
+}
+
 .spacer {
     height: .1rem;
 


### PR DESCRIPTION
- Made <code> a bit smaller, a bit darker red, and substantially improve word break appearance in
tables.

Staging: https://geeknoid.github.io/istio.github.io/
