### PR TITLE
Update reference docs.

### DIFF
--- a/_docs/reference/api/istio.mixer.v1.html
+++ b/_docs/reference/api/istio.mixer.v1.html
@@ -6,7 +6,6 @@ layout: protoc-gen-docs
 redirect_from: /docs/reference/api/mixer/mixer.html
 number_of_entries: 17
 ---
-{% raw %}
 <p>This package defines the Mixer API that the sidecar proxy uses to perform
 precondition checks, manage quotas, and report telemetry.</p>
 
@@ -69,7 +68,7 @@ in the deployment. The primary attribute producer in Istio is Envoy, although
 specialized Mixer adapters and services can also generate attributes.</p>
 
 <p>The common baseline set of attributes available in most Istio deployments is defined
-<a href="https://istio.io/docs/reference/config/mixer/attribute-vocabulary.html">here</a>.</p>
+<a href="{{site.baseurl}}/docs/reference/config/mixer/attribute-vocabulary.html">here</a>.</p>
 
 <p>Attributes are strongly typed. The supported attribute types are defined by
 <a href="https://github.com/istio/api/blob/master/mixer/v1/config/descriptor/value_type.proto">ValueType</a>.
@@ -848,4 +847,3 @@ message types for APIs to use.</p>
 </tbody>
 </table>
 </section>
-{% endraw %}

--- a/_docs/reference/commands/istioctl.html
+++ b/_docs/reference/commands/istioctl.html
@@ -2,7 +2,7 @@
 title: istioctl
 overview: Istio control interface
 layout: pkg-collateral-docs
-number_of_entries: 13
+number_of_entries: 14
 ---
 <p>
 Istio configuration command line utility.</p>
@@ -948,6 +948,106 @@ istioctl kube-inject -f deployment.yaml -o deployment-injected.yaml
 # Update an existing deployment.
 kubectl get deployment -o yaml | istioctl kube-inject -f - | kubectl apply -f -
 
+</code></pre>
+<h2 id="istioctl proxy-config">istioctl proxy-config</h2>
+<p>
+Retrieves the static/bootstrap proxy configuration for the specified pod when running in Kubernetes.
+Support for other environments to follow.
+</p>
+<pre class="language-bash"><code>istioctl proxy-config &lt;pod-name&gt; [flags]
+</code></pre>
+<table class="command-flags">
+<thead>
+<th>Flags</th>
+<th>Shorthand</th>
+<th>Description</th>
+</thead>
+<tbody>
+<tr>
+<td><code>--istioNamespace &lt;string&gt;</code></td>
+<td><code>-i</code></td>
+<td>Istio system namespace  (default `istio-system`)</td>
+</tr>
+<tr>
+<td><code>--kubeconfig &lt;string&gt;</code></td>
+<td><code>-c</code></td>
+<td>Kubernetes configuration file  (default `$KUBECONFIG else $HOME/.kube/config`)</td>
+</tr>
+<tr>
+<td><code>--log_as_json</code></td>
+<td></td>
+<td>Whether to format output as JSON or in plain console-friendly format </td>
+</tr>
+<tr>
+<td><code>--log_backtrace_at &lt;traceLocation&gt;</code></td>
+<td></td>
+<td>when logging hits line file:N, emit a stack trace  (default `:0`)</td>
+</tr>
+<tr>
+<td><code>--log_callers</code></td>
+<td></td>
+<td>Include caller information, useful for debugging </td>
+</tr>
+<tr>
+<td><code>--log_output_level &lt;string&gt;</code></td>
+<td></td>
+<td>The minimum logging level of messages to output, can be one of &#34;debug&#34;, &#34;info&#34;, &#34;warn&#34;, &#34;error&#34;, or &#34;none&#34;  (default `info`)</td>
+</tr>
+<tr>
+<td><code>--log_rotate &lt;string&gt;</code></td>
+<td></td>
+<td>The path for the optional rotating log file  (default ``)</td>
+</tr>
+<tr>
+<td><code>--log_rotate_max_age &lt;int&gt;</code></td>
+<td></td>
+<td>The maximum age in days of a log file beyond which the file is rotated (0 indicates no limit)  (default `30`)</td>
+</tr>
+<tr>
+<td><code>--log_rotate_max_backups &lt;int&gt;</code></td>
+<td></td>
+<td>The maximum number of log file backups to keep before older files are deleted (0 indicates no limit)  (default `1000`)</td>
+</tr>
+<tr>
+<td><code>--log_rotate_max_size &lt;int&gt;</code></td>
+<td></td>
+<td>The maximum size in megabytes of a log file beyond which the file is rotated  (default `104857600`)</td>
+</tr>
+<tr>
+<td><code>--log_stacktrace_level &lt;string&gt;</code></td>
+<td></td>
+<td>The minimum logging level at which stack traces are captured, can be one of &#34;debug&#34;, &#34;info&#34;, &#34;warn&#34;, &#34;error&#34;, or &#34;none&#34;  (default `none`)</td>
+</tr>
+<tr>
+<td><code>--log_target &lt;stringArray&gt;</code></td>
+<td></td>
+<td>The set of paths where to output the log. This can be any path as well as the special values stdout and stderr  (default `[stdout]`)</td>
+</tr>
+<tr>
+<td><code>--namespace &lt;string&gt;</code></td>
+<td><code>-n</code></td>
+<td>Config namespace  (default ``)</td>
+</tr>
+<tr>
+<td><code>--platform &lt;string&gt;</code></td>
+<td><code>-p</code></td>
+<td>Istio host platform  (default `kube`)</td>
+</tr>
+<tr>
+<td><code>--v &lt;Level&gt;</code></td>
+<td><code>-v</code></td>
+<td>log level for V logs  (default `0`)</td>
+</tr>
+<tr>
+<td><code>--vmodule &lt;moduleSpec&gt;</code></td>
+<td></td>
+<td>comma-separated list of pattern=N settings for file-filtered logging  (default ``)</td>
+</tr>
+</tbody>
+</table>
+<h3 id="istioctl proxy-config Examples">Examples</h3>
+<pre class="language-bash"><code>  # Retrieve config for productpage-v1-bb8d5cbc7-k7qbm pod
+  istioctl proxy-config productpage-v1-bb8d5cbc7-k7qbm
 </code></pre>
 <h2 id="istioctl register">istioctl register</h2>
 <p>Registers a service instance (e.g. VM) joining the mesh</p>

--- a/_docs/reference/commands/pilot-discovery.html
+++ b/_docs/reference/commands/pilot-discovery.html
@@ -121,6 +121,11 @@ number_of_entries: 4
 <td>Cloud Foundry config file  (default ``)</td>
 </tr>
 <tr>
+<td><code>--clusterRegistriesDir &lt;string&gt;</code></td>
+<td></td>
+<td>Directory for a file-based cluster config store  (default ``)</td>
+</tr>
+<tr>
 <td><code>--configDir &lt;string&gt;</code></td>
 <td></td>
 <td>Directory to watch for updates to config yaml files. If specified, the files will be used as the source of config, rather than a CRD client.  (default ``)</td>

--- a/_docs/reference/config/adapters/circonus.html
+++ b/_docs/reference/config/adapters/circonus.html
@@ -5,7 +5,6 @@ location: https://istio.io/docs/reference/config/adapters/circonus.html
 layout: protoc-gen-docs
 number_of_entries: 3
 ---
-{% raw %}
 <p>The <code>circonus</code> adapter enables Istio to deliver metric data to the
 <a href="https://www.circonus.com">Circonus</a> monitoring backend.</p>
 
@@ -110,4 +109,3 @@ number_of_entries: 3
 </tbody>
 </table>
 </section>
-{% endraw %}

--- a/_docs/reference/config/adapters/denier.html
+++ b/_docs/reference/config/adapters/denier.html
@@ -5,7 +5,6 @@ location: https://istio.io/docs/reference/config/adapters/denier.html
 layout: protoc-gen-docs
 number_of_entries: 2
 ---
