### PR TITLE
A few improvements

### DIFF
--- a/_docs/reference/config/mixer/attribute-vocabulary.md
+++ b/_docs/reference/config/mixer/attribute-vocabulary.md
@@ -16,8 +16,6 @@ A given Istio deployment has a fixed vocabulary of attributes that it understand
 determined by the set of attribute producers being used in the deployment. The primary attribute producer in Istio
 is Envoy, although Mixer and services can also introduce attributes.
 
-## Standard Istio attribute vocabulary
-
 The table below shows the set of canonical attributes and their respective types. Most Istio
 deployments will have agents (Envoy or Mixer adapters) that produce these attributes.
 

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -41,7 +41,7 @@
                     <a class="nav-link {% if current[1] == 'community.html' %}active{% endif %}" href="{{home}}/community">Community</a>
                 </li>
 
-                <li class="nav-item dropdown" id="gearDropdown">
+                <li class="nav-item dropdown" id="gearDropdown" style="white-space: nowrap">
                     <a href="" class="nav-link dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                         <i class='fa fa-lg fa-cog'></i>
                     </a>

--- a/_includes/toc.html
+++ b/_includes/toc.html
@@ -72,4 +72,7 @@
         {% capture my_toc %}{: #{{ include.id }}}
 {{ my_toc | lstrip }}{% endcapture %}
     {% endif %}
-{% endcapture %}{% assign tocWorkspace = '' %}{{ my_toc | markdownify | strip }}
+{% endcapture %}
+{% assign tocWorkspace = '' %}
+{% assign toc = my_toc | markdownify | strip %}
+{% assign emptyTOC = firstHeader %}

--- a/_layouts/about.html
+++ b/_layouts/about.html
@@ -7,7 +7,17 @@ layout: default
             {% include sidebar.html docs=site.about singlecard=true %}
         </div>
 
-        {% if page.toc != false %}
+        {% assign needTOC = true %}
+        {% if page.toc == false %}
+            {% assign needTOC = false %}
+        {% else %}
+            {% include toc.html html=content sanitize=true h_min=2 h_max=4 %}
+            {% if emptyTOC %}
+                {% assign needTOC = false %}
+            {% endif %}
+        {% endif %}
+
+        {% if needTOC %}
             <div class="col-12 col-md-9 col-lg-7 col-xl-8">
         {% else %}
             <div class="col-12 col-md-9 col-xl-10">
@@ -24,12 +34,12 @@ layout: default
             </main>
         </div>
 
-        {% if page.toc != false %}
+        {% if needTOC %}
             <div class="col-12 col-md-2 d-none d-lg-block">
                 <nav class="toc">
                     <div class="spacer"></div>
                     <div class="directory" role="directory">
-                        {% include toc.html html=content sanitize=true h_min=2 h_max=4 %}
+                        {{ toc }}
                     </div>
                 </nav>
             </div>

--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -9,7 +9,17 @@ layout: default
             {% include sidebar.html docs=site.blog bloghack=true %}
         </div>
 
-        {% if page.toc != false %}
+        {% assign needTOC = true %}
+        {% if page.toc == false %}
+            {% assign needTOC = false %}
+        {% else %}
+            {% include toc.html html=content sanitize=true h_min=2 h_max=4 %}
+            {% if emptyTOC %}
+                {% assign needTOC = false %}
+            {% endif %}
+        {% endif %}
+
+        {% if needTOC %}
             <div class="col-12 col-md-9 col-lg-7 col-xl-8">
         {% else %}
             <div class="col-12 col-md-9 col-xl-10">
@@ -40,12 +50,12 @@ layout: default
             </main>
         </div>
 
-        {% if page.toc != false %}
+        {% if needTOC %}
             <div class="col-12 col-md-2 d-none d-lg-block">
                 <nav class="toc">
                     <div class="spacer"></div>
                     <div class="directory" role="directory">
-                        {% include toc.html html=content sanitize=true h_min=2 h_max=4 %}
+                        {{ toc }}
                     </div>
                 </nav>
             </div>

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -7,7 +7,17 @@ layout: default
             {% include sidebar.html docs=site.docs %}
         </div>
 
-        {% if page.toc != false and page.number_of_entries != 1 %}
+        {% assign needTOC = true %}
+        {% if page.toc == false %}
+            {% assign needTOC = false %}
+        {% else %}
+            {% include toc.html html=content sanitize=true h_min=2 h_max=4 %}
+            {% if emptyTOC %}
+                {% assign needTOC = false %}
+            {% endif %}
+        {% endif %}
+
+        {% if needTOC %}
             <div class="col-12 col-md-9 col-lg-7 col-xl-8">
         {% else %}
             <div class="col-12 col-md-9 col-xl-10">
@@ -24,12 +34,12 @@ layout: default
             </main>
         </div>
 
-        {% if page.toc != false and page.number_of_entries != 1 %}
+        {% if needTOC %}
             <div class="col-12 col-md-2 d-none d-lg-block">
                 <nav class="toc">
                     <div class="spacer"></div>
                     <div class="directory" role="directory">
-                        {% include toc.html html=content sanitize=true h_min=2 h_max=4 %}
+                        {{ toc }}
                     </div>
                 </nav>
             </div>

--- a/_layouts/help.html
+++ b/_layouts/help.html
@@ -7,7 +7,17 @@ layout: default
             {% include sidebar.html docs=site.help singlecard=true %}
         </div>
 
-        {% if page.toc != false %}
+        {% assign needTOC = true %}
+        {% if page.toc == false %}
+            {% assign needTOC = false %}
+        {% else %}
+            {% include toc.html html=content sanitize=true h_min=2 h_max=4 %}
+            {% if emptyTOC %}
+                {% assign needTOC = false %}
+            {% endif %}
+        {% endif %}
+
+        {% if needTOC %}
             <div class="col-12 col-md-9 col-lg-6 col-xl-7">
         {% else %}
             <div class="col-12 col-md-9 col-xl-10">
@@ -24,12 +34,12 @@ layout: default
             </main>
         </div>
 
-        {% if page.toc != false %}
+        {% if needTOC %}
             <div class="col-12 col-md-3 d-none d-lg-block">
                 <nav class="toc">
                     <div class="spacer"></div>
                     <div class="directory" role="directory">
-                        {% include toc.html html=content sanitize=true h_min=2 h_max=4 %}
+                        {{ toc }}
                     </div>
                 </nav>
             </div>


### PR DESCRIPTION
- We now automatically detect when a TOC has no entries in it and omit the spacing on the right side
for the TOC. This improves the formatting of a few pages on the site.

- Make an another attempt at preventing the dropdown arrow from wrapping under the cog on smaller screens.
This new solution seems to work across several browsers I've tried.

- Remove an extraneous header in one page.

Staging: https://geeknoid.github.io/istio.github.io/