### PR TITLE
Force change directory in the Quick Start doc

### DIFF
--- a/_docs/setup/kubernetes/quick-start.md
+++ b/_docs/setup/kubernetes/quick-start.md
@@ -187,7 +187,7 @@ curl -L https://git.io/getLatestIstio | sh -
 
 1. Change directory to istio package. For example, if the package is istio-{{site.data.istio.version}}
 ```bash
-cd istio-{{site.data.istio.version}}
+cd istio-0.7.1
 ```
 
 1. Add the `istioctl` client to your PATH.


### PR DESCRIPTION
As discuss in #1156, I propose to force the change directory with static value, instead of create a new branch (due to automatic parameter {{site.data.istio.version}} )