-{% raw %}
 <p>The <code>denier</code> adapter is designed to always return a denial to precondition
 checks. You can specify the exact error to return for these denials.</p>
 
@@ -147,4 +146,3 @@ message types for APIs to use.</p>
 </tbody>
 </table>
 </section>
-{% endraw %}

--- a/_docs/reference/config/adapters/fluentd.html
+++ b/_docs/reference/config/adapters/fluentd.html
@@ -5,7 +5,6 @@ location: https://istio.io/docs/reference/config/adapters/fluentd.html
 layout: protoc-gen-docs
 number_of_entries: 1
 ---
-{% raw %}
 <p>The <code>fluentd</code> adapter is designed to deliver Istio log entries to a
 listening <a href="https://www.fluentd.org">fluentd</a> daemon.</p>
 
@@ -40,4 +39,3 @@ Default value is localhost:24224</p>
 </tbody>
 </table>
 </section>
-{% endraw %}

--- a/_docs/reference/config/adapters/kubernetesenv.html
+++ b/_docs/reference/config/adapters/kubernetesenv.html
@@ -5,7 +5,6 @@ location: https://istio.io/docs/reference/config/adapters/kubernetesenv.html
 layout: protoc-gen-docs
 number_of_entries: 1
 ---
-{% raw %}
 <p>The <code>kubernetesenv</code> adapter extracts information from a Kubernetes environment
 and produces attribtes that can be used in downstream adapters.</p>
 
@@ -118,4 +117,3 @@ ingress service in requests.</p>
 </tbody>
 </table>
 </section>
-{% endraw %}

--- a/_docs/reference/config/adapters/list.html
+++ b/_docs/reference/config/adapters/list.html
@@ -5,7 +5,6 @@ location: https://istio.io/docs/reference/config/adapters/list.html
 layout: protoc-gen-docs
 number_of_entries: 2
 ---
-{% raw %}
 <p>The <code>list</code> adapter makes it possible to perform simple whitelist or blacklist
 checks. You can configure the adapter with the list to check, or you can point
 it to a URL from where the list should be fetched. Lists can be simple strings,
@@ -136,4 +135,3 @@ before it should ask the adapter again.</p>
 </tbody>
 </table>
 </section>
-{% endraw %}

--- a/_docs/reference/config/adapters/memquota.html
+++ b/_docs/reference/config/adapters/memquota.html
@@ -5,7 +5,6 @@ location: https://istio.io/docs/reference/config/adapters/memquota.html
 layout: protoc-gen-docs
 number_of_entries: 3
 ---
-{% raw %}
 <p>The <code>memquota</code> adapter can be used to support Istio&rsquo;s quota management
 system. Although functional, this adapter is not intended for production
 use and is suited for local testing only. The reason for this limitation
@@ -136,4 +135,3 @@ The first matching override is applied.</p>
 </tbody>
 </table>
 </section>
-{% endraw %}

--- a/_docs/reference/config/adapters/opa.html
+++ b/_docs/reference/config/adapters/opa.html
@@ -5,7 +5,6 @@ location: https://istio.io/docs/reference/config/adapters/opa.html
 layout: protoc-gen-docs
 number_of_entries: 1
 ---
-{% raw %}
 <p>The <code>opa</code> adapter exposes an <a href="http://www.openpolicyagent.org">Open Policy Agent</a> engine
 that provides sophisticated access control mechanisms.</p>
 
@@ -19,8 +18,8 @@ that provides sophisticated access control mechanisms.</p>
   - |+
     package mixerauthz
     policy = [
-      {
-        &quot;rule&quot;: {
+      &lbrace;
+        &quot;rule&quot;: &lbrace;
           &quot;verbs&quot;: [
             &quot;storage.buckets.get&quot;
           ],
@@ -33,7 +32,7 @@ that provides sophisticated access control mechanisms.</p>
 
     default allow = false
 
-    allow = true {
+    allow = true &lbrace;
       rule = policy[_].rule
       input.subject.user = rule.users[_]
       input.action.method = rule.verbs[_]
@@ -81,4 +80,3 @@ instead of disabling the adapter, close the client request</p>
 </tbody>
 </table>
 </section>
-{% endraw %}

--- a/_docs/reference/config/adapters/prometheus.html
+++ b/_docs/reference/config/adapters/prometheus.html
@@ -5,7 +5,6 @@ location: https://istio.io/docs/reference/config/adapters/prometheus.html
 layout: protoc-gen-docs
 number_of_entries: 7
 ---
-{% raw %}
 <p>The <code>prometheus</code> adapter collects Istio metrics and makes them available to
 <a href="https://prometheus.io">Prometheus</a>.</p>
 
@@ -318,4 +317,3 @@ buckets are the underflow and overflow buckets.</p>
 </tbody>
 </table>
 </section>
-{% endraw %}

--- a/_docs/reference/config/adapters/rbac.html
+++ b/_docs/reference/config/adapters/rbac.html
@@ -5,7 +5,6 @@ location: https://istio.io/docs/reference/config/adapters/rbac.html
 layout: protoc-gen-docs
 number_of_entries: 1
 ---
-{% raw %}
 <p>The <code>rbac</code> adapter provides Role-Based Access Control (RBAC) functionality for
 for services within the Istio mesh.</p>
 
@@ -58,4 +57,3 @@ Following are some examples of the config store URL:
 </tbody>
 </table>
 </section>
-{% endraw %}

--- a/_docs/reference/config/adapters/redisquota.html
+++ b/_docs/reference/config/adapters/redisquota.html
@@ -5,7 +5,6 @@ location: https://istio.io/docs/reference/config/adapters/redisquota.html
 layout: protoc-gen-docs
 number_of_entries: 4
 ---
-{% raw %}
 <p>The <code>redisquota</code> adapter can be used to support Istio&rsquo;s quota management
 system. It depends on a Redis server to store quota values.</p>
 
@@ -199,4 +198,3 @@ The first matching override is applied.</p>
 </tbody>
 </table>
 </section>
-{% endraw %}

--- a/_docs/reference/config/adapters/servicecontrol.html
+++ b/_docs/reference/config/adapters/servicecontrol.html
@@ -5,7 +5,6 @@ location: https://istio.io/docs/reference/config/adapters/servicecontrol.html
 layout: protoc-gen-docs
 number_of_entries: 4
 ---
-{% raw %}
 <p>The <code>servicecontrol</code> adapter delivers logs and metrics to
 <a href="https://cloud.google.com/service-control">Google Service Control</a>.</p>
 
@@ -172,4 +171,3 @@ spec:
 </tbody>
 </table>
 </section>
-{% endraw %}

--- a/_docs/reference/config/adapters/solarwinds.html
+++ b/_docs/reference/config/adapters/solarwinds.html
@@ -5,7 +5,6 @@ location: https://istio.io/docs/reference/config/adapters/solarwinds.html
 layout: protoc-gen-docs
 number_of_entries: 3
 ---
-{% raw %}
 <p>The <code>solarwinds</code> adapter enables Istio to deliver log and metric data to the
 <a href="https://www.papertrailapp.com">Papertrail</a> logging backendu and the
 <a href="https://www.appoptics.com">AppOptics</a> monitoring backend.</p>
@@ -68,7 +67,7 @@ spec:
       - destination_version
   logs:
     solarwindslogentry.logentry.istio-system:
-      payloadTemplate: '{{or (.originIp) &quot;-&quot;}} - {{or (.sourceUser) &quot;-&quot;}} [{{or (.timestamp.Format &quot;2006-01-02T15:04:05Z07:00&quot;) &quot;-&quot;}}] &quot;{{or (.method) &quot;-&quot;}} {{or (.url) &quot;-&quot;}} {{or (.protocol) &quot;-&quot;}}&quot; {{or (.responseCode) &quot;-&quot;}} {{or (.responseSize) &quot;-&quot;}}'
+      payloadTemplate: '&lbrace;&lbrace;or (.originIp) &quot;-&quot;}} - &lbrace;&lbrace;or (.sourceUser) &quot;-&quot;}} [&lbrace;&lbrace;or (.timestamp.Format &quot;2006-01-02T15:04:05Z07:00&quot;) &quot;-&quot;}}] &quot;&lbrace;&lbrace;or (.method) &quot;-&quot;}} &lbrace;&lbrace;or (.url) &quot;-&quot;}} &lbrace;&lbrace;or (.protocol) &quot;-&quot;}}&quot; &lbrace;&lbrace;or (.responseCode) &quot;-&quot;}} &lbrace;&lbrace;or (.responseSize) &quot;-&quot;}}'
 </code></pre>
 
 <table class="message-fields">
@@ -157,7 +156,7 @@ of a network failure. Default value is 1 hour.</p>
 found here: https://golang.org/pkg/text/template/) that will be executed to construct the payload for
 this log entry.
 An example template that could be used:
-{{or (.originIp) &ldquo;-&rdquo;}} - {{or (.sourceUser) &ldquo;-&rdquo;}} [{{or (.timestamp.Format &ldquo;2006-01-02T15:04:05Z07:00&rdquo;) &ldquo;-&rdquo;}}] &ldquo;{{or (.method) &ldquo;-&rdquo;}} {{or (.url) &ldquo;-&rdquo;}} {{or (.protocol) &ldquo;-&rdquo;}}&rdquo; {{or (.responseCode) &ldquo;-&rdquo;}} {{or (.responseSize) &ldquo;-&rdquo;}}
+&lbrace;&lbrace;or (.originIp) &ldquo;-&rdquo;}} - &lbrace;&lbrace;or (.sourceUser) &ldquo;-&rdquo;}} [&lbrace;&lbrace;or (.timestamp.Format &ldquo;2006-01-02T15:04:05Z07:00&rdquo;) &ldquo;-&rdquo;}}] &ldquo;&lbrace;&lbrace;or (.method) &ldquo;-&rdquo;}} &lbrace;&lbrace;or (.url) &ldquo;-&rdquo;}} &lbrace;&lbrace;or (.protocol) &ldquo;-&rdquo;}}&rdquo; &lbrace;&lbrace;or (.responseCode) &ldquo;-&rdquo;}} &lbrace;&lbrace;or (.responseSize) &ldquo;-&rdquo;}}
 A sample log that will be created after parsing the template with appropriate variables will look like this:
 Jan 23 21:53:02 istio-mixer-57d88dc4b4-rbgmc istio: 10.32.0.15 - kubernetes://istio-ingress-78545c5bc9-wbr6g.istio-system [2018-01-24T02:53:02Z] &ldquo;GET /productpage http&rdquo; 200 5599
 It will be given the full set of variables for the log to use to construct its result.
