### PR TITLE
Inline the TOC on mobile.

### DIFF
--- a/_layouts/about.html
+++ b/_layouts/about.html
@@ -30,6 +30,15 @@ layout: default
 
             <main role="main">
                 <h1>{{page.title}}</h1>
+
+                {% if needTOC %}
+                    <nav class="toc-inlined d-lg-none">
+                        <div class="directory" role="directory">
+                            {{ toc }}
+                        </div>
+                    </nav>
+                {% endif %}
+
                 {{ content}}
             </main>
         </div>

--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -46,6 +46,14 @@ layout: default
                     </p>
                 {% endif %}
 
+                {% if needTOC %}
+                    <nav class="toc-inlined d-lg-none">
+                        <div class="directory" role="directory">
+                            {{ toc }}
+                        </div>
+                    </nav>
+                {% endif %}
+
                 {{ content}}
             </main>
 

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -30,6 +30,15 @@ layout: default
 
             <main role="main">
                 <h1>{{page.title}}</h1>
+
+                {% if needTOC %}
+                    <nav class="toc-inlined d-lg-none">
+                        <div class="directory" role="directory">
+                            {{ toc }}
+                        </div>
+                    </nav>
+                {% endif %}
+
                 {{content}}
             </main>
         </div>

--- a/_layouts/help.html
+++ b/_layouts/help.html
@@ -30,6 +30,15 @@ layout: default
 
             <main role="main">
                 <h1>{{page.title}}</h1>
+
+                {% if needTOC %}
+                    <nav class="toc-inlined d-lg-none">
+                        <div class="directory" role="directory">
+                            {{ toc }}
+                        </div>
+                    </nav>
+                {% endif %}
+
                 {{ content}}
             </main>
         </div>

--- a/_sass/base/_common.scss
+++ b/_sass/base/_common.scss
@@ -4,8 +4,8 @@
 *[id]:before {
       display: block;
       content: ' ';
-      margin-top: -3.0em;
-      height: 3.0em;
+      margin-top: -1.8em;
+      height: 1.8em;
       visibility: hidden;
 }
 

--- a/_sass/modules/_toc.scss
+++ b/_sass/modules/_toc.scss
@@ -51,3 +51,28 @@
         }
     }
 }
+
+.toc-inlined {
+    .directory {
+        border-left: 0;
+
+        li {
+            font-size: 1rem;
+        }
+
+        ul {
+            list-style-type: none !important;
+            padding-left: 0;
+            padding-bottom: 0;
+            margin: 0;
+
+            ul {
+                padding-left: 1em;
+            }
+
+            a {
+                font-weight: $tocLinkWeight;
+            }
+        }
+    }
+}


### PR DESCRIPTION
For small screens that don't have room for the righthand TOC, we now
display the TOC inline in the main document. This substantially improves
navigation on mobile.

Staging: https://geeknoid.github.io/istio.github.io/docs/setup/kubernetes/quick-start.html
(make your browser window skinny to see this behavior)