### PR TITLE
Refine Helm installation warning.

### DIFF
--- a/_docs/setup/kubernetes/helm-install.md
+++ b/_docs/setup/kubernetes/helm-install.md
@@ -14,7 +14,7 @@ type: markdown
 
 Quick start instructions for the setup and configuration of Istio using the Helm package manager.
 
-<span style="color:red">**Warning: Helm charts are currently broken in 0.5.0**</span>
+*Installation with Helm prior to Istio version 0.7 are unstable and not recommended.*
 
 ## Prerequisites
 


### PR DESCRIPTION
Helm charts are unstable prior to 0.7.  Remove the red warning
and instead add a simple notice that Helm charts =<0.7 are functional.