### PR TITLE
remove offending asterisk from curl output

### DIFF
--- a/_docs/tasks/security/mutual-tls.md
+++ b/_docs/tasks/security/mutual-tls.md
@@ -96,7 +96,7 @@ There are several steps:
    ```
    ```bash
    ...
-   * error fetching CN from cert:The requested data were not available.
+   error fetching CN from cert:The requested data were not available.
    ...
    < HTTP/1.1 200 OK
    < content-type: text/html; charset=utf-8


### PR DESCRIPTION
the asterisk does not have any meaning
it confuses jekyll, jekyll takes it as a bullet

See the format error: https://istio.io/docs/tasks/security/mutual-tls.html#testing-the-authentication-setup.