### PR TITLE
Fix broken links due to missing .html in URLs.

### DIFF
--- a/_about/feature-stages.md
+++ b/_about/feature-stages.md
@@ -103,4 +103,4 @@ Below is our list of existing features and their current phases. This informatio
 
 
 > <img src="{{home}}/img/bulb.svg" alt="Bulb" title="Help" style="width: 32px; display:inline" />
-Please get in touch by joining our [community]({{home}}/community) if there are features you'd like to see in our future releases!
+Please get in touch by joining our [community]({{home}}/community.html) if there are features you'd like to see in our future releases!

--- a/_help/faq/index.md
+++ b/_help/faq/index.md
@@ -39,7 +39,7 @@ You've got questions? We've got answers!
                             {% if cat == qcat %}
                                 {% assign name = q.path | downcase | split: '/' | last | remove: ".md" %}
 
-                                <a href="{{qcat}}#{{name}}">{{q.title}}</a><br/>
+                                <a href="{{qcat}}.html#{{name}}">{{q.title}}</a><br/>
                             {% endif %}
                         {% endfor %}
                     </div>

--- a/_help/index.md
+++ b/_help/index.md
@@ -11,5 +11,5 @@ toc: false
 
 {% include section-index.html docs=site.help %}
 
-And don't forget our vibrant [community]({{home}}/community) that's always ready to lend a hand
+And don't forget our vibrant [community]({{home}}/community.html) that's always ready to lend a hand
 with thorny problems.


### PR DESCRIPTION
Links in https://istio.io/help/faq/ page are broken due to missing ".html" in the URL.
Also 2 links to page community.html are missing ".html".