### PR TITLE
Should "openned" be a spelling mistake?

### DIFF
--- a/_docs/setup/kubernetes/quick-start.md
+++ b/_docs/setup/kubernetes/quick-start.md
@@ -109,7 +109,7 @@ Nevertheless the list of admission controllers needs to be updated.
 kops edit cluster $YOURCLUSTER
 ```
 
-Add following in the configuration file just openned:
+Add following in the configuration file just opened:
 
 ```bash
 kubeAPIServer:


### PR DESCRIPTION
In AWS (w/Kops) section:
"openned" should be "opened"?