@@ -192,4 +191,3 @@ If it is not provided, a default template in place will be used.</p>
 </tbody>
 </table>
 </section>
-{% endraw %}

--- a/_docs/reference/config/adapters/stackdriver.html
+++ b/_docs/reference/config/adapters/stackdriver.html
@@ -5,7 +5,6 @@ location: https://istio.io/docs/reference/config/adapters/stackdriver.html
 layout: protoc-gen-docs
 number_of_entries: 10
 ---
-{% raw %}
 <p>The <code>stackdriver</code> adapter enables Istio to deliver log and metric data to the
 <a href="https://cloud.google.com/stackdriver/">Stackdriver</a> logging and monitoring backend.</p>
 
@@ -539,4 +538,3 @@ This value type can be used only if the metric kind is <code>GAUGE</code>.</p>
 </tbody>
 </table>
 </section>
-{% endraw %}

--- a/_docs/reference/config/adapters/statsd.html
+++ b/_docs/reference/config/adapters/statsd.html
@@ -5,7 +5,6 @@ location: https://istio.io/docs/reference/config/adapters/statsd.html
 layout: protoc-gen-docs
 number_of_entries: 3
 ---
-{% raw %}
 <p>The <code>statsd</code> adapter enables Istio to deliver metric data to a
 <a href="https://github.com/etsy/statsd">StatsD</a> monitoring backend.</p>
 
@@ -102,7 +101,7 @@ same (private) network 1432 bytes is recommended for better performance.</p>
 the statsd metric name. This allows easier creation of statsd metrics like <code>action_name-response_code</code>.
 The template strings must conform to go&rsquo;s text/template syntax. For the example of <code>action_name-response_code</code>,
 we use the template:
-   <code>{{.apiMethod}}-{{.responseCode}}</code></p>
+   <code>&lbrace;&lbrace;.apiMethod}}-&lbrace;&lbrace;.responseCode}}</code></p>
 
 <p>If name_template is the empty string the Istio metric name will be used for statsd metric&rsquo;s name.</p>
 
@@ -146,4 +145,3 @@ we use the template:
 </tbody>
 </table>
 </section>
-{% endraw %}

--- a/_docs/reference/config/adapters/stdio.html
+++ b/_docs/reference/config/adapters/stdio.html
@@ -5,7 +5,6 @@ location: https://istio.io/docs/reference/config/adapters/stdio.html
 layout: protoc-gen-docs
 number_of_entries: 3
 ---
-{% raw %}
 <p>The <code>stdio</code> adapter enables Istio to output logs and metrics to
 the local machine. Logs and metrics can be directed to Mixer&rsquo;s
 standard output stream, standard error stream, or to any locally
@@ -209,4 +208,3 @@ is to retain at most 1000 logs. 0 indicates no limit.</p>
 </tbody>
 </table>
 </section>
-{% endraw %}

--- a/_docs/reference/config/istio.mesh.v1alpha1.html
+++ b/_docs/reference/config/istio.mesh.v1alpha1.html
@@ -6,7 +6,6 @@ layout: protoc-gen-docs
 redirect_from: /docs/reference/config/service-mesh.html
 number_of_entries: 5
 ---
-{% raw %}
 <h2 id="AuthenticationPolicy">AuthenticationPolicy</h2>
 <section>
 <p>AuthenticationPolicy defines authentication policy. It can be set for
@@ -442,4 +441,3 @@ Increase the value of this field if you find that the metrics from Envoys are tr
 </tbody>
 </table>
 </section>
-{% endraw %}

--- a/_docs/reference/config/istio.mixer.v1.config.client.html
+++ b/_docs/reference/config/istio.mixer.v1.config.client.html
@@ -5,7 +5,6 @@ location: https://istio.io/docs/reference/config/istio.mixer.v1.config.client.ht
 layout: protoc-gen-docs
 number_of_entries: 24
 ---
-{% raw %}
 <h2 id="APIKey">APIKey</h2>
 <section>
 <p>APIKey defines the explicit configuration for generating the
@@ -189,6 +188,9 @@ that should be mapped to the specified service(s).</p>
 </section>
 <h2 id="EndUserAuthenticationPolicySpecReference">EndUserAuthenticationPolicySpecReference</h2>
 <section>
+<p>EndUserAuthenticationPolicySpecReference identifies a
+EndUserAuthenticationPolicySpec that is bound to a set of services.</p>
+
 <table class="message-fields">
 <thead>
 <tr>
@@ -258,11 +260,11 @@ spec:
   - attributes:
       api.operation: findPetById
     httpMethod: GET
-    uriTemplate: /api/pets/{id}
+    uriTemplate: /api/pets/&lbrace;id}
   - attributes:
       api.operation: deletePet
     httpMethod: DELETE
-    uriTemplate: /api/pets/{id}
+    uriTemplate: /api/pets/&lbrace;id}
   api_keys:
   - query: api-key
 </code></pre>
