### PR TITLE
0.2.12 typo fix + doc link should be to docs/ directly + ...

### DIFF
--- a/_about/notes/index.md
+++ b/_about/notes/index.md
@@ -16,20 +16,20 @@ toc: false
 
 {% include section-index.html docs=site.about %}
 
-The [latest Istio monthly release](https://github.com/istio/istio/releases) is {{site.data.istio.version}} which
-you can download with(*):
+- The [latest Istio monthly release](https://github.com/istio/istio/releases) is {{site.data.istio.version}} which
+  you can download with(*):
 
-```
-curl -L https://git.io/getLatestIstio | sh -
-```
+  ```
+  curl -L https://git.io/getLatestIstio | sh -
+  ```
 
-The most recent stable release is [0.2.12](https://github.com/istio/istio/releases/tag/0.2.12) which you
-can download with:
+- The most recent stable release is [0.2.12](https://github.com/istio/istio/releases/tag/0.2.12) which you
+  can download with:
 
-```
-curl -L https://git.io/getIstio | sh -
-```
+  ```
+  curl -L https://git.io/getIstio | sh -
+  ```
 
-[Archived documentation for for 0.2.12 release](https://archive.istio.io/v0.2/docs/).
+  [Archived documentation for the 0.2.12 release](https://archive.istio.io/v0.2/docs/).
 
 > (*) Note: As we don't control the git.io domain, please examine the output of the curl command before piping it to a shell if running in any sensitive or non sandboxed environment.

--- a/_about/notes/index.md
+++ b/_about/notes/index.md
@@ -17,7 +17,7 @@ toc: false
 {% include section-index.html docs=site.about %}
 
 The [latest Istio monthly release](https://github.com/istio/istio/releases) is {{site.data.istio.version}} which
-you can download with:
+you can download with(*):
 
 ```
 curl -L https://git.io/getLatestIstio | sh -
@@ -30,4 +30,6 @@ can download with:
 curl -L https://git.io/getIstio | sh -
 ```
 
-[Archived documentation for for 0.2.12 release](https://archive.istio.io/v0.2/).
+[Archived documentation for for 0.2.12 release](https://archive.istio.io/v0.2/docs/).
+
+> (*) Note: As we don't control the git.io domain, please examine the output of the curl command before piping it to a shell if running in any sensitive or non sandboxed environment.

--- a/_about/notes/index.md
+++ b/_about/notes/index.md
@@ -14,17 +14,13 @@ redirect_from:
 toc: false  
 ---
 
-{% include section-index.html docs=site.about %}
-
-- The [latest Istio monthly release](https://github.com/istio/istio/releases) is {{site.data.istio.version}} which
-  you can download with(*):
+- The latest Istio monthly release is {{site.data.istio.version}} ([release notes]({{site.data.istio.version}}.html)). You can [download {{site.data.istio.version}}](https://github.com/istio/istio/releases) with(*):
 
   ```
   curl -L https://git.io/getLatestIstio | sh -
   ```
 
-- The most recent stable release is [0.2.12](https://github.com/istio/istio/releases/tag/0.2.12) which you
-  can download with:
+- The most recent stable release is 0.2.12. You can [download 0.2.12](https://github.com/istio/istio/releases/tag/0.2.12) with:
 
   ```
   curl -L https://git.io/getIstio | sh -
@@ -32,4 +28,5 @@ toc: false
 
   [Archived documentation for the 0.2.12 release](https://archive.istio.io/v0.2/docs/).
 
-> (*) Note: As we don't control the git.io domain, please examine the output of the curl command before piping it to a shell if running in any sensitive or non sandboxed environment.
+
+> (*) Note: As we don't control the `git.io` domain, please examine the output of the curl command before piping it to a shell if running in any sensitive or non sandboxed environment.


### PR DESCRIPTION
0.2.12 doc link should be to docs/ directly + note about shell security + typo fix (for for) + seperate the monthly from the stable