### PR TITLE
v1alpha3 — "greatly improved" caution message

### DIFF
--- a/_docs/tasks/traffic-management-v1alpha3/ingress.md
+++ b/_docs/tasks/traffic-management-v1alpha3/ingress.md
@@ -54,9 +54,9 @@ This task describes how to configure Istio to expose a service outside of the se
    ```
 
 ## Configuring ingress using an Istio Gateway resource (recommended)
-
-> This is still a work in progress and is not yet functional.
-
+----
+> This is still a work in progress and is **not available** in current Istio release (0.7.1). Current way of enabling inbound cluster traffic via Kubernetes Ingress resource is outlined [below](#configuring-ingress-using-a-kubernetes-ingress-resource).
+----
 An [Istio Gateway]({{home}}/docs/reference/config/istio.networking.v1alpha3.html#Gateway) is the preferred
 model for configuring ingress traffic in Istio.
 An ingress `Gateway` describes a load balancer operating at the edge of the mesh receiving incoming

--- a/_docs/tasks/traffic-management-v1alpha3/ingress.md
+++ b/_docs/tasks/traffic-management-v1alpha3/ingress.md
@@ -8,6 +8,7 @@ layout: docs
 type: markdown
 redirect_from: /docs/tasks/ingress.html
 ---
+
 {% include home.html %}
 
 In a Kubernetes environment, the [Kubernetes Ingress Resource](https://kubernetes.io/docs/concepts/services-networking/ingress/)
@@ -47,16 +48,20 @@ This task describes how to configure Istio to expose a service outside of the se
 
 * Generate a certificate and key that will be used to demonstrate a TLS-secured gateway
 
-   A private key and certificate can be created for testing using [OpenSSL](https://www.openssl.org/).
+  A private key and certificate can be created for testing using [OpenSSL](https://www.openssl.org/).
 
-   ```bash
-   openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /tmp/tls.key -out /tmp/tls.crt -subj "/CN=foo.bar.com"
-   ```
+  ```bash
+  openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /tmp/tls.key -out /tmp/tls.crt -subj "/CN=foo.bar.com"
+  ```
 
 ## Configuring ingress using an Istio Gateway resource (recommended)
-----
-> This is still a work in progress and is **not available** in current Istio release (0.7.1). Current way of enabling inbound cluster traffic via Kubernetes Ingress resource is outlined [below](#configuring-ingress-using-a-kubernetes-ingress-resource).
-----
+
+---
+
+> This is still a work in progress and is **not available** in the most recent Istio release (0.7.1). The current way of enabling inbound cluster traffic via Kubernetes Ingress resource is outlined [below](#configuring-ingress-using-a-kubernetes-ingress-resource).
+
+---
+
 An [Istio Gateway]({{home}}/docs/reference/config/istio.networking.v1alpha3.html#Gateway) is the preferred
 model for configuring ingress traffic in Istio.
 An ingress `Gateway` describes a load balancer operating at the edge of the mesh receiving incoming
@@ -64,78 +69,78 @@ HTTP/TCP connections.
 It configures exposed ports, protocols, etc.,
 but, unlike [Kubernetes Ingress Resources](https://kubernetes.io/docs/concepts/services-networking/ingress/),
 does not include any traffic routing configuration. Traffic routing for ingress traffic is instead configured
-using Istio routing rules, exactly in the same was as for internal service requests.
+using Istio routing rules, exactly in the same way as for internal service requests.
 
 ### Configuring a Gateway
 
-1. Create an Istio `Gateway`
+1.  Create an Istio `Gateway`
 
-   ```bash
-   cat <<EOF | kubectl create -f -
-   apiVersion: networking.istio.io/v1alpha3
-   kind: Gateway
-   metadata:
-     name: httpbin-gateway
-   spec:
-     servers:
-     - port:
-         number: 80
-         name: http
-     - port:
-         number: 443
-         name: https
-       tls:
-         mode: SIMPLE
-         serverCertificate: /tmp/tls.crt
-         privateKey: /tmp/tls.key
-   EOF
-   ```
+    ```bash
+    cat <<EOF | kubectl create -f -
+    apiVersion: networking.istio.io/v1alpha3
+    kind: Gateway
+    metadata:
+      name: httpbin-gateway
+    spec:
+      servers:
+      - port:
+          number: 80
+          name: http
+      - port:
+          number: 443
+          name: https
+        tls:
+          mode: SIMPLE
+          serverCertificate: /tmp/tls.crt
+          privateKey: /tmp/tls.key
+    EOF
+    ```
 
-   Notice that a single `Gateway` specification can configure multiple ports, a simple HTTP (port 80) and
-   secure HTTPS (port 443) in our case.
+    Notice that a single `Gateway` specification can configure multiple ports, a simple HTTP (port 80) and
+    secure HTTPS (port 443) in our case.
 
-1. Configure routes for traffic entering via the `Gateway`
+1.  Configure routes for traffic entering via the `Gateway`
 
-   ```bash
-   cat <<EOF | kubectl create -f -
-   apiVersion: networking.istio.io/v1alpha3
-   kind: VirtualService
-   metadata:
-     name: httpbin
-   spec:
-     hosts:
-     - httpbin
-     gateways:
-     - httpbin-gateway
-     http:
-     - match:
-         uri:
-           prefix: /status
-       route:
-       - destination:
-           port:
-             number: 8000
-           name: httpbin
-     - match:
-         uri:
-           prefix: /delay
-       route:
-       - destination:
-           port:
-             number: 8000
-           name: httpbin
-   EOF
-   ```
+    ```bash
+    cat <<EOF | kubectl create -f -
+    apiVersion: networking.istio.io/v1alpha3
+    kind: VirtualService
+    metadata:
+      name: httpbin
+    spec:
+      hosts:
+      - httpbin
+      gateways:
+      - httpbin-gateway
+      http:
+      - match:
+          uri:
+            prefix: /status
+        route:
+        - destination:
+            port:
+              number: 8000
+            name: httpbin
+      - match:
+          uri:
+            prefix: /delay
+        route:
+        - destination:
+            port:
+              number: 8000
+            name: httpbin
+    EOF
+    ```
 
-   Here we've created a [virtual service]({{home}}/docs/reference/config/istio.networking.v1alpha3.html#VirtualService)
-   configuration for the `httpbin` service, containing two route rules that allow traffic for paths `/status` and `/delay`.
-   The [gateways]({{home}}/docs/reference/config/istio.networking.v1alpha3.html#VirtualService.gateways) list
-   specifies that only requests through our `httpbin-gateway` are allowed.
-   All other external requests will be rejected with a 404 response.
+    Here we've created a [virtual service]({{home}}/docs/reference/config/istio.networking.v1alpha3.html#VirtualService)
+    configuration for the `httpbin` service, containing two route rules that allow traffic for paths `/status` and `/delay`.
+    The [gateways]({{home}}/docs/reference/config/istio.networking.v1alpha3.html#VirtualService.gateways) list
+    specifies that only requests through our `httpbin-gateway` are allowed.
+    All other external requests will be rejected with a 404 response.
 
-   Note that in this configuration internal requests from other services in the mesh are not subject to these rules,
-   but instead will simply default to round-robin routing. To apply these (or other rules) to internal calls,
-   we could add the special value `mesh` to the list of `gateways`.
+    Note that in this configuration internal requests from other services in the mesh are not subject to these rules,
+    but instead will simply default to round-robin routing. To apply these (or other rules) to internal calls,
+    we could add the special value `mesh` to the list of `gateways`.
 
 ### Verifying a Gateway
 
@@ -144,99 +149,99 @@ The proxy instances implementing a particular `Gateway` configuration can be spe
 If not specified, as in our case, the `Gateway` will be implemented by the default `istio-ingress` controller.
 Therefore, to test our `Gateway` we will send requests to the `istio-ingress` service.
 
-1. Get the ingress controller pod's hostIP:
+1.  Get the ingress controller pod's hostIP:
 
-   ```bash
-   kubectl -n istio-system get po -l istio=ingress -o jsonpath='{.items[0].status.hostIP}'
-   ```
+    ```bash
+    kubectl -n istio-system get po -l istio=ingress -o jsonpath='{.items[0].status.hostIP}'
+    ```
 
-   ```bash
-   169.47.243.100
-   ```
+    ```bash
+    169.47.243.100
+    ```
 
-1. Get the istio-ingress service's nodePorts for port 80 and 443:
+1.  Get the istio-ingress service's nodePorts for port 80 and 443:
 
-   ```bash
-   kubectl -n istio-system get svc istio-ingress
-   ```
+    ```bash
+    kubectl -n istio-system get svc istio-ingress
+    ```
 
-   ```bash
-   NAME            CLUSTER-IP     EXTERNAL-IP   PORT(S)                      AGE
-   istio-ingress   10.10.10.155   <pending>     80:31486/TCP,443:32254/TCP   32m
-   ```
+    ```bash
+    NAME            CLUSTER-IP     EXTERNAL-IP   PORT(S)                      AGE
+    istio-ingress   10.10.10.155   <pending>     80:31486/TCP,443:32254/TCP   32m
+    ```
 
-   ```bash
-   export INGRESS_HOST=169.47.243.100:31486
-   export SECURE_INGRESS_HOST=169.47.243.100:32254
-   ```
+    ```bash
+    export INGRESS_HOST=169.47.243.100:31486
+    export SECURE_INGRESS_HOST=169.47.243.100:32254
+    ```
 
-1. Access the httpbin service with either HTTP or HTTPS using _curl_:
+1.  Access the httpbin service with either HTTP or HTTPS using _curl_:
 
-   ```bash
-   curl -I http://$INGRESS_HOST/status/200
-   ```
+    ```bash
+    curl -I http://$INGRESS_HOST/status/200
+    ```
 
-   ```xxx
-   HTTP/1.1 200 OK
-   server: envoy
-   date: Mon, 29 Jan 2018 04:45:49 GMT
-   content-type: text/html; charset=utf-8
-   access-control-allow-origin: *
-   access-control-allow-credentials: true
-   content-length: 0
-   x-envoy-upstream-service-time: 48
-   ```
+    ```xxx
+    HTTP/1.1 200 OK
+    server: envoy
+    date: Mon, 29 Jan 2018 04:45:49 GMT
+    content-type: text/html; charset=utf-8
+    access-control-allow-origin: *
+    access-control-allow-credentials: true
+    content-length: 0
+    x-envoy-upstream-service-time: 48
+    ```
 
-   ```bash
-   curl -I -k https://$SECURE_INGRESS_HOST/status/200
-   ```
+    ```bash
+    curl -I -k https://$SECURE_INGRESS_HOST/status/200
+    ```
 
-   ```xxx
-   HTTP/1.1 200 OK
-   server: envoy
-   date: Mon, 29 Jan 2018 04:45:49 GMT
-   content-type: text/html; charset=utf-8
-   access-control-allow-origin: *
-   access-control-allow-credentials: true
-   content-length: 0
-   x-envoy-upstream-service-time: 96
-   ```
+    ```xxx
+    HTTP/1.1 200 OK
+    server: envoy
+    date: Mon, 29 Jan 2018 04:45:49 GMT
+    content-type: text/html; charset=utf-8
+    access-control-allow-origin: *
+    access-control-allow-credentials: true
+    content-length: 0
+    x-envoy-upstream-service-time: 96
+    ```
 
-1. Access any other URL that has not been explicitly exposed. You should
-   see a HTTP 404 error:
+1.  Access any other URL that has not been explicitly exposed. You should
+    see a HTTP 404 error:
 
-   ```bash
-   curl -I http://$INGRESS_HOST/headers
-   ```
+    ```bash
+    curl -I http://$INGRESS_HOST/headers
+    ```
 
-   ```xxx
-   HTTP/1.1 404 Not Found
-   date: Mon, 29 Jan 2018 04:45:49 GMT
-   server: envoy
-   content-length: 0
-   ```
+    ```xxx
+    HTTP/1.1 404 Not Found
+    date: Mon, 29 Jan 2018 04:45:49 GMT
+    server: envoy
+    content-length: 0
+    ```
 
-   ```bash
-   curl -I https://$SECURE_INGRESS_HOST/headers
-   ```
+    ```bash
+    curl -I https://$SECURE_INGRESS_HOST/headers
+    ```
 
-   ```xxx
-   HTTP/1.1 404 Not Found
-   date: Mon, 29 Jan 2018 04:45:49 GMT
-   server: envoy
-   content-length: 0
-   ```
+    ```xxx
+    HTTP/1.1 404 Not Found
+    date: Mon, 29 Jan 2018 04:45:49 GMT
+    server: envoy
+    content-length: 0
+    ```
 
 ## Configuring ingress using a Kubernetes Ingress resource
 
 An Istio `Ingress` specification is based on the standard [Kubernetes Ingress Resource](https://kubernetes.io/docs/concepts/services-networking/ingress/)
 specification, with the following differences:
 
-1. Istio `Ingress` specification contains a `kubernetes.io/ingress.class: istio` annotation.
+1.  Istio `Ingress` specification contains a `kubernetes.io/ingress.class: istio` annotation.
 
-1. All other annotations are ignored.
+1.  All other annotations are ignored.
 
-1. Path syntax is [c++11 regex format](http://en.cppreference.com/w/cpp/regex/ecmascript)
+1.  Path syntax is [c++11 regex format](http://en.cppreference.com/w/cpp/regex/ecmascript)
 
 Note that `Ingress` traffic is not affected by routing rules configured for a backend
 (i.e., an Istio `VirtualService` cannot be combined with an `Ingress` specification).
@@ -251,229 +256,229 @@ service declaration.
 
 ### Configuring simple Ingress
 
-1. Create a basic `Ingress` specification for the httpbin service
+1.  Create a basic `Ingress` specification for the httpbin service
 
-   ```bash
-   cat <<EOF | kubectl create -f -
-   apiVersion: extensions/v1beta1
-   kind: Ingress
-   metadata:
-     name: simple-ingress
-     annotations:
-       kubernetes.io/ingress.class: istio
-   spec:
-     rules:
-     - http:
-         paths:
-         - path: /status/*
-           backend:
-             serviceName: httpbin
-             servicePort: 8000
-         - path: /delay/*
-           backend:
-             serviceName: httpbin
-             servicePort: 8000
-   EOF
-   ```
+    ```bash
+    cat <<EOF | kubectl create -f -
+    apiVersion: extensions/v1beta1
+    kind: Ingress
+    metadata:
+      name: simple-ingress
+      annotations:
+        kubernetes.io/ingress.class: istio
+    spec:
+      rules:
+      - http:
+          paths:
+          - path: /status/*
+            backend:
+              serviceName: httpbin
+              servicePort: 8000
+          - path: /delay/*
+            backend:
+              serviceName: httpbin
+              servicePort: 8000
+    EOF
+    ```
 
 ### Verifying simple Ingress
 
-1. Determine the ingress URL:
+1.  Determine the ingress URL:
 
-   * If your cluster is running in an environment that supports external load balancers, use the ingress' external address:
+    * If your cluster is running in an environment that supports external load balancers, use the ingress' external address:
 
-   ```bash
-   kubectl get ingress simple-ingress -o wide
-   ```
+    ```bash
+    kubectl get ingress simple-ingress -o wide
+    ```
 
-   ```xxx
-   NAME             HOSTS     ADDRESS                 PORTS     AGE
-   simple-ingress   *         130.211.10.121          80        1d
-   ```
+    ```xxx
+    NAME             HOSTS     ADDRESS                 PORTS     AGE
+    simple-ingress   *         130.211.10.121          80        1d
+    ```
 
-   ```bash
-   export INGRESS_HOST=130.211.10.121
-   ```
+    ```bash
+    export INGRESS_HOST=130.211.10.121
+    ```
 
-   * If load balancers are not supported, use the ingress controller pod's hostIP:
+    * If load balancers are not supported, use the ingress controller pod's hostIP:
 
-   ```bash
-   kubectl -n istio-system get po -l istio=ingress -o jsonpath='{.items[0].status.hostIP}'
-   ```
+    ```bash
+    kubectl -n istio-system get po -l istio=ingress -o jsonpath='{.items[0].status.hostIP}'
+    ```
 
-   ```xxx
-   169.47.243.100
-   ```
+    ```xxx
+    169.47.243.100
+    ```
 
-   along with the istio-ingress service's nodePort for port 80:
+    along with the istio-ingress service's nodePort for port 80:
 
-   ```bash
-   kubectl -n istio-system get svc istio-ingress
-   ```
+    ```bash
+    kubectl -n istio-system get svc istio-ingress
+    ```
 
-   ```xxx
-   NAME            CLUSTER-IP     EXTERNAL-IP   PORT(S)                      AGE
-   istio-ingress   10.10.10.155   <pending>     80:31486/TCP,443:32254/TCP   32m
-   ```
+    ```xxx
+    NAME            CLUSTER-IP     EXTERNAL-IP   PORT(S)                      AGE
+    istio-ingress   10.10.10.155   <pending>     80:31486/TCP,443:32254/TCP   32m
+    ```
 
-   ```bash
-   export INGRESS_HOST=169.47.243.100:31486
-   ```
+    ```bash
+    export INGRESS_HOST=169.47.243.100:31486
+    ```
 
-1. Access the httpbin service using _curl_:
+1.  Access the httpbin service using _curl_:
 
-   ```bash
-   curl -I http://$INGRESS_HOST/status/200
-   ```
+    ```bash
+    curl -I http://$INGRESS_HOST/status/200
+    ```
 
-   ```xxx
-   HTTP/1.1 200 OK
-   server: envoy
-   date: Mon, 29 Jan 2018 04:45:49 GMT
-   content-type: text/html; charset=utf-8
-   access-control-allow-origin: *
-   access-control-allow-credentials: true
-   content-length: 0
-   x-envoy-upstream-service-time: 48
-   ```
+    ```xxx
+    HTTP/1.1 200 OK
+    server: envoy
+    date: Mon, 29 Jan 2018 04:45:49 GMT
+    content-type: text/html; charset=utf-8
+    access-control-allow-origin: *
+    access-control-allow-credentials: true
+    content-length: 0
+    x-envoy-upstream-service-time: 48
+    ```
 
-1. Access any other URL that has not been explicitly exposed. You should
-   see a HTTP 404 error
+1.  Access any other URL that has not been explicitly exposed. You should
+    see a HTTP 404 error
 
-   ```bash
-   curl -I http://$INGRESS_HOST/headers
-   ```
+    ```bash
+    curl -I http://$INGRESS_HOST/headers
+    ```
 
-   ```xxx
-   HTTP/1.1 404 Not Found
-   date: Mon, 29 Jan 2018 04:45:49 GMT
-   server: envoy
-   content-length: 0
-   ```
+    ```xxx
+    HTTP/1.1 404 Not Found
+    date: Mon, 29 Jan 2018 04:45:49 GMT
+    server: envoy
+    content-length: 0
+    ```
 
 ### Configuring secure Ingress (HTTPS)
 
-1. Create a Kubernetes `Secret` to hold the key/cert
+1.  Create a Kubernetes `Secret` to hold the key/cert
 
-   Create the secret `istio-ingress-certs` in namespace `istio-system` using `kubectl`. The Istio ingress controller
-   will automatically load the secret.
+    Create the secret `istio-ingress-certs` in namespace `istio-system` using `kubectl`. The Istio ingress controller
+    will automatically load the secret.
 
-   > The secret MUST be called `istio-ingress-certs` in the `istio-system` namespace, or it will not
-   be mounted and available to the Istio ingress controller.
+    > The secret MUST be called `istio-ingress-certs` in the `istio-system` namespace, or it will not
+    > be mounted and available to the Istio ingress controller.
 
-   ```bash
-   kubectl create -n istio-system secret tls istio-ingress-certs --key /tmp/tls.key --cert /tmp/tls.crt
-   ```
+    ```bash
+    kubectl create -n istio-system secret tls istio-ingress-certs --key /tmp/tls.key --cert /tmp/tls.crt
+    ```
 
-   Note that by default all service accounts in the `istio-system` namespace can access this ingress key/cert,
-   which risks leaking the key/cert. You can change the Role-Based Access Control (RBAC) rules to protect them.
-   See (Link TBD) for details.
+    Note that by default all service accounts in the `istio-system` namespace can access this ingress key/cert,
+    which risks leaking the key/cert. You can change the Role-Based Access Control (RBAC) rules to protect them.
+    See (Link TBD) for details.
 
-1. Create the `Ingress` specification for the httpbin service
+1.  Create the `Ingress` specification for the httpbin service
 
-   ```bash
-   cat <<EOF | kubectl create -f -
-   apiVersion: extensions/v1beta1
-   kind: Ingress
-   metadata:
-     name: secure-ingress
-     annotations:
-       kubernetes.io/ingress.class: istio
-   spec:
-     tls:
-       - secretName: istio-ingress-certs # currently ignored
-     rules:
-     - http:
-         paths:
-         - path: /status/*
-           backend:
-             serviceName: httpbin
-             servicePort: 8000
-         - path: /delay/*
-           backend:
-             serviceName: httpbin
-             servicePort: 8000
-   EOF
-   ```
+    ```bash
+    cat <<EOF | kubectl create -f -
+    apiVersion: extensions/v1beta1
+    kind: Ingress
+    metadata:
+      name: secure-ingress
+      annotations:
+        kubernetes.io/ingress.class: istio
+    spec:
+      tls:
+        - secretName: istio-ingress-certs # currently ignored
+      rules:
+      - http:
+          paths:
+          - path: /status/*
+            backend:
+              serviceName: httpbin
+              servicePort: 8000
+          - path: /delay/*
+            backend:
+              serviceName: httpbin
+              servicePort: 8000
+    EOF
+    ```
 
-   > Because SNI is not yet supported, Envoy currently only allows a single TLS secret in the ingress.
-   > That means the secretName field in ingress resource is not used.
+    > Because SNI is not yet supported, Envoy currently only allows a single TLS secret in the ingress.
+    > That means the secretName field in ingress resource is not used.
 
 ### Verifying secure Ingress
 
-1. Determine the ingress URL:
+1.  Determine the ingress URL:
 
-   * If your cluster is running in an environment that supports external load balancers,
-   use the ingress' external address:
+    * If your cluster is running in an environment that supports external load balancers,
+      use the ingress' external address:
 
-   ```bash
-   kubectl get ingress secure-ingress -o wide
-   ```
+    ```bash
+    kubectl get ingress secure-ingress -o wide
+    ```
 
-   ```xxx
-   NAME             HOSTS     ADDRESS                 PORTS     AGE
-   secure-ingress   *         130.211.10.121          80        1d
-   ```
+    ```xxx
+    NAME             HOSTS     ADDRESS                 PORTS     AGE
+    secure-ingress   *         130.211.10.121          80        1d
+    ```
 
-   ```bash
-   export SECURE_INGRESS_HOST=130.211.10.121
-   ```
+    ```bash
+    export SECURE_INGRESS_HOST=130.211.10.121
+    ```
 
-   * If load balancers are not supported, use the ingress controller pod's hostIP:
+    * If load balancers are not supported, use the ingress controller pod's hostIP:
 
-   ```bash
-   kubectl -n istio-system get po -l istio=ingress -o jsonpath='{.items[0].status.hostIP}'
-   ```
+    ```bash
+    kubectl -n istio-system get po -l istio=ingress -o jsonpath='{.items[0].status.hostIP}'
+    ```
 
-   ```xxx
-   169.47.243.100
-   ```
+    ```xxx
+    169.47.243.100
+    ```
 
-   along with the istio-ingress service's nodePort for port 443:
+    along with the istio-ingress service's nodePort for port 443:
 
-   ```bash
-   kubectl -n istio-system get svc istio-ingress
-   ```
+    ```bash
+    kubectl -n istio-system get svc istio-ingress
+    ```
 
-   ```xxx
-   NAME            CLUSTER-IP     EXTERNAL-IP   PORT(S)                      AGE
-   istio-ingress   10.10.10.155   <pending>     80:31486/TCP,443:32254/TCP   32m
-   ```
+    ```xxx
+    NAME            CLUSTER-IP     EXTERNAL-IP   PORT(S)                      AGE
+    istio-ingress   10.10.10.155   <pending>     80:31486/TCP,443:32254/TCP   32m
+    ```
 
-   ```bash
-   export SECURE_INGRESS_HOST=169.47.243.100:32254
-   ```
+    ```bash
+    export SECURE_INGRESS_HOST=169.47.243.100:32254
+    ```
 
-1. Access the httpbin service using _curl_:
+1.  Access the httpbin service using _curl_:
 
-   ```bash
-   curl -I -k https://$SECURE_INGRESS_HOST/status/200
-   ```
+    ```bash
+    curl -I -k https://$SECURE_INGRESS_HOST/status/200
+    ```
 
-   ```xxx
-   HTTP/1.1 200 OK
-   server: envoy
-   date: Mon, 29 Jan 2018 04:45:49 GMT
-   content-type: text/html; charset=utf-8
-   access-control-allow-origin: *
-   access-control-allow-credentials: true
-   content-length: 0
-   x-envoy-upstream-service-time: 96
-   ```
+    ```xxx
+    HTTP/1.1 200 OK
+    server: envoy
+    date: Mon, 29 Jan 2018 04:45:49 GMT
+    content-type: text/html; charset=utf-8
+    access-control-allow-origin: *
+    access-control-allow-credentials: true
+    content-length: 0
+    x-envoy-upstream-service-time: 96
+    ```
 
-1. Access any other URL that has not been explicitly exposed. You should
-   see a HTTP 404 error
+1.  Access any other URL that has not been explicitly exposed. You should
+    see a HTTP 404 error
 
-   ```bash
-   curl -I -k https://$SECURE_INGRESS_HOST/headers
-   ```
+    ```bash
+    curl -I -k https://$SECURE_INGRESS_HOST/headers
+    ```
 
-   ```xxx
-   HTTP/1.1 404 Not Found
-   date: Mon, 29 Jan 2018 04:45:49 GMT
-   server: envoy
-   content-length: 0
-   ```
+    ```xxx
+    HTTP/1.1 404 Not Found
+    date: Mon, 29 Jan 2018 04:45:49 GMT
+    server: envoy
+    content-length: 0
+    ```
 
 ## Understanding what happened
 
@@ -489,30 +494,30 @@ and may be especially useful when moving existing Kubernetes applications to Ist
 
 ## Cleanup
 
-1. Remove the `Gateway` configuration.
+1.  Remove the `Gateway` configuration.
 
-   ```bash
-   kubectl delete gateway httpbin-gateway
-   ```
+    ```bash
+    kubectl delete gateway httpbin-gateway
+    ```
 
-1. Remove the `Ingress` configuration.
+1.  Remove the `Ingress` configuration.
 
-   ```bash
-   kubectl delete ingress simple-ingress secure-ingress
-   ```
+    ```bash
+    kubectl delete ingress simple-ingress secure-ingress
+    ```
 
-1. Remove the routing rule and secret.
+1.  Remove the routing rule and secret.
 
-   ```bash
-   istioctl delete virtualservice httpbin
-   kubectl delete -n istio-system secret istio-ingress-certs
-   ```
+    ```bash
+    istioctl delete virtualservice httpbin
+    kubectl delete -n istio-system secret istio-ingress-certs
+    ```
 
-1. Shutdown the [httpbin](https://github.com/istio/istio/tree/master/samples/httpbin) service.
+1.  Shutdown the [httpbin](https://github.com/istio/istio/tree/master/samples/httpbin) service.
 
-   ```bash
-   kubectl delete -f samples/httpbin/httpbin.yaml
-   ```
+    ```bash
+    kubectl delete -f samples/httpbin/httpbin.yaml
+    ```
 
 ## What's next
 


### PR DESCRIPTION
Clarified the warning immediately following the "Recommended" approach
- added information about what "WIP" means, i.e. it doesn't work at all in 0.7.1. 
- added a #header link to help people skip to the Kubernetes Ingress section (needs to be verified on a live template)

I feel like it wasn't just me who jumped on the opportunity to test drive the v1alpha3 API, and what is more confusing I have succeeded — `VirtualService` is a bit quirky but it works and the lack of clarity in the API reference has not deterred my love for decoupling k8s and Istio. But I have glanced over the note @geeknoid left in the docs, taking the success of one Istio extension as a green light to use the remaining ones — `DestinationRule` and `Gateway`. It was only when I tried to use a good'ol `Ingress` resource instead that I found everything actually works in my toy cluster. Moreover, this experimentation led me to [issues#294](https://github.com/istio/issues/issues/294) which was completely baffling until just a couple of hours ago that @ZackButcher has said the magic words: "it's not there yet."

This PR is meant to patch the main portion of the website for a remaining couple of weeks before 0.8 drops — clearly deterring usage of the practically non-existent `Gateway`. Please consider merging it regardless of future plans.