@@ -416,9 +418,9 @@ example: GET, HEAD, POST, PUT, DELETE.</p>
 following are valid URI templates:</p>
 
 <pre><code>/pets
-/pets/{id}
-/dictionary/{term:1}/{term}
-/search{?q*,lang}
+/pets/&lbrace;id}
+/dictionary/&lbrace;term:1}/&lbrace;term}
+/search&lbrace;?q*,lang}
 </code></pre>
 
 </td>
@@ -702,6 +704,8 @@ specified.</p>
 <td><code>locations</code></td>
 <td><code><a href="#JWT.Location">JWT.Location[]</a></code></td>
 <td>
+<p>Zero or more locations to search for JWT in an HTTP request.</p>
+
 </td>
 </tr>
 <tr id="JWT.jwks_uri_envoy_cluster">
@@ -893,6 +897,9 @@ conditions defined in the QuotaSpecs should not overlap.</p>
 </section>
 <h2 id="QuotaSpecBinding.QuotaSpecReference">QuotaSpecBinding.QuotaSpecReference</h2>
 <section>
+<p>QuotaSpecReference uniquely identifies the QuotaSpec used in the
+Binding.</p>
+
 <table class="message-fields">
 <thead>
 <tr>
@@ -1187,6 +1194,9 @@ Istio Grafana dashboards to be reconfigured to use the new name.</p>
 </section>
 <h2 id="TransportConfig.NetworkFailPolicy">TransportConfig.NetworkFailPolicy</h2>
 <section>
+<p>NetworkFailPolicy defines behavior when network connection
+failure occurs.</p>
+
 <table class="enum-values">
 <thead>
 <tr>
@@ -1236,7 +1246,7 @@ in the deployment. The primary attribute producer in Istio is Envoy, although
 specialized Mixer adapters and services can also generate attributes.</p>
 
 <p>The common baseline set of attributes available in most Istio deployments is defined
-<a href="https://istio.io/docs/reference/config/mixer/attribute-vocabulary.html">here</a>.</p>
+<a href="{{site.baseurl}}/docs/reference/config/mixer/attribute-vocabulary.html">here</a>.</p>
 
 <p>Attributes are strongly typed. The supported attribute types are defined by
 <a href="https://github.com/istio/api/blob/master/mixer/v1/config/descriptor/value_type.proto">ValueType</a>.
@@ -1269,4 +1279,3 @@ Following places may use this message:
 </tbody>
 </table>
 </section>
-{% endraw %}

--- a/_docs/reference/config/istio.mixer.v1.config.html
+++ b/_docs/reference/config/istio.mixer.v1.config.html
@@ -6,7 +6,6 @@ layout: protoc-gen-docs
 redirect_from: /docs/reference/config/mixer/policy-and-telemetry-rules.html
 number_of_entries: 7
 ---
-{% raw %}
 <h2 id="Action">Action</h2>
 <section>
 <p>Action describes which <a href="#Handler">Handler</a> to invoke and what data to pass to it for processing.</p>
@@ -91,7 +90,7 @@ the proxy (with the canonical name &ldquo;istio-proxy&rdquo;) or the name of an
 We map from attribute name to the attribute&rsquo;s specification. The name of an attribute,
 which is how attributes are referred to in aspect configuration, must conform to:</p>
 
-<pre><code>Name = IDENT { SEPARATOR IDENT };
+<pre><code>Name = IDENT &lbrace; SEPARATOR IDENT };
 </code></pre>
 
 <p>Where <code>IDENT</code> must match the regular expression <code>*a-z*+</code> and <code>SEPARATOR</code> must
@@ -170,7 +169,7 @@ encoding scheme will be decided later.</p>
 </tr>
 <tr id="AttributeManifest.AttributeInfo.value_type">
 <td><code>valueType</code></td>
-<td><code><a href="https://istio.io/docs/reference/config/mixer/istio.mixer.v1.config.descriptor.html#ValueType">istio.mixer.v1.config.descriptor.ValueType</a></code></td>
+<td><code><a href="{{site.baseurl}}/docs/reference/config/mixer/istio.mixer.v1.config.descriptor.html#ValueType">istio.mixer.v1.config.descriptor.ValueType</a></code></td>
 <td>
 <p>Required. The type of data carried by this attribute.</p>
 
@@ -380,4 +379,3 @@ with the proto support for the language.</p>
 </tbody>
 </table>
 </section>
-{% endraw %}

--- a/_docs/reference/config/istio.rbac.v1alpha1.html
+++ b/_docs/reference/config/istio.rbac.v1alpha1.html
@@ -5,7 +5,6 @@ location: https://istio.io/docs/reference/config/istio.rbac.v1alpha1.html
 layout: protoc-gen-docs
 number_of_entries: 6
 ---
-{% raw %}
 <p>Istio RBAC (Role Based Access Control) defines ServiceRole and ServiceRoleBinding
 objects.</p>
 
@@ -332,4 +331,3 @@ In the above ServiceRoleBinding example, the second subject has two properties:
 </tbody>
 </table>
 </section>
-{% endraw %}

--- a/_docs/reference/config/istio.routing.v1alpha1.html
+++ b/_docs/reference/config/istio.routing.v1alpha1.html
@@ -6,7 +6,6 @@ layout: protoc-gen-docs
 redirect_from: /docs/reference/config/traffic-rules/routing-rules.html
 number_of_entries: 28
 ---
-{% raw %}
 <p>Configuration affecting traffic routing. Here are a few terms useful to define
 in the context of routing rules.</p>
 
@@ -1831,4 +1830,3 @@ destnation service.</p>
 </tbody>
 </table>
 </section>
-{% endraw %}

