### PR TITLE
Introduce support for building the site in "preliminary" mode.

### DIFF
--- a/_data/istio.yml
+++ b/_data/istio.yml
@@ -1,4 +1,5 @@
-version: 0.6 (preliminary)
+version: 0.6
+preliminary: false
 archive: false
 archive_date: DD-MMM-YYYY
 search_engine_id: "013699703217164175118:veyyqmfmpj4"

--- a/_docs/setup/kubernetes/quick-start.md
+++ b/_docs/setup/kubernetes/quick-start.md
@@ -91,9 +91,9 @@ curl -L https://git.io/getLatestIstio | sh -
     * The `istioctl` client binary in the `bin/` directory. `istioctl` is used when manually injecting Envoy as a sidecar proxy and for creating routing rules and policies.
     * The `istio.VERSION` configuration file
 
-1. Change directory to istio package. For example, if the package is istio-{{ site.data.istio.version }}
+1. Change directory to istio package. For example, if the package is istio-{{site.data.istio.version}}
 ```bash
-cd istio-{{ site.data.istio.version }}
+cd istio-{{site.data.istio.version}}
 ```
 
 1. Add the `istioctl` client to your PATH.
@@ -191,7 +191,7 @@ kubectl create -f <(istioctl kube-inject -f <your-app-spec>.yaml)
 kubectl delete -f install/kubernetes/istio-sidecar-injector-with-ca-bundle.yaml
 ```
 
-* Uninstall Istio core components. For the {{ site.data.istio.version }} release, the uninstall
+* Uninstall Istio core components. For the {{site.data.istio.version}} release, the uninstall
    deletes the RBAC permissions, the `istio-system` namespace, and hierarchically all resources under it.
    It is safe to ignore errors for non-existent resources because they may have been deleted hierarchically.
 

--- a/_faq/general/what-deployment-environment.md
+++ b/_faq/general/what-deployment-environment.md
@@ -6,6 +6,6 @@ type: markdown
 {% include home.html %}
 
 Istio is designed and built to be platform-independent. For our 
-{{ site.data.istio.version }} release, Istio supports environments running
+{{site.data.istio.version}} release, Istio supports environments running
 container orchestration platforms such as Kubernetes (v1.7.4 or greater)
 and Nomad (with Consul).

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -45,7 +45,13 @@
             <div class="row">
                 <div class="col-12">
                     <p class="description text-center" role="contentinfo">
-                        Istio {{site.data.istio.version}}, Copyright &copy; 2018 Istio Authors<br>
+                        Istio
+                        {% if site.data.istio.archive %}
+                            Archive
+                        {% elsif site.data.istio.preliminary %}
+                            Preliminary
+                        {% endif %}
+                        {{site.data.istio.version}}, Copyright &copy; 2018 Istio Authors<br>
                         {% if site.data.istio.archive %}
                             Archived on {{site.data.istio.archive_date}}
                         {% else %}

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -14,8 +14,10 @@
             <img class="logo" src="{{home}}/img/istio-logo.svg" alt="Istio Logo"/>
             {% if site.data.istio.archive %}
                 <span class="brand-name">Istioldie {{site.data.istio.version}}</span>
+            {% elsif site.data.istio.preliminary %}
+                <span class="brand-name">Istio Prelim {{site.data.istio.version}}</span>
             {% else %}
-                <span class="brand-name">Istio</span>
+                <span class="brand-name">Istio {{site.data.istio.version}}</span>
             {% endif %}
         </a>
 

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -32,6 +32,12 @@ layout: compress
             {% else %}
                 <title>Istioldie {{site.data.istio.version}} / {{ page.title }}</title>
             {% endif %}
+        {% elsif site.data.istio.preliminary %}
+            {% if page.title == 'Istio' %}
+                <title>Istio Prelim {{site.data.istio.version}}</title>
+            {% else %}
+                <title>Istio Prelim {{site.data.istio.version}} / {{ page.title }}</title>
+            {% endif %}
         {% else %}
             {% if page.title == 'Istio' %}
                 <title>Istio</title>

--- a/_sass/base/_brand_colors_preliminary.scss
+++ b/_sass/base/_brand_colors_preliminary.scss
@@ -1,0 +1,4 @@
+$mainBrandColor: #466BB0;
+$secondBrandColor: #68AAF7;
+$textBrandColor: #FFFFFF;
+$textBrandColorLight: #CCCCCC;

--- a/css/dark_theme.scss
+++ b/css/dark_theme.scss
@@ -3,6 +3,8 @@
 
 {% if site.data.istio.archive %}
 @import "base/brand_colors_archive";
+{% elsif site.data.istio.preliminary %}
+@import "base/brand_colors_preliminary";
 {% else %}
 @import "base/brand_colors_normal";
 {% endif %}

--- a/css/light_theme.scss
+++ b/css/light_theme.scss
@@ -3,6 +3,8 @@
 
 {% if site.data.istio.archive %}
 @import "base/brand_colors_archive";
+{% elsif site.data.istio.preliminary %}
+@import "base/brand_colors_preliminary";
 {% else %}
 @import "base/brand_colors_normal";
 {% endif %}

--- a/index.html
+++ b/index.html
@@ -8,6 +8,8 @@ title: Istio
     <div class="container">
         {% if site.data.istio.archive %}
             <h1 class="hero-label">Istio Archive {{site.data.istio.version}}</h1>
+        {% elsif site.data.istio.preliminary %}
+            <h1 class="hero-label">Istio Preliminary {{site.data.istio.version}}</h1>
         {% else %}
             <h1 class="hero-label">Istio</h1>
         {% endif %}


### PR DESCRIPTION
This makes it so we can build the site in normal mode, archive mode, and preliminary mode. These modes change the content of the header, footer, page title, and landing page content, along with the site coloring.

Preliminary mode is turned off in this PR but as soon as we've got a few DNS items taken care and the 0.6 release notes are done, we'll then flip the master branch of istio.github.io to be built with preliminary=true and this will be exposed as https://preliminary.istio.io. 