### PR TITLE
Update document to use --debug option when deploy BookInfo app

### DIFF
--- a/_docs/guides/bookinfo.md
+++ b/_docs/guides/bookinfo.md
@@ -85,7 +85,7 @@ To start the application, follow the instructions below corresponding to your Is
    use the following command instead:
 
    ```bash
-   kubectl apply -f <(istioctl kube-inject -f samples/bookinfo/kube/bookinfo.yaml)
+   kubectl apply -f <(istioctl kube-inject --debug -f samples/bookinfo/kube/bookinfo.yaml)
    ```
 
    If you are using a cluster with


### PR DESCRIPTION
This is required for mutual TLS verification, where we asks user to login into envoy container and `curl`. program curl is only installed in docker.io/istio/proxy_debug:.*.

See https://github.com/istio/istio/issues/3399 for background.