### PR TITLE
Update ratelimit docs to include QuotaSpec and QuotaSpecBinding

### DIFF
--- a/_docs/tasks/policy-enforcement/rate-limiting.md
+++ b/_docs/tasks/policy-enforcement/rate-limiting.md
@@ -44,10 +44,11 @@ Using Istio we can ensure that `1qps` is not breached.
    indicating that the `ratings` service is being called by the "v3" version of the `reviews` service.
 
 1. Configure `memquota`, `quota`, `rule`, `QuotaSpec`, `QuotaSpecBinding` to enable rate limiting.
-
    ```command
    $ istioctl create -f samples/bookinfo/kube/mixer-rule-ratings-ratelimit.yaml
    ```
+   The file looks like this:
+   {% include file-content.html url='https://raw.githubusercontent.com/istio/istio/master/samples/bookinfo/kube/mixer-rule-ratings-ratelimit.yaml %}
 
 1. Confirm the `memquota` was created:
 
@@ -102,7 +103,7 @@ Using Istio we can ensure that `1qps` is not breached.
         sourceVersion: source.labels["version"] | "unknown"
     ```
 
-  The `quota` template defines 4 `dimensions` that are used by `memquota` to set overrides on request that match certain attributes. Destination will be set to the requests destinations app label attribute if it exists. If not it will be the destinations service attribute if it exists. If not it will be set to "unknown". More info on expressions can be found [here]({{home}}/docs/reference/config/mixer/expression-language.html)
+  The `quota` template defines 4 `dimensions` that are used by `memquota` to set overrides on request that match certain attributes. `destination` will be set to the first non-empty value in `destination.labels["app"]`, `destination.service`, or `"unknown"`. More info on expressions can be found [here]({{home}}/docs/reference/config/mixer/expression-language.html)
 
 1. Confirm the `rule` was created:
     ```command

--- a/_docs/tasks/policy-enforcement/rate-limiting.md
+++ b/_docs/tasks/policy-enforcement/rate-limiting.md
@@ -35,17 +35,25 @@ Istio enables users to rate limit traffic to a service.
 Consider `ratings` as an external paid service like Rotten Tomatoes® with `1qps` free quota.
 Using Istio we can ensure that `1qps` is not breached.
 
-1.  Point your browser at the Bookinfo `productpage` (http://$GATEWAY_URL/productpage).
+1. Point your browser at the Bookinfo `productpage` (http://$GATEWAY_URL/productpage).
 
-    If you log in as user "jason", you should see black ratings stars with each review,
-    indicating that the `ratings` service is being called by the "v2" version of the `reviews` service.
+   If you log in as user "jason", you should see black ratings stars with each review,
+   indicating that the `ratings` service is being called by the "v2" version of the `reviews` service.
 
-    If you log in as any other user (or logout) you should see red ratings stars with each review,
-    indicating that the `ratings` service is being called by the "v3" version of the `reviews` service.
+   If you log in as any other user (or logout) you should see red ratings stars with each review,
+   indicating that the `ratings` service is being called by the "v3" version of the `reviews` service.
 
-1.  Configure a `memquota` adapter with rate limits.
+1. Configure `memquota`, `quota`, `rule`, `QuotaSpec`, `QuotaSpecBinding` to enable rate limiting.
 
-    Save the following YAML snippet as `ratelimit-handler.yaml`.
+   ```bash
+   istioctl create -f samples/bookinfo/kube/mixer-rule-ratings-ratelimit.yaml
+   ```
+
+1. Confirm the `memquota` was created:
+
+    ```bash
+    kubectl -n istio-system get memquota handler -o yaml
+    ```
 
     ```yaml
     apiVersion: config.istio.io/v1alpha2
@@ -53,39 +61,31 @@ Using Istio we can ensure that `1qps` is not breached.
     metadata:
       name: handler
       namespace: istio-system
+      ...
     spec:
       quotas:
       - name: requestcount.quota.istio-system
-        # default rate limit is 5000qps
         maxAmount: 5000
         validDuration: 1s
-        # The first matching override is applied.
-        # A requestcount instance is checked against override dimensions.
         overrides:
-        # The following override applies to traffic from 'rewiews' version v2,
-        # destined for the ratings service. The destinationVersion dimension is ignored.
         - dimensions:
             destination: ratings
             source: reviews
-            sourceVersion: v2
+            sourceVersion: v3
           maxAmount: 1
-          validDuration: 1s
+          validDuration: 5s
+        - dimensions:
+            destination: ratings
+          maxAmount: 5
+          validDuration: 10s
     ```
 
-    and then run the following command:
+    The `memquota` defines 3 different rate limit schemes. The default, if no overrides match, is `5000` requests per `1s`. Two overrides are also defined. The first is `1` request every `5s` if the `destination` is `ratings`, the source is `reviews`, and the sourceVersion is `v3`. The second is `5` request every `10s` if the `destination` is `ratings`. The first matching override is picked (reading from top to bottom).
 
-    ```command
-    $ istioctl create -f ratelimit-handler.yaml
+1. Confirm the `quota` was created:
+    ```bash
+    kubectl -n istio-system get quotas requestcount -o yaml
     ```
-
-    This configuration specifies a default 5000 qps rate limit. Traffic reaching the ratings service via
-    reviews-v2 is subject to a 1qps rate limit. In our example user "jason" is routed via reviews-v2 and is therefore subject
-    to the 1qps rate limit.
-
-1.  Configure rate limit instance and rule
-
-    Create a quota instance named `requestcount` that maps incoming attributes to quota dimensions,
-    and create a rule that uses it with the memquota handler.
 
     ```yaml
     apiVersion: config.istio.io/v1alpha2
@@ -93,18 +93,29 @@ Using Istio we can ensure that `1qps` is not breached.
     metadata:
       name: requestcount
       namespace: istio-system
+      ...
     spec:
       dimensions:
-        source: source.labels["app"] | source.service | "unknown"
-        sourceVersion: source.labels["version"] | "unknown"
         destination: destination.labels["app"] | destination.service | "unknown"
         destinationVersion: destination.labels["version"] | "unknown"
-    ---
+        source: source.labels["app"] | source.service | "unknown"
+        sourceVersion: source.labels["version"] | "unknown"
+    ```
+
+  The `quota` template defines 4 `dimensions` that are used by `memquota` to set overrides on request that match certain attributes. Destination will be set to the requests destinations app label attribute if it exists. If not it will be the destinations service attribute if it exists. If not it will be set to "unknown". More info on expressions can be found [here]({{home}}/docs/reference/config/mixer/expression-language.html)
+
+1. Confirm the `rule` was created:
+    ```bash
+    kubectl -n istio-system get rules quota -o yaml
+    ```
+
+    ```yaml
     apiVersion: config.istio.io/v1alpha2
     kind: rule
     metadata:
       name: quota
       namespace: istio-system
+      ...
     spec:
       actions:
       - handler: handler.memquota
@@ -112,24 +123,64 @@ Using Istio we can ensure that `1qps` is not breached.
         - requestcount.quota
     ```
 
-    Save the configuration as `ratelimit-rule.yaml` and run the following command:
+    The `rule` tells mixer to invoke `handler.memquota` handler (created above) and pass it the object constructed using the instance `requestcount.quota` (also created above). This effectively maps the dimensions from the `quota` template to `memquota` handler.
 
-    ```command
-    $ istioctl create -f ratelimit-rule.yaml
+1. Confirm the `QuotaSpec` was created:
+    ```bash
+    kubectl -n istio-system get QuotaSpec request-count -o yaml
     ```
 
-1.  Generate load on the `productpage` with the following command:
-
-    ```command
-    $ while true; do curl -s -o /dev/null http://$GATEWAY_URL/productpage; done
+    ```yaml
+    apiVersion: config.istio.io/v1alpha2
+    kind: QuotaSpec
+    metadata:
+      name: request-count
+      namespace: istio-system
+      ...
+    spec:
+      rules:
+      - quotas:
+        - charge: "1"
+          quota: requestcount
     ```
 
-1.  Refresh the `productpage` in your browser.
+    This `QuotaSpec` defines the requestcount `quota` we created above with a charge of `1`
 
-    If you log in as user "jason" while the load generator is running (i.e., generating more than 1 req/s),
-    the traffic generated by your browser will be rate limited to 1qps.
-    The reviews-v2 service is unable to access the ratings service and you stop seeing stars.
-    For all other users the default 5000qps rate limit will apply and you will continue seeing red stars.
+1. Confirm the `QuotaSpecBinding` was created:
+    ```bash
+    kubectl -n istio-system get QuotaSpecBinding request-count -o yaml
+    ```
+
+    ```yaml
+    kind: QuotaSpecBinding
+    metadata:
+      name: request-count
+      namespace: istio-system
+      ...
+    spec:
+      quotaSpecs:
+      - name: request-count
+        namespace: istio-system
+      services:
+      - name: ratings
+        namespace: default
+      - name: reviews
+        namespace: default
+      - name: details
+        namespace: default
+      - name: productpage
+        namespace: default
+    ```
+
+    This `QuotaSpecBinding` binds the `QuotaSpec` we created above to the services we want to apply it to. Note we have to define the namespace for each service since it is not in the same namespace this `QuotaSpecBinding` resource was deployed into.
+
+1. Refresh the `productpage` in your browser.
+
+   If you are logged out, reviews-v3 service is rate limited to 1 request every 5 seconds. If you keep refreshing the page the stars should only load around once every 5 seconds.
+
+   If you log in as user "jason", reviews-v2 service is rate limited to 5 requests every 10 seconds. If you keep refreshing the page the stars should only load 5 times every 10 seconds.
+
+   For all other services the default 5000qps rate limit will apply.
 
 ## Conditional rate limits
 
@@ -169,7 +220,7 @@ The `memquota` adapter uses a sliding window of sub second resolution to enforce
 
 The `maxAmount` in the adapter configuration sets the default limit for all counters associated with a quota instance.
 This default limit applies if a quota override does not match the request. Memquota selects the first override that matches a request.
-An override need not specify all quota dimensions. In the ratelimit-handler.yaml example, the `1qps` override is
+An override need not specify all quota dimensions. In the mixer-rule-ratings-ratelimit.yaml example, the `0.2qps` override is
 selected by matching only three out of four quota dimensions.
 
 If you would like the above policies enforced for a given namespace instead of the entire Istio mesh, you can replace all occurrences of istio-system with the given namespace.
@@ -178,10 +229,9 @@ If you would like the above policies enforced for a given namespace instead of t
 
 *   Remove the rate limit configuration:
 
-    ```command
-    $ istioctl delete -f ratelimit-handler.yaml
-    $ istioctl delete -f ratelimit-rule.yaml
-    ```
+  ```bash
+  istioctl delete -f samples/bookinfo/kube/mixer-rule-ratings-ratelimit.yaml
+  ```
 
 *   Remove the application routing rules:
 

--- a/_docs/tasks/policy-enforcement/rate-limiting.md
+++ b/_docs/tasks/policy-enforcement/rate-limiting.md
@@ -17,13 +17,13 @@ This task shows you how to use Istio to dynamically limit the traffic to a servi
 
 * Deploy the [Bookinfo]({{home}}/docs/guides/bookinfo.html) sample application.
 
-*   Initialize the application version routing to direct `reviews` service requests from
-    test user "jason" to version v2 and requests from any other user to v3.
+* Initialize the application version routing to direct `reviews` service requests from
+  test user "jason" to version v2 and requests from any other user to v3.
 
-    ```command
-    $ istioctl create -f samples/bookinfo/kube/route-rule-reviews-test-v2.yaml
-    $ istioctl create -f samples/bookinfo/kube/route-rule-reviews-v3.yaml
-    ```
+  ```command
+  $ istioctl create -f samples/bookinfo/kube/route-rule-reviews-test-v2.yaml
+  $ istioctl create -f samples/bookinfo/kube/route-rule-reviews-v3.yaml
+  ```
 
 > If you have conflicting rule that you set in previous tasks,
 use `istioctl replace` instead of `istioctl create`.
@@ -45,14 +45,14 @@ Using Istio we can ensure that `1qps` is not breached.
 
 1. Configure `memquota`, `quota`, `rule`, `QuotaSpec`, `QuotaSpecBinding` to enable rate limiting.
 
-   ```bash
-   istioctl create -f samples/bookinfo/kube/mixer-rule-ratings-ratelimit.yaml
+   ```command
+   $ istioctl create -f samples/bookinfo/kube/mixer-rule-ratings-ratelimit.yaml
    ```
 
 1. Confirm the `memquota` was created:
 
-    ```bash
-    kubectl -n istio-system get memquota handler -o yaml
+    ```command
+    $ kubectl -n istio-system get memquota handler -o yaml
     ```
 
     ```yaml
@@ -83,8 +83,8 @@ Using Istio we can ensure that `1qps` is not breached.
     The `memquota` defines 3 different rate limit schemes. The default, if no overrides match, is `5000` requests per `1s`. Two overrides are also defined. The first is `1` request every `5s` if the `destination` is `ratings`, the source is `reviews`, and the sourceVersion is `v3`. The second is `5` request every `10s` if the `destination` is `ratings`. The first matching override is picked (reading from top to bottom).
 
 1. Confirm the `quota` was created:
-    ```bash
-    kubectl -n istio-system get quotas requestcount -o yaml
+    ```command
+    $ kubectl -n istio-system get quotas requestcount -o yaml
     ```
 
     ```yaml
@@ -105,8 +105,8 @@ Using Istio we can ensure that `1qps` is not breached.
   The `quota` template defines 4 `dimensions` that are used by `memquota` to set overrides on request that match certain attributes. Destination will be set to the requests destinations app label attribute if it exists. If not it will be the destinations service attribute if it exists. If not it will be set to "unknown". More info on expressions can be found [here]({{home}}/docs/reference/config/mixer/expression-language.html)
 
 1. Confirm the `rule` was created:
-    ```bash
-    kubectl -n istio-system get rules quota -o yaml
+    ```command
+    $ kubectl -n istio-system get rules quota -o yaml
     ```
 
     ```yaml
@@ -126,8 +126,8 @@ Using Istio we can ensure that `1qps` is not breached.
     The `rule` tells mixer to invoke `handler.memquota` handler (created above) and pass it the object constructed using the instance `requestcount.quota` (also created above). This effectively maps the dimensions from the `quota` template to `memquota` handler.
 
 1. Confirm the `QuotaSpec` was created:
-    ```bash
-    kubectl -n istio-system get QuotaSpec request-count -o yaml
+    ```command
+    $ kubectl -n istio-system get QuotaSpec request-count -o yaml
     ```
 
     ```yaml
@@ -147,8 +147,8 @@ Using Istio we can ensure that `1qps` is not breached.
     This `QuotaSpec` defines the requestcount `quota` we created above with a charge of `1`
 
 1. Confirm the `QuotaSpecBinding` was created:
-    ```bash
-    kubectl -n istio-system get QuotaSpecBinding request-count -o yaml
+    ```command
+    $ kubectl -n istio-system get QuotaSpecBinding request-count -o yaml
     ```
 
     ```yaml
@@ -227,18 +227,18 @@ If you would like the above policies enforced for a given namespace instead of t
 
 ## Cleanup
 
-*   Remove the rate limit configuration:
+* Remove the rate limit configuration:
 
-  ```bash
-  istioctl delete -f samples/bookinfo/kube/mixer-rule-ratings-ratelimit.yaml
+  ```command
+  $ istioctl delete -f samples/bookinfo/kube/mixer-rule-ratings-ratelimit.yaml
   ```
 
-*   Remove the application routing rules:
+* Remove the application routing rules:
 
-    ```command
-    $ istioctl delete -f samples/bookinfo/kube/route-rule-reviews-test-v2.yaml
-    $ istioctl delete -f samples/bookinfo/kube/route-rule-reviews-v3.yaml
-    ```
+  ```command
+  $ istioctl delete -f samples/bookinfo/kube/route-rule-reviews-test-v2.yaml
+  $ istioctl delete -f samples/bookinfo/kube/route-rule-reviews-v3.yaml
+  ```
 
 * If you are not planning to explore any follow-on tasks, refer to the
   [Bookinfo cleanup]({{home}}/docs/guides/bookinfo.html#cleanup) instructions

--- a/_docs/tasks/policy-enforcement/rate-limiting.md
+++ b/_docs/tasks/policy-enforcement/rate-limiting.md
@@ -48,7 +48,7 @@ Using Istio we can ensure that `1qps` is not breached.
    $ istioctl create -f samples/bookinfo/kube/mixer-rule-ratings-ratelimit.yaml
    ```
    The file looks like this:
-   {% include file-content.html url='https://raw.githubusercontent.com/istio/istio/master/samples/bookinfo/kube/mixer-rule-ratings-ratelimit.yaml %}
+   {% include file-content.html url='https://raw.githubusercontent.com/istio/istio/master/samples/bookinfo/kube/mixer-rule-ratings-ratelimit.yaml' %}
 
 1. Confirm the `memquota` was created:
 


### PR DESCRIPTION
I updated the rate-limiting documentation to use `samples/bookinfo/kube/mixer-rule-ratings-ratelimit.yaml` for the example because the current doc does not work because it is missing `QuotaSpec` and `QuotaSpecBinding`. 

I also added a bit more detail about all the things that `mixer-rule-ratings-ratelimit.yaml` creates.

Addresses: https://github.com/istio/issues/issues/257 
Code Change: https://github.com/istio/istio/pull/4576