--- a/_docs/reference/config/mixer/istio.mixer.adapter.model.v1beta.html
+++ b/_docs/reference/config/mixer/istio.mixer.adapter.model.v1beta.html
@@ -1,0 +1,193 @@
+---
+title: Mixer Adapter Model
+overview: Definitions used when creating Mixer templates
+location: https://istio.io/docs/reference/config/mixer/istio.mixer.adapter.model.v1beta.html
+layout: protoc-gen-docs
+number_of_entries: 9
+---
+<p>This package defines the types that are used when creating Mixer templates. <code>ValueType</code> defined in this pacakge
+is also used by adapters to know the underlying datatype of the instance fields.</p>
+
+<h2 id="DNSName">DNSName</h2>
+<section>
+<p>DNSName is used inside templates for fields that are of ValueType &ldquo;DNS_NAME&rdquo;</p>
+
+</section>
+<h2 id="Duration">Duration</h2>
+<section>
+<p>Duration is used inside templates for fields that are of ValueType &ldquo;DURATION&rdquo;</p>
+
+</section>
+<h2 id="EmailAddress">EmailAddress</h2>
+<section>
+<p>EmailAddress is used inside templates for fields that are of ValueType &ldquo;EMAIL_ADDRESS&rdquo;
+DO NOT USE !! Under Development</p>
+
+</section>
+<h2 id="IPAddress">IPAddress</h2>
+<section>
+<p>IPAddress is used inside templates for fields that are of ValueType &ldquo;IP_ADDRESS&rdquo;</p>
+
+</section>
+<h2 id="TemplateVariety">TemplateVariety</h2>
+<section>
+<p>The available varieties of templates, controlling the semantics of what an adapter does with each instance.</p>
+
+<table class="enum-values">
+<thead>
+<tr>
+<th>Name</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr id="TemplateVariety.TEMPLATE_VARIETY_CHECK">
+<td><code>TEMPLATE_VARIETY_CHECK</code></td>
+<td>
+<p>Makes the template applicable for Mixer&rsquo;s check calls.</p>
+
+</td>
+</tr>
+<tr id="TemplateVariety.TEMPLATE_VARIETY_REPORT">
+<td><code>TEMPLATE_VARIETY_REPORT</code></td>
+<td>
+<p>Makes the template applicable for Mixer&rsquo;s report calls.</p>
+
+</td>
+</tr>
+<tr id="TemplateVariety.TEMPLATE_VARIETY_QUOTA">
+<td><code>TEMPLATE_VARIETY_QUOTA</code></td>
+<td>
+<p>Makes the template applicable for Mixer&rsquo;s quota calls.</p>
+
+</td>
+</tr>
+<tr id="TemplateVariety.TEMPLATE_VARIETY_ATTRIBUTE_GENERATOR">
+<td><code>TEMPLATE_VARIETY_ATTRIBUTE_GENERATOR</code></td>
+<td>
+<p>Makes the template applicable for Mixer&rsquo;s quota calls.</p>
+
+</td>
+</tr>
+</tbody>
+</table>
+</section>
+<h2 id="TimeStamp">TimeStamp</h2>
+<section>
+<p>TimeStamp is used inside templates for fields that are of ValueType &ldquo;TIMESTAMP&rdquo;</p>
+
+</section>
+<h2 id="Uri">Uri</h2>
+<section>
+<p>Uri is used inside templates for fields that are of ValueType &ldquo;URI&rdquo;
+DO NOT USE ! Under Development</p>
+
+</section>
+<h2 id="Value">Value</h2>
+<section>
+<p>Value is used inside templates for fields that have dynamic types. The actual datatype
+of the field depends on the datatype of the expression used in the operator configuration.</p>
+
+</section>
+<h2 id="ValueType">ValueType</h2>
+<section>
+<p>ValueType describes the types that values in the Istio system can take. These
+are used to describe the type of Attributes at run time, describe the type of
+the result of evaluating an expression, and to describe the runtime type of
+fields of other descriptors.</p>
+
+<table class="enum-values">
+<thead>
+<tr>
+<th>Name</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr id="ValueType.VALUE_TYPE_UNSPECIFIED">
+<td><code>VALUE_TYPE_UNSPECIFIED</code></td>
+<td>
+<p>Invalid, default value.</p>
+
+</td>
+</tr>
+<tr id="ValueType.STRING">
+<td><code>STRING</code></td>
+<td>
+<p>An undiscriminated variable-length string.</p>
+
+</td>
+</tr>
+<tr id="ValueType.INT64">
+<td><code>INT64</code></td>
+<td>
+<p>An undiscriminated 64-bit signed integer.</p>
+
+</td>
+</tr>
+<tr id="ValueType.DOUBLE">
+<td><code>DOUBLE</code></td>
+<td>
+<p>An undiscriminated 64-bit floating-point value.</p>
+
+</td>
+</tr>
+<tr id="ValueType.BOOL">
+<td><code>BOOL</code></td>
+<td>
+<p>An undiscriminated boolean value.</p>
+
+</td>
+</tr>
+<tr id="ValueType.TIMESTAMP">
+<td><code>TIMESTAMP</code></td>
+<td>
+<p>A point in time.</p>
+
+</td>
+</tr>
+<tr id="ValueType.IP_ADDRESS">
+<td><code>IP_ADDRESS</code></td>
+<td>
+<p>An IP address.</p>
+
+</td>
+</tr>
+<tr id="ValueType.EMAIL_ADDRESS">
+<td><code>EMAIL_ADDRESS</code></td>
+<td>
+<p>An email address.</p>
+
+</td>
+</tr>
+<tr id="ValueType.URI">
+<td><code>URI</code></td>
+<td>
+<p>A URI.</p>
+
+</td>
+</tr>
+<tr id="ValueType.DNS_NAME">
+<td><code>DNS_NAME</code></td>
+<td>
+<p>A DNS name.</p>
+
+</td>
+</tr>
+<tr id="ValueType.DURATION">
+<td><code>DURATION</code></td>
+<td>
+<p>A span between two points in time.</p>
+
+</td>
+</tr>
+<tr id="ValueType.STRING_MAP">
+<td><code>STRING_MAP</code></td>
+<td>
+<p>A map string -&gt; string, typically used by headers.</p>
+
+</td>
+</tr>
+</tbody>
+</table>
+</section>

--- a/_docs/reference/config/mixer/istio.mixer.v1.config.descriptor.html
+++ b/_docs/reference/config/mixer/istio.mixer.v1.config.descriptor.html
@@ -5,7 +5,6 @@ location: https://istio.io/docs/reference/config/mixer/istio.mixer.v1.config.des
 layout: protoc-gen-docs
 number_of_entries: 1
 ---
-{% raw %}
 <h2 id="ValueType">ValueType</h2>
 <section>
 <p>ValueType describes the types that values in the Istio system can take. These
@@ -108,4 +107,3 @@ fields of other descriptors.</p>
 </tbody>
 </table>
 </section>
-{% endraw %}

--- a/_docs/reference/config/mixer/istio.mixer.v1.template.html
+++ b/_docs/reference/config/mixer/istio.mixer.v1.template.html
@@ -5,7 +5,6 @@ location: https://istio.io/docs/reference/config/mixer/istio.mixer.v1.template.h
 layout: protoc-gen-docs
 number_of_entries: 8
 ---
-{% raw %}
 <p>This proto describes the types that can be used inside Mixer templates. These message types are used to specify
 field datatype to express the equivalent ValueType for the expressions the field can be mapped to.</p>
 
@@ -82,4 +81,3 @@ DO NOT USE ! Under Development</p>
 of the field depends on the datatype of the expression used in the operator configuration.</p>
 
 </section>
-{% endraw %}

--- a/_docs/reference/config/template/apikey.html
+++ b/_docs/reference/config/template/apikey.html
@@ -5,7 +5,6 @@ location: https://istio.io/docs/reference/config/template/apikey.html
 layout: protoc-gen-docs
 number_of_entries: 1
 ---
-{% raw %}
 <p>The <code>apikey</code> template represents a single API key, which is used for authorization checks.</p>
 
 <h2 id="Template">Template</h2>
@@ -70,7 +69,7 @@ spec:
 </tr>
 <tr id="Template.timestamp">
 <td><code>timestamp</code></td>
-<td><code><a href="https://istio.io/docs/reference/config/mixer/istio.mixer.v1.template.html#TimeStamp">istio.mixer.v1.template.TimeStamp</a></code></td>
+<td><code><a href="{{site.baseurl}}/docs/reference/config/mixer/istio.mixer.v1.template.html#TimeStamp">istio.mixer.v1.template.TimeStamp</a></code></td>
 <td>
 <p>Timestamp of API call.</p>
 
@@ -79,4 +78,3 @@ spec:
 </tbody>
 </table>
 </section>
-{% endraw %}

--- a/_docs/reference/config/template/authorization.html
+++ b/_docs/reference/config/template/authorization.html
@@ -5,7 +5,6 @@ location: https://istio.io/docs/reference/config/template/authorization.html
 layout: protoc-gen-docs
 number_of_entries: 3
 ---
-{% raw %}
 <p>The <code>authorization</code> template defines parameters for performing policy
 enforcement within Istio. It is primarily concerned with enabling Mixer</p>
 
@@ -56,7 +55,7 @@ enforcement within Istio. It is primarily concerned with enabling Mixer</p>
 </tr>
 <tr id="Action.properties">
 <td><code>properties</code></td>
-<td><code>map&lt;string, <a href="https://istio.io/docs/reference/config/mixer/istio.mixer.v1.template.html#Value">istio.mixer.v1.template.Value</a>&gt;</code></td>
+<td><code>map&lt;string, <a href="{{site.baseurl}}/docs/reference/config/mixer/istio.mixer.v1.template.html#Value">istio.mixer.v1.template.Value</a>&gt;</code></td>
 <td>
 <p>Additional data about the action for use in policy.</p>
 
@@ -100,7 +99,7 @@ the template.</p>
 </tr>
 <tr id="Subject.properties">
 <td><code>properties</code></td>
