### PR TITLE
Fix misnamed link

### DIFF
--- a/_docs/concepts/policy-and-control/mixer.md
+++ b/_docs/concepts/policy-and-control/mixer.md
@@ -88,7 +88,7 @@ operator is responsible for:
 
 - Configuring a set of *handlers* for Mixer-generated data. Handlers are
   configured adapters (adapters being binary plugins as described
-  [below](#adapters)). Providing a `statsd` adapter with the IP address for a
+  [here](#adapters)). Providing a `statsd` adapter with the IP address for a
   statsd backend is an example of handler configuration.
 
 - Configuring a set of *instances* for Mixer to generate based on attributes and


### PR DESCRIPTION
Link is named "below" but adapters section is above it.