### PR TITLE
www.yaml.org went missing - yaml.org seems to work.

### DIFF
--- a/_docs/tasks/traffic-management/egress-tcp.md
+++ b/_docs/tasks/traffic-management/egress-tcp.md
@@ -97,7 +97,7 @@ EOF
 ```
 
 This command will create five egress rules, a rule per different block of IPs of `wikipedia.org`. Note the `---` (three dashes) separator between the egress rules. This is the
-[YAML separator between documents](http://www.yaml.org/spec/1.2/spec.html#id2760395) in a stream. It allows us to create multiple configuration artifacts using
+[YAML separator between documents](http://yaml.org/spec/1.2/spec.html#id2760395) in a stream. It allows us to create multiple configuration artifacts using
 a single `istioctl` command.
 
 ## Access wikipedia.org by HTTPS


### PR DESCRIPTION
sdake@falkor-08:~/go/src/istio.io/istio.github.io/_docs$ dig www.yaml.org

; <<>> DiG 9.10.3-P4-Ubuntu <<>> www.yaml.org
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: SERVFAIL, id: 34828
;; flags: qr rd ra; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 512
;; QUESTION SECTION:
;www.yaml.org.			IN	A

;; Query time: 917 msec
;; SERVER: 8.8.8.8#53(8.8.8.8)
;; WHEN: Sun Apr 08 09:10:51 MST 2018