### PR TITLE
Make non-manifest based installers have similar titles and overviews

### DIFF
--- a/_docs/setup/kubernetes/ansible-install.md
+++ b/_docs/setup/kubernetes/ansible-install.md
@@ -1,6 +1,6 @@
 ---
 title: Installing with Ansible
-overview: Instructions on using the included Ansible playbook to perform installation.
+overview: Instructions for using the included Ansible playbook to perform installation.
 
 order: 40
 

--- a/_docs/setup/kubernetes/ansible-install.md
+++ b/_docs/setup/kubernetes/ansible-install.md
@@ -1,6 +1,6 @@
 ---
-title: Installing with Ansible
-overview: Instructions for using the included Ansible playbook to perform installation.
+title: Installion with Ansible
+overview: Install Itio with the included Ansible playbook.
 
 order: 40
 

--- a/_docs/setup/kubernetes/ansible-install.md
+++ b/_docs/setup/kubernetes/ansible-install.md
@@ -1,5 +1,5 @@
 ---
-title: Installion with Ansible
+title: Installation with Ansible
 overview: Install Itio with the included Ansible playbook.
 
 order: 40

--- a/_docs/setup/kubernetes/helm-install.md
+++ b/_docs/setup/kubernetes/helm-install.md
@@ -1,5 +1,5 @@
 ---
-title: Installion with Helm
+title: Installation with Helm
 overview: Install Istio with the included Helm chart.
 
 order: 30

--- a/_docs/setup/kubernetes/helm-install.md
+++ b/_docs/setup/kubernetes/helm-install.md
@@ -1,8 +1,10 @@
 ---
-title: Installing with Helm
-overview: Instructions for using the included Helm chart to perform installation.
+title: Installion with Helm
+overview: Install Istio with the included Helm chart.
 
 order: 30
+
+redirect_from: /docs/setup/kubernetes/helm.html
 
 layout: docs
 type: markdown

--- a/_docs/setup/kubernetes/helm-install.md
+++ b/_docs/setup/kubernetes/helm-install.md
@@ -1,6 +1,6 @@
 ---
-title: Istio Helm Chart Instructions
-overview: Instructions for the setup and configuration of Istio using the Helm package manager.
+title: Installing with Helm
+overview: Instructions for using the included Helm chart to perform installation.
 
 order: 30
 
@@ -10,7 +10,7 @@ type: markdown
 
 {% include home.html %}
 
-Quick Start instructions for the setup and configuration of Istio using the Helm package manager.
+Quick start instructions for the setup and configuration of Istio using the Helm package manager.
 
 <span style="color:red">**Warning: Helm charts are currently broken in 0.5.0**</span>
 

--- a/_docs/setup/kubernetes/quick-start.md
+++ b/_docs/setup/kubernetes/quick-start.md
@@ -183,7 +183,7 @@ export PATH=$PWD/bin:$PATH
 ```
 
 1. Install Istio's core components. Choose one of the two _**mutually exclusive**_ options below or alternately install
-   with the [Helm Chart]({{home}}/docs/setup/kubernetes/helm.html):
+   with the [Helm Chart]({{home}}/docs/setup/kubernetes/helm-install.html):
 
     a) Install Istio without enabling [mutual TLS authentication]({{home}}/docs/concepts/security/mutual-tls.html) between sidecars.
          Choose this option for clusters with existing applications, applications where services with an


### PR DESCRIPTION
Only deltas should be the base installation technology in the title and overview section of the documentation.  (looks better)