-<td><code>map&lt;string, <a href="https://istio.io/docs/reference/config/mixer/istio.mixer.v1.template.html#Value">istio.mixer.v1.template.Value</a>&gt;</code></td>
+<td><code>map&lt;string, <a href="{{site.baseurl}}/docs/reference/config/mixer/istio.mixer.v1.template.html#Value">istio.mixer.v1.template.Value</a>&gt;</code></td>
 <td>
 <p>Additional attributes about the subject.</p>
 
@@ -170,4 +169,3 @@ the caller identity.</p>
 </tbody>
 </table>
 </section>
-{% endraw %}

--- a/_docs/reference/config/template/checknothing.html
+++ b/_docs/reference/config/template/checknothing.html
@@ -5,7 +5,6 @@ location: https://istio.io/docs/reference/config/template/checknothing.html
 layout: protoc-gen-docs
 number_of_entries: 1
 ---
-{% raw %}
 <p>The <code>checknothing</code> template represents an empty block of data, which can useful
 in different testing scenarios.</p>
 
@@ -26,4 +25,3 @@ spec:
 </code></pre>
 
 </section>
-{% endraw %}

--- a/_docs/reference/config/template/kubernetes.html
+++ b/_docs/reference/config/template/kubernetes.html
@@ -5,7 +5,6 @@ location: https://istio.io/docs/reference/config/template/kubernetes.html
 layout: protoc-gen-docs
 number_of_entries: 2
 ---
-{% raw %}
 <p>The <code>kubernetes</code> template holds data that controls the production of Kubernetes-specific
 attributes.</p>
 
@@ -25,7 +24,7 @@ to assign values to the generated attributes using the <code>$out.&lt;field name
 <tbody>
 <tr id="OutputTemplate.source_pod_ip">
 <td><code>sourcePodIp</code></td>
-<td><code><a href="https://istio.io/docs/reference/config/mixer/istio.mixer.v1.template.html#IPAddress">istio.mixer.v1.template.IPAddress</a></code></td>
+<td><code><a href="{{site.baseurl}}/docs/reference/config/mixer/istio.mixer.v1.template.html#IPAddress">istio.mixer.v1.template.IPAddress</a></code></td>
 <td>
 <p>Refers to source pod ip address. attribute<em>bindings can refer to this field using $out.source</em>pod_ip</p>
 
@@ -73,7 +72,7 @@ to assign values to the generated attributes using the <code>$out.&lt;field name
 </tr>
 <tr id="OutputTemplate.source_host_ip">
 <td><code>sourceHostIp</code></td>
-<td><code><a href="https://istio.io/docs/reference/config/mixer/istio.mixer.v1.template.html#IPAddress">istio.mixer.v1.template.IPAddress</a></code></td>
+<td><code><a href="{{site.baseurl}}/docs/reference/config/mixer/istio.mixer.v1.template.html#IPAddress">istio.mixer.v1.template.IPAddress</a></code></td>
 <td>
 <p>Refers to source pod host ip address. attribute<em>bindings can refer to this field using $out.source</em>host_ip</p>
 
@@ -81,7 +80,7 @@ to assign values to the generated attributes using the <code>$out.&lt;field name
 </tr>
 <tr id="OutputTemplate.destination_pod_ip">
 <td><code>destinationPodIp</code></td>
-<td><code><a href="https://istio.io/docs/reference/config/mixer/istio.mixer.v1.template.html#IPAddress">istio.mixer.v1.template.IPAddress</a></code></td>
+<td><code><a href="{{site.baseurl}}/docs/reference/config/mixer/istio.mixer.v1.template.html#IPAddress">istio.mixer.v1.template.IPAddress</a></code></td>
 <td>
 <p>Refers to destination pod ip address. attribute<em>bindings can refer to this field using $out.destination</em>pod_ip</p>
 
@@ -129,7 +128,7 @@ to assign values to the generated attributes using the <code>$out.&lt;field name
 </tr>
 <tr id="OutputTemplate.destination_host_ip">
 <td><code>destinationHostIp</code></td>
-<td><code><a href="https://istio.io/docs/reference/config/mixer/istio.mixer.v1.template.html#IPAddress">istio.mixer.v1.template.IPAddress</a></code></td>
+<td><code><a href="{{site.baseurl}}/docs/reference/config/mixer/istio.mixer.v1.template.html#IPAddress">istio.mixer.v1.template.IPAddress</a></code></td>
 <td>
 <p>Refers to destination pod host ip address. attribute<em>bindings can refer to this field using $out.destination</em>host_ip</p>
 
@@ -137,7 +136,7 @@ to assign values to the generated attributes using the <code>$out.&lt;field name
 </tr>
 <tr id="OutputTemplate.origin_pod_ip">
 <td><code>originPodIp</code></td>
-<td><code><a href="https://istio.io/docs/reference/config/mixer/istio.mixer.v1.template.html#IPAddress">istio.mixer.v1.template.IPAddress</a></code></td>
+<td><code><a href="{{site.baseurl}}/docs/reference/config/mixer/istio.mixer.v1.template.html#IPAddress">istio.mixer.v1.template.IPAddress</a></code></td>
 <td>
 <p>Refers to origin pod ip address. attribute<em>bindings can refer to this field using $out.origin</em>pod_ip</p>
 
@@ -185,7 +184,7 @@ to assign values to the generated attributes using the <code>$out.&lt;field name
 </tr>
 <tr id="OutputTemplate.origin_host_ip">
 <td><code>originHostIp</code></td>
-<td><code><a href="https://istio.io/docs/reference/config/mixer/istio.mixer.v1.template.html#IPAddress">istio.mixer.v1.template.IPAddress</a></code></td>
+<td><code><a href="{{site.baseurl}}/docs/reference/config/mixer/istio.mixer.v1.template.html#IPAddress">istio.mixer.v1.template.IPAddress</a></code></td>
 <td>
 <p>Refers to origin pod host ip address. attribute<em>bindings can refer to this field using $out.origin</em>host_ip</p>
 
@@ -248,7 +247,7 @@ spec:
 </tr>
 <tr id="Template.source_ip">
 <td><code>sourceIp</code></td>
-<td><code><a href="https://istio.io/docs/reference/config/mixer/istio.mixer.v1.template.html#IPAddress">istio.mixer.v1.template.IPAddress</a></code></td>
+<td><code><a href="{{site.baseurl}}/docs/reference/config/mixer/istio.mixer.v1.template.html#IPAddress">istio.mixer.v1.template.IPAddress</a></code></td>
 <td>
 <p>Source pod&rsquo;s ip.</p>
 
@@ -264,7 +263,7 @@ spec:
 </tr>
 <tr id="Template.destination_ip">
 <td><code>destinationIp</code></td>
-<td><code><a href="https://istio.io/docs/reference/config/mixer/istio.mixer.v1.template.html#IPAddress">istio.mixer.v1.template.IPAddress</a></code></td>
+<td><code><a href="{{site.baseurl}}/docs/reference/config/mixer/istio.mixer.v1.template.html#IPAddress">istio.mixer.v1.template.IPAddress</a></code></td>
 <td>
 <p>Destination pod&rsquo;s ip.</p>
 
@@ -280,7 +279,7 @@ spec:
 </tr>
 <tr id="Template.origin_ip">
 <td><code>originIp</code></td>
-<td><code><a href="https://istio.io/docs/reference/config/mixer/istio.mixer.v1.template.html#IPAddress">istio.mixer.v1.template.IPAddress</a></code></td>
+<td><code><a href="{{site.baseurl}}/docs/reference/config/mixer/istio.mixer.v1.template.html#IPAddress">istio.mixer.v1.template.IPAddress</a></code></td>
 <td>
 <p>Origin pod&rsquo;s ip.</p>
 
@@ -289,4 +288,3 @@ spec:
 </tbody>
 </table>
 </section>
-{% endraw %}

