### PR TITLE
Add a bunch of redirects for old pages

### DIFF
--- a/_about/notes/index.md
+++ b/_about/notes/index.md
@@ -10,6 +10,7 @@ redirect_from:
   - "/docs/reference/release-notes.html"
   - "/release-notes"
   - "/docs/welcome/notes/index.html"
+  - "/docs/references/notes"
 toc: false  
 ---
 

--- a/_blog/2017/mixer-spof-myth.md
+++ b/_blog/2017/mixer-spof-myth.md
@@ -9,7 +9,7 @@ order: 94
 
 layout: blog
 type: markdown
-
+redirect_from: /blog/posts/2017/mixer-spof-myth.html
 ---
 {% include home.html %}
 

--- a/_docs/concepts/traffic-management/pilot.md
+++ b/_docs/concepts/traffic-management/pilot.md
@@ -7,6 +7,7 @@ order: 10
 layout: docs
 type: markdown
 toc: false
+redirect_from: /docs/concepts/traffic-management/manager.html
 ---
 {% include home.html %}
 

--- a/_docs/tasks/policy-enforcement/rate-limiting.md
+++ b/_docs/tasks/policy-enforcement/rate-limiting.md
@@ -6,6 +6,7 @@ order: 10
 
 layout: docs
 type: markdown
+redirect_from: /docs/tasks/rate-limiting.html
 ---
 {% include home.html %}
 

--- a/_docs/tasks/security/index.md
+++ b/_docs/tasks/security/index.md
@@ -7,6 +7,7 @@ order: 40
 layout: docs
 type: markdown
 toc: false
+redirect_from: /docs/tasks/istio-auth.html
 ---
 
 {% include section-index.html docs=site.docs %}

--- a/_docs/tasks/telemetry/distributed-tracing.md
+++ b/_docs/tasks/telemetry/distributed-tracing.md
@@ -6,6 +6,7 @@ order: 10
 
 layout: docs
 type: markdown
+redirect_from: /docs/tasks/zipkin-tracing.html
 ---
 {% include home.html %}
 

--- a/_docs/tasks/traffic-management/egress.md
+++ b/_docs/tasks/traffic-management/egress.md
@@ -6,6 +6,7 @@ order: 40
 
 layout: docs
 type: markdown
+redirect_from: /docs/tasks/egress.html
 ---
 {% include home.html %}
 

--- a/_docs/tasks/traffic-management/ingress.md
+++ b/_docs/tasks/traffic-management/ingress.md
@@ -6,6 +6,7 @@ order: 30
 
 layout: docs
 type: markdown
+redirect_from: /docs/tasks/ingress.html
 ---
 {% include home.html %}
 

--- a/_docs/tasks/traffic-management/request-routing.md
+++ b/_docs/tasks/traffic-management/request-routing.md
@@ -6,6 +6,7 @@ order: 10
 
 layout: docs
 type: markdown
+redirect_from: /docs/tasks/request-routing.html
 ---
 {% include home.html %}
 

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -49,29 +49,34 @@
                     </a>
 
                     <ul class="dropdown-menu" aria-labelledby="gearDropdown">
+                        {% assign future_release = true %}
                         {% for rel in site.data.releases %}
 
-                            {% assign target = "" %}
-                            {% if current[1] == 'about' %}
-                                {% assign target = "about" %}
-                            {% elsif current[1] == 'blog' %}
-                                {% assign target = "blog" %}
-                            {% elsif current[1] == 'community.html' %}
-                                {% assign target = "community" %}
-                            {% elsif current[1] == 'help' %}
-                                {% assign target = "help" %}
-                            {% elsif current[1] == 'docs' %}
-                                {% assign target = "docs" %}
-                                {% if current[2] == 'reference' %}
-                                    {% assign target = "docs/reference" %}
-                                {% elsif current[2] == 'guides' %}
-                                    {% assign target = "docs/guides" %}
-                                {% elsif current[2] == 'tasks' %}
-                                    {% assign target = "docs/tasks" %}
-                                {% elsif current[2] == 'concepts' %}
-                                    {% assign target = "docs/concepts" %}
-                                {% elsif current[2] == 'setup' %}
-                                    {% assign target = "docs/setup" %}
+                            {% if future_release %}
+                                {% assign target = page.url | remove_first: "/" %}
+                            {% else %}
+                                {% assign target = "" %}
+                                {% if current[1] == 'about' %}
+                                    {% assign target = "about" %}
+                                {% elsif current[1] == 'blog' %}
+                                    {% assign target = "blog" %}
+                                {% elsif current[1] == 'community.html' %}
+                                    {% assign target = "community" %}
+                                {% elsif current[1] == 'help' %}
+                                    {% assign target = "help" %}
+                                {% elsif current[1] == 'docs' %}
+                                    {% assign target = "docs" %}
+                                    {% if current[2] == 'reference' %}
+                                        {% assign target = "docs/reference" %}
+                                    {% elsif current[2] == 'guides' %}
+                                        {% assign target = "docs/guides" %}
+                                    {% elsif current[2] == 'tasks' %}
+                                        {% assign target = "docs/tasks" %}
+                                    {% elsif current[2] == 'concepts' %}
+                                        {% assign target = "docs/concepts" %}
+                                    {% elsif current[2] == 'setup' %}
+                                        {% assign target = "docs/setup" %}
+                                    {% endif %}
                                 {% endif %}
                             {% endif %}
 
@@ -93,11 +98,12 @@
                             <li>
                                 {% if site.data.istio.version == rel.name %}
                                     <i class='fa fa-check'></i>
+                                    {{rel.name}}
+                                    {% assign future_release = false %}
                                 {% else %}
                                     <i style="visibility: hidden;" class='fa fa-check'></i>
+                                    <a href="{{rel.url}}/{{target}}">{{rel.name}}</a>
                                 {% endif %}
-
-                                <a href="{{rel.url}}/{{target}}">{{rel.name}}</a>
                             </li>
                         {% endfor %}
 


### PR DESCRIPTION
The Google Crawl Engine reported a bunch of broken links pointing into istio.io.
This adds redirects so that these links work.

Add a hack such that the gear menu logic that lets you time travel through versions
of the site will insist that if a page existed in a given version, it must also exist
in subsequent versions. This will ensure we always create redirects when we move site
content, and thus avoid breaking links into the site. If a page is moved or removed,
this will lead to rake test errors when checking the content of archive.istio.io.