### PR TITLE
Release 0.2

### DIFF
--- a/_docs/index.md
+++ b/_docs/index.md
@@ -37,5 +37,3 @@ We're always looking for help improving our documentation, so please don't hesit
 [file an issue](https://github.com/istio/istio.github.io/issues/new) if you see some problem.
 Or better yet, submit your own [contributions]({{home}}/docs/reference/contribute/editing.html) to help
 make our docs better.
-
-Follow this link for the archive of [v0.1 documentation](https://istio.io/v-0.1/docs/).

--- a/_docs/setup/kubernetes/quick-start.md
+++ b/_docs/setup/kubernetes/quick-start.md
@@ -19,7 +19,7 @@ The following instructions require you have access to a Kubernetes **1.7.3 or ne
 with [RBAC (Role-Based Access Control)](https://kubernetes.io/docs/admin/authorization/rbac/) enabled. You will also need `kubectl` **1.7.3 or newer** installed.  If you wish to enable [automatic injection of sidecar]({{home}}/docs/setup/kubernetes/sidecar-injection.html#automatic-sidecar-injection), you need to turn on Kubernetes alpha features in your cluster.
 
   > Note: If you installed Istio 0.1.x,
-  > [uninstall](https://istio.io/v-0.1/docs/tasks/installing-istio.html#uninstalling)
+  > [uninstall](https://archive.istio.io/v0.1/docs/tasks/installing-istio.html#uninstalling)
   > it completely before installing the newer version (including the Istio sidecar
   > for all Istio enabled application pods).
 


### PR DESCRIPTION
Fix uses of https://istio.io so the site works in the archive.