--- a/_docs/reference/config/template/listentry.html
+++ b/_docs/reference/config/template/listentry.html
@@ -5,9 +5,8 @@ location: https://istio.io/docs/reference/config/template/listentry.html
 layout: protoc-gen-docs
 number_of_entries: 1
 ---
-{% raw %}
 <p>The <code>listentry</code> template is designed to let you perform list check operations
-with the <a href="https://istio.io/docs/reference/config/adapters/list.html">list</a> adapter.</p>
+with the <a href="{{site.baseurl}}/docs/reference/config/adapters/list.html">list</a> adapter.</p>
 
 <h2 id="Template">Template</h2>
 <section>
@@ -15,8 +14,8 @@ with the <a href="https://istio.io/docs/reference/config/adapters/list.html">lis
 within a list.</p>
 
 <p>When writing the configuration, the value for the fields associated with this template can either be a
-literal or an <a href="https://istio.io/docs/reference/config/mixer/expression-language.html">expression</a>. Please note that if the datatype of a field is not istio.mixer.v1.template.Value,
-then the expression&rsquo;s <a href="https://istio.io/docs/reference/config/mixer/expression-language.html#type-checking">inferred type</a> must match the datatype of the field.</p>
+literal or an <a href="{{site.baseurl}}/docs/reference/config/mixer/expression-language.html">expression</a>. Please note that if the datatype of a field is not istio.mixer.v1.template.Value,
+then the expression&rsquo;s <a href="{{site.baseurl}}/docs/reference/config/mixer/expression-language.html#type-checking">inferred type</a> must match the datatype of the field.</p>
 
 <p>Example config:</p>
 
@@ -49,4 +48,3 @@ spec:
 </tbody>
 </table>
 </section>
-{% endraw %}

--- a/_docs/reference/config/template/logentry.html
+++ b/_docs/reference/config/template/logentry.html
@@ -5,7 +5,6 @@ location: https://istio.io/docs/reference/config/template/logentry.html
 layout: protoc-gen-docs
 number_of_entries: 1
 ---
-{% raw %}
 <p>The <code>logentry</code> template represents an individual entry within a log.</p>
 
 <h2 id="Template">Template</h2>
@@ -13,8 +12,8 @@ number_of_entries: 1
 <p>The <code>logentry</code> template represents an individual entry within a log.</p>
 
 <p>When writing the configuration, the value for the fields associated with this template can either be a
-literal or an <a href="https://istio.io/docs/reference/config/mixer/expression-language.html">expression</a>. Please note that if the datatype of a field is not istio.mixer.v1.template.Value,
-then the expression&rsquo;s <a href="https://istio.io/docs/reference/config/mixer/expression-language.html#type-checking">inferred type</a> must match the datatype of the field.</p>
+literal or an <a href="{{site.baseurl}}/docs/reference/config/mixer/expression-language.html">expression</a>. Please note that if the datatype of a field is not istio.mixer.v1.template.Value,
+then the expression&rsquo;s <a href="{{site.baseurl}}/docs/reference/config/mixer/expression-language.html#type-checking">inferred type</a> must match the datatype of the field.</p>
 
 <p>Example config:</p>
 
@@ -51,7 +50,7 @@ spec:
 <tbody>
 <tr id="Template.variables">
 <td><code>variables</code></td>
-<td><code>map&lt;string, <a href="https://istio.io/docs/reference/config/mixer/istio.mixer.v1.template.html#Value">istio.mixer.v1.template.Value</a>&gt;</code></td>
+<td><code>map&lt;string, <a href="{{site.baseurl}}/docs/reference/config/mixer/istio.mixer.v1.template.html#Value">istio.mixer.v1.template.Value</a>&gt;</code></td>
 <td>
 <p>Variables that are delivered for each log entry.</p>
 
@@ -59,7 +58,7 @@ spec:
 </tr>
 <tr id="Template.timestamp">
 <td><code>timestamp</code></td>
-<td><code><a href="https://istio.io/docs/reference/config/mixer/istio.mixer.v1.template.html#TimeStamp">istio.mixer.v1.template.TimeStamp</a></code></td>
+<td><code><a href="{{site.baseurl}}/docs/reference/config/mixer/istio.mixer.v1.template.html#TimeStamp">istio.mixer.v1.template.TimeStamp</a></code></td>
 <td>
 <p>Timestamp is the time value for the log entry</p>
 
@@ -85,7 +84,7 @@ Otherwise these fields will be ignored by the adapter.</p>
 </tr>
 <tr id="Template.monitored_resource_dimensions">
 <td><code>monitoredResourceDimensions</code></td>
-<td><code>map&lt;string, <a href="https://istio.io/docs/reference/config/mixer/istio.mixer.v1.template.html#Value">istio.mixer.v1.template.Value</a>&gt;</code></td>
+<td><code>map&lt;string, <a href="{{site.baseurl}}/docs/reference/config/mixer/istio.mixer.v1.template.html#Value">istio.mixer.v1.template.Value</a>&gt;</code></td>
 <td>
 <p>Optional. A set of expressions that will form the dimensions of the monitored resource this log entry is being
 recorded on. If the logging backend supports monitored resources, these fields are used to populate that resource.
@@ -96,4 +95,3 @@ Otherwise these fields will be ignored by the adapter.</p>
 </tbody>
 </table>
 </section>
-{% endraw %}

--- a/_docs/reference/config/template/metric.html
+++ b/_docs/reference/config/template/metric.html
@@ -5,7 +5,6 @@ location: https://istio.io/docs/reference/config/template/metric.html
 layout: protoc-gen-docs
 number_of_entries: 1
 ---
-{% raw %}
 <p>The <code>metric</code> template is designed to let you describe runtime metric to dispatch to
 monitoring backends.</p>
 
@@ -14,8 +13,8 @@ monitoring backends.</p>
 <p>The <code>metric</code> template represents a single piece of data to report.</p>
 
 <p>When writing the configuration, the value for the fields associated with this template can either be a
-literal or an <a href="https://istio.io/docs/reference/config/mixer/expression-language.html">expression</a>. Please note that if the datatype of a field is not istio.mixer.v1.template.Value,
-then the expression&rsquo;s <a href="https://istio.io/docs/reference/config/mixer/expression-language.html#type-checking">inferred type</a> must match the datatype of the field.</p>
+literal or an <a href="{{site.baseurl}}/docs/reference/config/mixer/expression-language.html">expression</a>. Please note that if the datatype of a field is not istio.mixer.v1.template.Value,
+then the expression&rsquo;s <a href="{{site.baseurl}}/docs/reference/config/mixer/expression-language.html#type-checking">inferred type</a> must match the datatype of the field.</p>
 
 <p>Example config:</p>
 
@@ -46,7 +45,7 @@ spec:
 <tbody>
 <tr id="Template.value">
 <td><code>value</code></td>
-<td><code><a href="https://istio.io/docs/reference/config/mixer/istio.mixer.v1.template.html#Value">istio.mixer.v1.template.Value</a></code></td>
+<td><code><a href="{{site.baseurl}}/docs/reference/config/mixer/istio.mixer.v1.template.html#Value">istio.mixer.v1.template.Value</a></code></td>
 <td>
 <p>The value being reported.</p>
 
@@ -54,7 +53,7 @@ spec:
 </tr>
 <tr id="Template.dimensions">
 <td><code>dimensions</code></td>
-<td><code>map&lt;string, <a href="https://istio.io/docs/reference/config/mixer/istio.mixer.v1.template.html#Value">istio.mixer.v1.template.Value</a>&gt;</code></td>
+<td><code>map&lt;string, <a href="{{site.baseurl}}/docs/reference/config/mixer/istio.mixer.v1.template.html#Value">istio.mixer.v1.template.Value</a>&gt;</code></td>
 <td>
 <p>The unique identity of the particular metric to report.</p>
 
