### PR TITLE
Fix incorrect behavior of the sidenav when dealing with long non-wrapping page titles

### DIFF
--- a/_sass/modules/_sidebar.scss
+++ b/_sass/modules/_sidebar.scss
@@ -4,9 +4,14 @@
         z-index: 42;
         left: -1500px;
         width: auto;
-        max-width: 80%;
         top: $headerHeight;
         position: absolute;
+    }
+
+    @media (max-width: calc($bp-md - 1)) {
+        .row-offcanvas .sidebar-offcanvas {
+            max-width: 80%;
+        }
     }
 
     .row-offcanvas.active .sidebar-offcanvas {
@@ -24,7 +29,7 @@
     order: 0;
     font-size: 85%;
 
-    @media (min-width: $bp-lg) {
+    @media (min-width: $bp-xl) {
         font-size: 100%;
     }
 
@@ -110,11 +115,7 @@
         @media (min-width: $bp-lg) {
             .card-body {
                 padding-left: 1.25rem;
-                padding-right: 1.25rem;
-            }
-
-            li {
-                font-size: 100%;
+                padding-right: 0.5rem;
             }
 
             ul {


### PR DESCRIPTION
- When I was last fiddling with the sidenav on mobile, I messed up the sizing for non-mobile cases.
This cause the sidenav to grow beyond its expected size when presented with long non-wrapping page
titles. The text is now wrapped instead as it should.

- Shrank the font size of the list items in the sidenav to 85% to reduce the amount of wrapping that
happens.

- Reduce the right margin in the side nav to again try to reduce the amount of wrapping.

Staging: https://geeknoid.github.io/istio.github.io/