### PR TITLE
Make the rake test ensure that we use {{home}} consistently.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 _site
+_rakesite
 _static_site
 .bundle
 config_override.yml

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,9 @@
 require 'html-proofer'
 
 task :test do
-  sh "bundle exec jekyll build --incremental"
+  sh "rm -fr _rakesite"
+  sh "mkdir _rakesite"
+  sh "bundle exec jekyll build --config _config.yml,_rake_config_override.yml"
   typhoeus_configuration = {
   :timeout => 30,
 #  :verbose => true
@@ -17,5 +19,5 @@ task :test do
               :url_ignore => [/localhost|github\.com\/istio\/istio\.github\.io\/edit\/master\//],
               :typhoeus => typhoeus_configuration,
              }
-  HTMLProofer.check_directory("./_site", options).run
+  HTMLProofer.check_directory("./_rakesite", options).run
 end

--- a/_about/notes/0.3.md
+++ b/_about/notes/0.3.md
@@ -8,6 +8,8 @@ type: markdown
 redirect_from: /docs/welcome/notes/0.3.html
 ---
 
+{% include home.html %}
+
 ## General
 
 Starting with 0.3, Istio is switching to a monthly release cadence. We hope this will help accelerate our ability

--- a/_blog/2017/0.1-canary.md
+++ b/_blog/2017/0.1-canary.md
@@ -12,6 +12,8 @@ type: markdown
 redirect_from: "/blog/canary-deployments-using-istio.html"
 ---
 
+{% include home.html %}
+
 One of the benefits of the [Istio]({{home}}) project is that it provides the control needed to deploy canary services. The idea behind canary deployment (or rollout) is to introduce a new version of a service by first testing it using a small percentage of user traffic, and then if all goes well, increase, possibly gradually in increments, the percentage while simultaneously phasing out the old version. If anything goes wrong along the way, we abort and rollback to the previous version. In its simplest form, the traffic sent to the canary version is a randomly selected percentage of requests, but in more sophisticated schemes it can be based on the region, user, or other properties of the request.
 
 Depending on your level of expertise in this area, you may wonder why Istio's support for canary deployment is even needed, given that platforms like Kubernetes already provide a way to do [version rollout](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#updating-a-deployment) and [canary deployment](https://kubernetes.io/docs/concepts/cluster-administration/manage-deployment/#canary-deployments). Problem solved, right? Well, not exactly. Although doing a rollout this way works in simple cases, it’s very limited, especially in large scale cloud environments receiving lots of (and especially varying amounts of) traffic, where autoscaling is needed.

--- a/_docs/concepts/policy-and-control/mixer.md
+++ b/_docs/concepts/policy-and-control/mixer.md
@@ -8,6 +8,8 @@ layout: docs
 type: markdown
 ---
 
+{% include home.html %}
+
 The page explains Mixer's role and general architecture.
 
 ## Background

--- a/_docs/concepts/security/mutual-tls.md
+++ b/_docs/concepts/security/mutual-tls.md
@@ -7,6 +7,8 @@ layout: docs
 type: markdown
 ---
 
+{% include home.html %}
+
 ## Overview
 
 Istio Auth's aim is to enhance the security of microservices and their communication without requiring service code changes. It is responsible for:

--- a/_docs/concepts/traffic-management/overview.md
+++ b/_docs/concepts/traffic-management/overview.md
@@ -8,6 +8,8 @@ layout: docs
 type: markdown
 ---
 
+{% include home.html %}
+
 This page provides an overview of how traffic management works
 in Istio, including the benefits of its traffic management
 principles. It assumes that you've already read [What Is Istio?]({{home}}/docs/concepts/what-is-istio/overview.html)

--- a/_docs/concepts/traffic-management/request-routing.md
+++ b/_docs/concepts/traffic-management/request-routing.md
@@ -7,6 +7,7 @@ order: 20
 layout: docs
 type: markdown
 ---
+{% include home.html %}
 
 This page describes how requests are routed between services in an Istio service mesh.
 

--- a/_docs/concepts/what-is-istio/overview.md
+++ b/_docs/concepts/what-is-istio/overview.md
@@ -7,6 +7,7 @@ order: 15
 layout: docs
 type: markdown
 ---
+{% include home.html %}
 
 This document introduces Istio: an open platform to connect, manage, and secure microservices. Istio provides an easy way to create a network of deployed services with load balancing, service-to-service authentication, monitoring, and more, without requiring any changes in service code. You add Istio support to services by deploying a special sidecar proxy throughout your environment that intercepts all network communication between microservices, configured and managed using Istio's control plane functionality.
 

--- a/_docs/index.md
+++ b/_docs/index.md
@@ -19,8 +19,8 @@ is where you can learn about what Istio does and how it does it.
   the Istio control plane in various environments, as well as instructions
   for installing the sidecar in the application deployment. Quick start
   instructions are available for
-  [Kubernetes]({{docs}}/docs/setup/kubernetes/quick-start.html) and 
-  [Docker Compose w/ Consul]({{docs}}/docs/setup/consul/quick-start.html).
+  [Kubernetes]({{home}}/docs/setup/kubernetes/quick-start.html) and
+  [Docker Compose w/ Consul]({{home}}/docs/setup/consul/quick-start.html).
 
 - [Tasks]({{home}}/docs/tasks/). Tasks show you how to do a single directed activity with Istio.
 

--- a/_docs/reference/config/mixer/expression-language.md
+++ b/_docs/reference/config/mixer/expression-language.md
@@ -8,6 +8,8 @@ layout: docs
 type: markdown
 ---
 
+{% include home.html %}
+
 {% capture mixerConfig %}{{home}}/docs/concepts/policy-and-control/mixer-config.html{% endcapture %}
 
 This page describes how to use the Mixer config expression language (CEXL).

--- a/_docs/tasks/traffic-management/circuit-breaking.md
+++ b/_docs/tasks/traffic-management/circuit-breaking.md
@@ -7,6 +7,7 @@ order: 50
 layout: docs
 type: markdown
 ---
+{% include home.html %}
 
 This task demonstrates the circuit-breaking capability for resilient applications. Circuit breaking allows developers to write applications that limit the impact of failures, latency spikes, and other undesirable effects of network peculiarities. This task will show how to configure circuit breaking for connections, requests, and outlier detection.
 

--- a/_docs/tasks/traffic-management/ingress.md
+++ b/_docs/tasks/traffic-management/ingress.md
@@ -7,13 +7,14 @@ order: 30
 layout: docs
 type: markdown
 ---
+{% include home.html %}
 
 This task describes how to configure Istio to expose a service outside of the service mesh cluster.
 In a Kubernetes environment, the [Kubernetes Ingress Resource](https://kubernetes.io/docs/concepts/services-networking/ingress/)
 allows users to specify services that should be exposed outside the
 cluster. It allows one to define a backend service per virtual host and path.
 
-Once the Istio Ingress specification is defined, the traffic entering the cluster is directed through the `istio-ingress` service. As a result, Istio features, for example, monitoring and route rules, can be applied to the traffic entering the cluster.
+Once the Istio Ingress specification is defined, traffic entering the cluster is directed through the `istio-ingress` service. As a result, Istio features, for example, monitoring and route rules, can be applied to the traffic entering the cluster.
 
 The Istio Ingress specification is based on the standard [Kubernetes Ingress Resource](https://kubernetes.io/docs/concepts/services-networking/ingress/) specification, with the following differences:
 

--- a/_docs/tasks/traffic-management/mirroring.md
+++ b/_docs/tasks/traffic-management/mirroring.md
@@ -1,14 +1,16 @@
 ---
 title: Mirroring
-overview: This task demonstrates the traffic shadowing/mirroring capabilities of Istio
+overview: Demonstrates Istio's traffic shadowing/mirroring capabilities
 
 order: 60
 
 layout: docs
 type: markdown
 ---
+{% include home.html %}
 
-This task demonstrates the traffic shadowing/mirroring capabilites of Istio. Traffic mirroring is a powerful concept that allows feature teams to bring changes to production with as little risk as possible. Mirroring brings a copy of live traffic to a mirrored service and happens out of band of the critical request path for the primary service.
+This task demonstrates Istio's traffic shadowing/mirroring capabilities. Traffic mirroring is a powerful concept that allows feature teams to bring
+changes to production with as little risk as possible. Mirroring brings a copy of live traffic to a mirrored service and happens out of band of the critical request path for the primary service.
 
 
 ## Before you begin

--- a/_rake_config_override.yml
+++ b/_rake_config_override.yml
@@ -1,0 +1,2 @@
+destination: _rakesite/test
+baseurl: /test


### PR DESCRIPTION
We now generate the test site into a subdirectory such that we can ensure all
links are correctly using {{home}}, which makes the site work correctly once
archived.

Fixed a bunch of broken cases.