@@ -72,7 +71,7 @@ these fields will be ignored by the adapter.</p>
 </tr>
 <tr id="Template.monitored_resource_dimensions">
 <td><code>monitoredResourceDimensions</code></td>
-<td><code>map&lt;string, <a href="https://istio.io/docs/reference/config/mixer/istio.mixer.v1.template.html#Value">istio.mixer.v1.template.Value</a>&gt;</code></td>
+<td><code>map&lt;string, <a href="{{site.baseurl}}/docs/reference/config/mixer/istio.mixer.v1.template.html#Value">istio.mixer.v1.template.Value</a>&gt;</code></td>
 <td>
 <p>Optional. A set of expressions that will form the dimensions of the monitored resource this metric is being reported on.
 If the metric backend supports monitored resources, these fields are used to populate that resource. Otherwise
@@ -83,4 +82,3 @@ these fields will be ignored by the adapter.</p>
 </tbody>
 </table>
 </section>
-{% endraw %}

--- a/_docs/reference/config/template/quota.html
+++ b/_docs/reference/config/template/quota.html
@@ -5,7 +5,6 @@ location: https://istio.io/docs/reference/config/template/quota.html
 layout: protoc-gen-docs
 number_of_entries: 1
 ---
-{% raw %}
 <p>The <code>quota</code> template represents an item for which to check quota.</p>
 
 <h2 id="Template">Template</h2>
@@ -13,8 +12,8 @@ number_of_entries: 1
 <p>The <code>quota</code> template represents a piece of data to check Quota for.</p>
 
 <p>When writing the configuration, the value for the fields associated with this template can either be a
-literal or an <a href="https://istio.io/docs/reference/config/mixer/expression-language.html">expression</a>. Please note that if the datatype of a field is not istio.mixer.v1.template.Value,
-then the expression&rsquo;s <a href="https://istio.io/docs/reference/config/mixer/expression-language.html#type-checking">inferred type</a> must match the datatype of the field.</p>
+literal or an <a href="{{site.baseurl}}/docs/reference/config/mixer/expression-language.html">expression</a>. Please note that if the datatype of a field is not istio.mixer.v1.template.Value,
+then the expression&rsquo;s <a href="{{site.baseurl}}/docs/reference/config/mixer/expression-language.html#type-checking">inferred type</a> must match the datatype of the field.</p>
 
 <p>Example config:</p>
 
@@ -42,7 +41,7 @@ spec:
 <tbody>
 <tr id="Template.dimensions">
 <td><code>dimensions</code></td>
-<td><code>map&lt;string, <a href="https://istio.io/docs/reference/config/mixer/istio.mixer.v1.template.html#Value">istio.mixer.v1.template.Value</a>&gt;</code></td>
+<td><code>map&lt;string, <a href="{{site.baseurl}}/docs/reference/config/mixer/istio.mixer.v1.template.html#Value">istio.mixer.v1.template.Value</a>&gt;</code></td>
 <td>
 <p>The unique identity of the particular quota to manipulate.</p>
 
@@ -51,4 +50,3 @@ spec:
 </tbody>
 </table>
 </section>
-{% endraw %}

--- a/_docs/reference/config/template/reportnothing.html
+++ b/_docs/reference/config/template/reportnothing.html
@@ -5,7 +5,6 @@ location: https://istio.io/docs/reference/config/template/reportnothing.html
 layout: protoc-gen-docs
 number_of_entries: 1
 ---
-{% raw %}
 <p>The <code>reportnothing</code> template represents an empty block of data, which can useful
 in different testing scenarios.</p>
 
@@ -26,4 +25,3 @@ spec:
 </code></pre>
 
 </section>
-{% endraw %}

--- a/_docs/reference/config/template/servicecontrolreport.html
+++ b/_docs/reference/config/template/servicecontrolreport.html
@@ -5,13 +5,8 @@ location: https://istio.io/docs/reference/config/template/servicecontrolreport.h
 layout: protoc-gen-docs
 number_of_entries: 1
 ---
-{% include home.html %}
-
-<p>The <code>servicecontrolreport</code> template is used by the <a href="{{home}}/docs/reference/config/adapters/servicecontrol.html">Google
-    Service
-    Control</a>
+<p>The <code>servicecontrolreport</code> template is used by the <a href="{{site.baseurl}}/docs/reference/config/adapters/servicecontrol.html">Google Service Control</a>
 adapter.</p>
-{% raw %}
 
 <h2 id="Template">Template</h2>
 <section>
@@ -83,7 +78,7 @@ spec:
 </tr>
 <tr id="Template.request_time">
 <td><code>requestTime</code></td>
-<td><code><a href="https://istio.io/docs/reference/config/mixer/istio.mixer.v1.template.html#TimeStamp">istio.mixer.v1.template.TimeStamp</a></code></td>
+<td><code><a href="{{site.baseurl}}/docs/reference/config/mixer/istio.mixer.v1.template.html#TimeStamp">istio.mixer.v1.template.TimeStamp</a></code></td>
 <td>
 </td>
 </tr>
@@ -107,7 +102,7 @@ spec:
 </tr>
 <tr id="Template.response_time">
 <td><code>responseTime</code></td>
-<td><code><a href="https://istio.io/docs/reference/config/mixer/istio.mixer.v1.template.html#TimeStamp">istio.mixer.v1.template.TimeStamp</a></code></td>
+<td><code><a href="{{site.baseurl}}/docs/reference/config/mixer/istio.mixer.v1.template.html#TimeStamp">istio.mixer.v1.template.TimeStamp</a></code></td>
 <td>
 </td>
 </tr>
@@ -125,11 +120,10 @@ spec:
 </tr>
 <tr id="Template.response_latency">
 <td><code>responseLatency</code></td>
-<td><code><a href="https://istio.io/docs/reference/config/mixer/istio.mixer.v1.template.html#Duration">istio.mixer.v1.template.Duration</a></code></td>
+<td><code><a href="{{site.baseurl}}/docs/reference/config/mixer/istio.mixer.v1.template.html#Duration">istio.mixer.v1.template.Duration</a></code></td>
 <td>
 </td>
 </tr>
 </tbody>
 </table>
 </section>
-{% endraw %}

--- a/_docs/setup/kubernetes/quick-start.md
+++ b/_docs/setup/kubernetes/quick-start.md
@@ -124,7 +124,8 @@ kubectl apply -f install/kubernetes/istio-auth.yaml
   Both options create the `istio-system` namespace along with the required RBAC permissions,
   and deploy Istio-Pilot, Istio-Mixer, Istio-Ingress, and Istio-CA (Certificate Authority).
 
-1. *Optional:* If your cluster has Kubernetes version 1.9 or greater, and you wish to enable automatic proxy injection, install the sidecar injector webhook using the instructions at ({{home}}/docs/setup/kubernetes/sidecar-injection.html#automatic-sidecar-injection).
+1. *Optional:* If your cluster has Kubernetes version 1.9 or greater, and you wish to enable automatic proxy injection,
+install the [sidecar injector webhook]({{home}}/docs/setup/kubernetes/sidecar-injection.html#automatic-sidecar-injection).
 
 ## Verifying the installation
 

--- a/scripts/grab_reference_docs.sh
+++ b/scripts/grab_reference_docs.sh
@@ -36,7 +36,7 @@ locate_file() {
     FNP=${LOCATION:31}
     FN=$(echo $FNP | rev | cut -d'/' -f1 | rev)
     PP=$(echo $FNP | rev | cut -d'/' -f2- | rev)
-    cp ${FILENAME} _docs/${PP}/${FN}
+    sed -e 's/href="https:\/\/istio.io/href="{{site.baseurl}}/g' ${FILENAME} >_docs/${PP}/${FN}
 }
 
 # Given the path and name to an Istio command, builds the command and then


### PR DESCRIPTION
- We now replace instances of https://istio.io with {{site.baseurl}} in imported
reference docs such that the generated site will work properly for staging and for
archive.istio.io