### PR TITLE
Update content to help upcoming migration from Jekyll to Hugo

### DIFF
--- a/404.md
+++ b/404.md
@@ -1,11 +1,10 @@
 ---
 title: Page Not Found
-overview: Page redirection
+description: Page redirection
 
-order: 0
+weight: 1
 
 layout: notfound
-type: markdown
 ---
 {% include home.html %}
 

--- a/_about/contribute/creating-a-pull-request.md
+++ b/_about/contribute/creating-a-pull-request.md
@@ -1,11 +1,9 @@
 ---
 title: Creating a Pull Request
-overview: Shows you how to create a GitHub pull request in order to submit your docs for approval.
+description: Shows you how to create a GitHub pull request in order to submit your docs for approval.
 
-order: 20
+weight: 20
 
-layout: about
-type: markdown
 redirect_from: /docs/welcome/contribute/creating-a-pull-request.html
 ---
 

--- a/_about/contribute/editing.md
+++ b/_about/contribute/editing.md
@@ -1,11 +1,9 @@
 ---
 title: Editing Docs
-overview: Lets you start editing this site's documentation.
+description: Lets you start editing this site's documentation.
 
-order: 10
+weight: 10
 
-layout: about
-type: markdown
 redirect_from: /docs/welcome/contribute/editing.html
 ---
 

--- a/_about/contribute/index.md
+++ b/_about/contribute/index.md
@@ -1,11 +1,9 @@
 ---
 title: Contributing to the Docs
-overview: Learn how to contribute to improve and expand the Istio documentation.
+description: Learn how to contribute to improve and expand the Istio documentation.
 
-order: 100
+weight: 100
 
-layout: about
-type: markdown
 toc: false
 redirect_from: /docs/welcome/contribute/index.html
 ---

--- a/_about/contribute/reviewing-doc-issues.md
+++ b/_about/contribute/reviewing-doc-issues.md
@@ -1,11 +1,9 @@
 ---
 title: Doc Issues
-overview: Explains the process involved in accepting documentation updates.
+description: Explains the process involved in accepting documentation updates.
 
-order: 60
+weight: 60
 
-layout: about
-type: markdown
 redirect_from: /docs/welcome/contribute/reviewing-doc-issues.html
 ---
 

--- a/_about/contribute/staging-your-changes.md
+++ b/_about/contribute/staging-your-changes.md
@@ -1,11 +1,9 @@
 ---
 title: Staging Your Changes
-overview: Explains how to test your changes locally before submitting them.
+description: Explains how to test your changes locally before submitting them.
 
-order: 40
+weight: 40
 
-layout: about
-type: markdown
 redirect_from: /docs/welcome/contribute/staging-your-changes.html
 ---
 

--- a/_about/contribute/style-guide.md
+++ b/_about/contribute/style-guide.md
@@ -1,11 +1,9 @@
 ---
 title: Style Guide
-overview: Explains the dos and donts of writing Istio docs.
+description: Explains the dos and donts of writing Istio docs.
 
-order: 70
+weight: 70
 
-layout: about
-type: markdown
 redirect_from: /docs/welcome/contribute/style-guide.html
 ---
 

--- a/_about/contribute/writing-a-new-topic.md
+++ b/_about/contribute/writing-a-new-topic.md
@@ -1,11 +1,9 @@
 ---
 title: Writing a New Topic
-overview: Explains the mechanics of creating new documentation pages.
+description: Explains the mechanics of creating new documentation pages.
 
-order: 30
+weight: 30
 
-layout: about
-type: markdown
 redirect_from: /docs/welcome/contribute/writing-a-new-topic.html
 ---
 {% include home.html %}
@@ -88,12 +86,9 @@ chunk of front matter you should start with:
 ```yaml
 ---
 title: <title>
-overview: <overview>
+description: <overview>
 
-order: <order>
-
-layout: docs
-type: markdown
+weight: <order>
 ---
 ```
 
@@ -272,12 +267,10 @@ For example
 ```xxx
 ---
 title: Frequently Asked Questions
-overview: Questions Asked Frequently
+description: Questions Asked Frequently
 
-order: 12
+weight: 12
 
-layout: docs
-type: markdown
 redirect_from: /faq
 ---
 
@@ -291,12 +284,10 @@ You can also add many redirects like so:
 ```xxx
 ---
 title: Frequently Asked Questions
-overview: Questions Asked Frequently
+description: Questions Asked Frequently
 
-order: 12
+weight: 12
 
-layout: docs
-type: markdown
 redirect_from:
     - /faq
     - /faq2

--- a/_about/feature-stages.md
+++ b/_about/feature-stages.md
@@ -1,11 +1,9 @@
 ---
 title: Feature Status
-overview: List of features and their release stages.
+description: List of features and their release stages.
 
-order: 10
+weight: 10
 
-layout: about
-type: markdown
 redirect_from:
   - "/docs/reference/release-roadmap.html"
   - "/docs/reference/feature-stages.html"

--- a/_about/index.md
+++ b/_about/index.md
@@ -1,11 +1,9 @@
 ---
 title: About Istio
-overview: All about Istio.
+description: All about Istio.
 
-order: 15
+weight: 15
 
-layout: about
-type: markdown
 toc: false
 ---
 {% include home.html %}

--- a/_about/intro.md
+++ b/_about/intro.md
@@ -1,11 +1,9 @@
 ---
 title: What is Istio?
-overview: Context about what problems Istio is designed to solve.
+description: Context about what problems Istio is designed to solve.
 
-order: 0
+weight: 1
 
-layout: about
-type: markdown
 toc: false
 ---
 

--- a/_about/notes/0.1.md
+++ b/_about/notes/0.1.md
@@ -1,10 +1,8 @@
 ---
 title: Istio 0.1
 
-order: 100
+weight: 100
 
-layout: about
-type: markdown
 toc: false
 redirect_from: /docs/welcome/notes/0.1.html
 ---

--- a/_about/notes/0.2.md
+++ b/_about/notes/0.2.md
@@ -1,10 +1,8 @@
 ---
 title: Istio 0.2
 
-order: 99
+weight: 99
 
-layout: about
-type: markdown
 redirect_from: /docs/welcome/notes/0.2.html
 ---
 

--- a/_about/notes/0.3.md
+++ b/_about/notes/0.3.md
@@ -1,10 +1,8 @@
 ---
 title: Istio 0.3
 
-order: 98
+weight: 98
 
-layout: about
-type: markdown
 redirect_from: /docs/welcome/notes/0.3.html
 ---
 

--- a/_about/notes/0.4.md
+++ b/_about/notes/0.4.md
@@ -1,10 +1,8 @@
 ---
 title: Istio 0.4
 
-order: 97
+weight: 97
 
-layout: about
-type: markdown
 toc: false
 redirect_from: /docs/welcome/notes/0.4.html
 ---

--- a/_about/notes/0.5.md
+++ b/_about/notes/0.5.md
@@ -1,10 +1,8 @@
 ---
 title: Istio 0.5
 
-order: 96
+weight: 96
 
-layout: about
-type: markdown
 ---
 {% include home.html %}
 

--- a/_about/notes/0.6.md
+++ b/_about/notes/0.6.md
@@ -1,10 +1,8 @@
 ---
 title: Istio 0.6
 
-order: 95
+weight: 95
 
-layout: about
-type: markdown
 ---
 {% include home.html %}
 

--- a/_about/notes/0.7.md
+++ b/_about/notes/0.7.md
@@ -1,10 +1,8 @@
 ---
 title: Istio 0.7
 
-order: 94
+weight: 94
 
-layout: about
-type: markdown
 ---
 {% include home.html %}
 

--- a/_about/notes/0.8.md
+++ b/_about/notes/0.8.md
@@ -1,10 +1,7 @@
 ---
 title: Istio 0.8
 
-order: 93
-
-layout: about
-type: markdown
+weight: 93
 ---
 {% include home.html %}
 

--- a/_about/notes/index.md
+++ b/_about/notes/index.md
@@ -1,11 +1,9 @@
 ---
 title: Release Notes
-overview: Description of features and improvements for every Istio release.
+description: Description of features and improvements for every Istio release.
 
-order: 5
+weight: 5
 
-layout: about
-type: markdown
 redirect_from:
   - "/docs/reference/release-notes.html"
   - "/release-notes"

--- a/_blog/2017/0.1-announcement.md
+++ b/_blog/2017/0.1-announcement.md
@@ -1,14 +1,12 @@
 ---
-title: "Introducing Istio"
-overview: Istio 0.1 announcement
+title: Introducing Istio
+description: Istio 0.1 announcement
 publish_date: May 24, 2017
 subtitle: A robust service mesh for microservices
 attribution: The Istio Team
 
-order: 100
+weight: 100
 
-layout: blog
-type: markdown
 redirect_from:
   - "/blog/istio-service-mesh-for-microservices.html"
   - "/blog/0.1-announcement.html"

--- a/_blog/2017/0.1-auth.md
+++ b/_blog/2017/0.1-auth.md
@@ -1,14 +1,12 @@
 ---
-title: "Using Istio to Improve End-to-End Security"
-overview: Istio Auth 0.1 announcement
+title: Using Istio to Improve End-to-End Security
+description: Istio Auth 0.1 announcement
 publish_date: May 25, 2017
 subtitle: Secure by default service to service communications
 attribution: The Istio Team
 
-order: 99
+weight: 99
 
-layout: blog
-type: markdown
 redirect_from:
   - "/blog/0.1-auth.html"
   - "/blog/istio-auth-for-microservices.html"

--- a/_blog/2017/0.1-canary.md
+++ b/_blog/2017/0.1-canary.md
@@ -1,14 +1,12 @@
 ---
-title: "Canary Deployments using Istio"
-overview: Using Istio to create autoscaled canary deployments
+title: Canary Deployments using Istio
+description: Using Istio to create autoscaled canary deployments
 publish_date: June 14, 2017
 subtitle:
 attribution: Frank Budinsky
 
-order: 98
+weight: 98
 
-layout: blog
-type: markdown
 redirect_from: "/blog/canary-deployments-using-istio.html"
 ---
 

--- a/_blog/2017/0.1-using-network-policy.md
+++ b/_blog/2017/0.1-using-network-policy.md
@@ -1,14 +1,12 @@
 ---
-title: "Using Network Policy with Istio"
-overview: How Kubernetes Network Policy relates to Istio policy
+title: Using Network Policy with Istio
+description: How Kubernetes Network Policy relates to Istio policy
 publish_date: August 10, 2017
 subtitle:
 attribution: Spike Curtis
 
-order: 97
+weight: 97
 
-layout: blog
-type: markdown
 redirect_from: "/blog/using-network-policy-in-concert-with-istio.html"
 ---
 {% include home.html %}

--- a/_blog/2017/0.2-announcement.md
+++ b/_blog/2017/0.2-announcement.md
@@ -1,14 +1,12 @@
 ---
-title: "Announcing Istio 0.2"
-overview: Istio 0.2 announcement
+title: Announcing Istio 0.2
+description: Istio 0.2 announcement
 publish_date: October 10, 2017
 subtitle: Improved mesh and support for multiple environments
 attribution: The Istio Team
 
-order: 96
+weight: 96
 
-layout: blog
-type: markdown
 toc: false
 redirect_from: "/blog/istio-0.2-announcement.html"
 ---

--- a/_blog/2017/adapter-model.md
+++ b/_blog/2017/adapter-model.md
@@ -1,14 +1,12 @@
 ---
-title: "Mixer Adapter Model"
-overview: Provides an overview of the Mixer plug-in architecture
+title: Mixer Adapter Model
+description: Provides an overview of the Mixer plug-in architecture
 publish_date: November 3, 2017
 subtitle: Extending Istio to integrate with a world of infrastructure backends
 attribution: Martin Taillefer
 
-order: 95
+weight: 95
 
-layout: blog
-type: markdown
 redirect_from: "/blog/mixer-adapter-model.html"
 ---
 {% include home.html %}

--- a/_blog/2017/index.md
+++ b/_blog/2017/index.md
@@ -1,11 +1,9 @@
 ---
 title: 2017 Posts
-overview: Blog posts for 2017
+description: Blog posts for 2017
 
-order: 20
+weight: 20
 
-layout: blog
-type: markdown
 toc: false
 ---
 

--- a/_blog/2017/mixer-spof-myth.md
+++ b/_blog/2017/mixer-spof-myth.md
@@ -1,14 +1,12 @@
 ---
-title: "Mixer and the SPOF Myth"
-overview: Improving availability and reducing latency
+title: Mixer and the SPOF Myth
+description: Improving availability and reducing latency
 publish_date: December 7, 2017
 subtitle: Improving availability and reducing latency
 attribution: Martin Taillefer
 
-order: 94
+weight: 94
 
-layout: blog
-type: markdown
 redirect_from: /blog/posts/2017/mixer-spof-myth.html
 ---
 {% include home.html %}

--- a/_blog/2018/aws-nlb.md
+++ b/_blog/2018/aws-nlb.md
@@ -1,14 +1,12 @@
 ---
-title: "Configuring Istio Ingress with AWS NLB"
-overview: Describes how to configure Istio ingress with a network load balancer on AWS
+title: Configuring Istio Ingress with AWS NLB
+description: Describes how to configure Istio ingress with a network load balancer on AWS
 publish_date: April 20, 2018
 subtitle: Ingress AWS Network Load Balancer
 attribution: Julien SENON
 
-order: 89
+weight: 89
 
-layout: blog
-type: markdown
 redirect_from: "/blog/aws-nlb.html"
 ---
 {% include home.html %}

--- a/_blog/2018/egress-https.md
+++ b/_blog/2018/egress-https.md
@@ -1,14 +1,12 @@
 ---
-title: "Consuming External Web Services"
-overview: Describes a simple scenario based on Istio Bookinfo sample
+title: Consuming External Web Services
+description: Describes a simple scenario based on Istio Bookinfo sample
 publish_date: January 31, 2018
 subtitle: Egress Rules for HTTPS traffic
 attribution: Vadim Eisenberg
 
-order: 93
+weight: 93
 
-layout: blog
-type: markdown
 redirect_from: "/blog/egress-https.html"
 ---
 {% include home.html %}

--- a/_blog/2018/egress-tcp.md
+++ b/_blog/2018/egress-tcp.md
@@ -1,14 +1,12 @@
 ---
-title: "Consuming External TCP Services"
-overview: Describes a simple scenario based on Istio Bookinfo sample
+title: Consuming External TCP Services
+description: Describes a simple scenario based on Istio Bookinfo sample
 publish_date: February 6, 2018
 subtitle: Egress rules for TCP traffic
 attribution: Vadim Eisenberg
 
-order: 92
+weight: 92
 
-layout: blog
-type: markdown
 redirect_from: "/blog/egress-tcp.html"
 ---
 {% include home.html %}

--- a/_blog/2018/index.md
+++ b/_blog/2018/index.md
@@ -1,11 +1,9 @@
 ---
 title: 2018 Posts
-overview: Blog posts for 2018
+description: Blog posts for 2018
 
-order: 10
+weight: 10
 
-layout: blog
-type: markdown
 toc: false
 ---
 

--- a/_blog/2018/soft-multitenancy.md
+++ b/_blog/2018/soft-multitenancy.md
@@ -1,14 +1,12 @@
 ---
-title: "Istio Soft Multi-tenancy Support"
-overview: Using Kubernetes namespace and RBAC to create an Istio soft multi-tenancy environment
+title: Istio Soft Multi-tenancy Support
+description: Using Kubernetes namespace and RBAC to create an Istio soft multi-tenancy environment
 publish_date: April 19, 2018
 subtitle: Using multiple Istio control planes and RBAC to create multi-tenancy
 attribution: John Joyce and Rich Curran
 
-order: 90
+weight: 90
 
-layout: blog
-type: markdown
 redirect_from: "/blog/soft-multitenancy.html"
 ---
 {% include home.html %}

--- a/_blog/2018/traffic-mirroring.md
+++ b/_blog/2018/traffic-mirroring.md
@@ -1,14 +1,12 @@
 ---
-title: "Traffic Mirroring with Istio for Testing in Production"
-overview: An introduction to safer, lower-risk deployments and release to production
+title: Traffic Mirroring with Istio for Testing in Production
+description: An introduction to safer, lower-risk deployments and release to production
 publish_date: February 8, 2018
 subtitle: Routing rules for HTTP traffic
 attribution: Christian Posta
 
-order: 91
+weight: 91
 
-layout: blog
-type: markdown
 redirect_from: "/blog/traffic-mirroring.html"
 ---
 {% include home.html %}

--- a/_blog/2018/v1alpha3-routing.md
+++ b/_blog/2018/v1alpha3-routing.md
@@ -1,14 +1,12 @@
 ---
-title: "Introducing the Istio v1alpha3 routing API"
-overview: Introduction, motivation and design principles for the Istio v1alpha3 routing API. 
+title: Introducing the Istio v1alpha3 routing API
+description: Introduction, motivation and design principles for the Istio v1alpha3 routing API.
 publish_date: April 25, 2018
 subtitle:
 attribution: Frank Budinsky (IBM) and Shriram Rajagopalan (VMware)
 
-order: 88
+weight: 88
 
-layout: blog
-type: markdown
 redirect_from: "/blog/v1alpha3-routing.html"
 ---
 

--- a/_blog/index.html
+++ b/_blog/index.html
@@ -1,6 +1,6 @@
 ---
 title: Istio Blog
-overview: The Istio blog
+description: The Istio blog
 layout: compress
 ---
 {% include latest_blog_post.html %}

--- a/_config.yml
+++ b/_config.yml
@@ -42,6 +42,32 @@ plugins:
   - jekyll-redirect-from
   - jekyll-sitemap
 
+defaults:
+  -
+    scope:
+      path: ""
+      type: "about"
+    values:
+      layout: "about"
+  -
+    scope:
+      path: ""
+      type: "docs"
+    values:
+      layout: "docs"
+  -
+    scope:
+      path: ""
+      type: "help"
+    values:
+      layout: "help"
+  -
+    scope:
+      path: ""
+      type: "blog"
+    values:
+      layout: "blog"
+
 exclude:
   - README.md
   - LICENSE

--- a/_docs/concepts/index.md
+++ b/_docs/concepts/index.md
@@ -1,11 +1,9 @@
 ---
 title: Concepts
-overview: Concepts help you learn about the different parts of the Istio system and the abstractions it uses.
+description: Concepts help you learn about the different parts of the Istio system and the abstractions it uses.
 
-order: 10
+weight: 10
 
-layout: docs
-type: markdown
 toc: false
 ---
 

--- a/_docs/concepts/policy-and-control/attributes.md
+++ b/_docs/concepts/policy-and-control/attributes.md
@@ -1,11 +1,9 @@
 ---
 title: Attributes
-overview: Explains the important notion of attributes, which is a central mechanism for how policies and control are applied to services within the mesh.
+description: Explains the important notion of attributes, which is a central mechanism for how policies and control are applied to services within the mesh.
 
-order: 10
+weight: 10
 
-layout: docs
-type: markdown
 ---
 {% include home.html %}
 

--- a/_docs/concepts/policy-and-control/index.md
+++ b/_docs/concepts/policy-and-control/index.md
@@ -1,11 +1,9 @@
 ---
 title: Policies and Control
-overview: Introduces the policy control mechanisms.
+description: Introduces the policy control mechanisms.
 
-order: 40
+weight: 40
 
-layout: docs
-type: markdown
 toc: false
 ---
 

--- a/_docs/concepts/policy-and-control/mixer-config.md
+++ b/_docs/concepts/policy-and-control/mixer-config.md
@@ -1,11 +1,9 @@
 ---
 title: Mixer Configuration
-overview: An overview of the key concepts used to configure Mixer.
+description: An overview of the key concepts used to configure Mixer.
 
-order: 30
+weight: 30
 
-layout: docs
-type: markdown
 ---
 {% include home.html %}
 

--- a/_docs/concepts/policy-and-control/mixer.md
+++ b/_docs/concepts/policy-and-control/mixer.md
@@ -1,11 +1,9 @@
 ---
 title: Mixer
-overview: Architectural deep-dive into the design of Mixer, which provides the policy and control mechanisms within the service mesh.
+description: Architectural deep-dive into the design of Mixer, which provides the policy and control mechanisms within the service mesh.
 
-order: 20
+weight: 20
 
-layout: docs
-type: markdown
 ---
 
 {% include home.html %}

--- a/_docs/concepts/security/authn-policy.md
+++ b/_docs/concepts/security/authn-policy.md
@@ -1,11 +1,9 @@
 ---
 title: Istio Authentication Policy
-overview: Describes Istio authentication policy
+description: Describes Istio authentication policy
 
-order: 10
+weight: 10
 
-layout: docs
-type: markdown
 ---
 {% include home.html %}
 

--- a/_docs/concepts/security/index.md
+++ b/_docs/concepts/security/index.md
@@ -1,11 +1,9 @@
 ---
 title: Security
-overview: Describes Istio's authorization and authentication functionality.
+description: Describes Istio's authorization and authentication functionality.
 
-order: 30
+weight: 30
 
-layout: docs
-type: markdown
 toc: false
 ---
 

--- a/_docs/concepts/security/mutual-tls.md
+++ b/_docs/concepts/security/mutual-tls.md
@@ -1,10 +1,8 @@
 ---
 title: Mutual TLS Authentication
-overview: Describes Istio's mutual TLS authentication architecture which provides a strong service identity and secure communication channels between services.
-order: 10
+description: Describes Istio's mutual TLS authentication architecture which provides a strong service identity and secure communication channels between services.
+weight: 10
 
-layout: docs
-type: markdown
 ---
 
 {% include home.html %}

--- a/_docs/concepts/security/rbac.md
+++ b/_docs/concepts/security/rbac.md
@@ -1,10 +1,8 @@
 ---
 title: Istio Role-Based Access Control (RBAC)
-overview: Describes Istio RBAC which provides access control for services in Istio Mesh.
-order: 20
+description: Describes Istio RBAC which provides access control for services in Istio Mesh.
+weight: 20
 
-layout: docs
-type: markdown
 ---
 {% include home.html %}
 

--- a/_docs/concepts/traffic-management/fault-injection.md
+++ b/_docs/concepts/traffic-management/fault-injection.md
@@ -1,11 +1,9 @@
 ---
 title: Fault Injection
-overview: Introduces the idea of systematic fault injection that can be used to uncover conflicting failure recovery policies across services.
+description: Introduces the idea of systematic fault injection that can be used to uncover conflicting failure recovery policies across services.
 
-order: 40
+weight: 40
 
-layout: docs
-type: markdown
 toc: false
 ---
 

--- a/_docs/concepts/traffic-management/handling-failures.md
+++ b/_docs/concepts/traffic-management/handling-failures.md
@@ -1,11 +1,9 @@
 ---
 title: Handling Failures
-overview: An overview of failure recovery capabilities in Envoy that can be leveraged by unmodified applications to improve robustness and prevent cascading failures.
+description: An overview of failure recovery capabilities in Envoy that can be leveraged by unmodified applications to improve robustness and prevent cascading failures.
 
-order: 30
+weight: 30
 
-layout: docs
-type: markdown
 ---
 {% include home.html %}
 

--- a/_docs/concepts/traffic-management/index.md
+++ b/_docs/concepts/traffic-management/index.md
@@ -1,11 +1,9 @@
 ---
 title: Traffic Management
-overview: Describes the various Istio features focused on traffic routing and control.
+description: Describes the various Istio features focused on traffic routing and control.
 
-order: 20
+weight: 20
 
-layout: docs
-type: markdown
 toc: false
 ---
 

--- a/_docs/concepts/traffic-management/load-balancing.md
+++ b/_docs/concepts/traffic-management/load-balancing.md
@@ -1,11 +1,9 @@
 ---
 title: Discovery & Load Balancing
-overview: Describes how traffic is load balanced across instances of a service in the mesh.
+description: Describes how traffic is load balanced across instances of a service in the mesh.
 
-order: 25
+weight: 25
 
-layout: docs
-type: markdown
 toc: false
 ---
 

--- a/_docs/concepts/traffic-management/overview.md
+++ b/_docs/concepts/traffic-management/overview.md
@@ -1,11 +1,9 @@
 ---
 title: Overview
-overview: Provides a conceptual overview of traffic management in Istio and the features it enables.
+description: Provides a conceptual overview of traffic management in Istio and the features it enables.
 
-order: 0
+weight: 1
 
-layout: docs
-type: markdown
 ---
 
 {% include home.html %}

--- a/_docs/concepts/traffic-management/pilot.md
+++ b/_docs/concepts/traffic-management/pilot.md
@@ -1,11 +1,9 @@
 ---
 title: Pilot
-overview: Introduces Pilot, the component responsible for managing a distributed deployment of Envoy proxies in the service mesh.
+description: Introduces Pilot, the component responsible for managing a distributed deployment of Envoy proxies in the service mesh.
 
-order: 10
+weight: 10
 
-layout: docs
-type: markdown
 toc: false
 redirect_from: /docs/concepts/traffic-management/manager.html
 ---

--- a/_docs/concepts/traffic-management/request-routing.md
+++ b/_docs/concepts/traffic-management/request-routing.md
@@ -1,11 +1,9 @@
 ---
 title: Request Routing
-overview: Describes how requests are routed between services in an Istio service mesh.
+description: Describes how requests are routed between services in an Istio service mesh.
 
-order: 20
+weight: 20
 
-layout: docs
-type: markdown
 ---
 {% include home.html %}
 

--- a/_docs/concepts/traffic-management/rules-configuration.md
+++ b/_docs/concepts/traffic-management/rules-configuration.md
@@ -1,11 +1,9 @@
 ---
 title: Rules Configuration
-overview: Provides a high-level overview of the domain-specific language used by Istio to configure traffic management rules in the service mesh.
+description: Provides a high-level overview of the domain-specific language used by Istio to configure traffic management rules in the service mesh.
 
-order: 50
+weight: 50
 
-layout: docs
-type: markdown
 ---
 {% include home.html %}
 

--- a/_docs/concepts/what-is-istio/goals.md
+++ b/_docs/concepts/what-is-istio/goals.md
@@ -1,11 +1,9 @@
 ---
 title: Design Goals
-overview: Describes the core principles that Istio's design adheres to.
+description: Describes the core principles that Istio's design adheres to.
 
-order: 20
+weight: 20
 
-layout: docs
-type: markdown
 ---
 
 This page outlines the core principles that guide Istio's design.

--- a/_docs/concepts/what-is-istio/index.md
+++ b/_docs/concepts/what-is-istio/index.md
@@ -1,11 +1,9 @@
 ---
 title: What is Istio?
-overview: A broad overview of the Istio system.
+description: A broad overview of the Istio system.
 
-order: 10
+weight: 10
 
-layout: docs
-type: markdown
 toc: false
 ---
 

--- a/_docs/concepts/what-is-istio/overview.md
+++ b/_docs/concepts/what-is-istio/overview.md
@@ -1,11 +1,9 @@
 ---
 title: Overview
-overview: Provides a conceptual introduction to Istio, including the problems it solves and its high-level architecture.
+description: Provides a conceptual introduction to Istio, including the problems it solves and its high-level architecture.
 
-order: 15
+weight: 15
 
-layout: docs
-type: markdown
 ---
 {% include home.html %}
 

--- a/_docs/guides/bookinfo.md
+++ b/_docs/guides/bookinfo.md
@@ -1,11 +1,9 @@
 ---
 1;95;0ctitle: Bookinfo Sample Application
-overview: This guide deploys a sample application composed of four separate microservices which will be used to demonstrate various features of the Istio service mesh.
+description: This guide deploys a sample application composed of four separate microservices which will be used to demonstrate various features of the Istio service mesh.
 
-order: 10
+weight: 10
 
-layout: docs
-type: markdown
 ---
 {% include home.html %}
 

--- a/_docs/guides/endpoints.md
+++ b/_docs/guides/endpoints.md
@@ -1,10 +1,8 @@
 ---
 title: Install Istio for Google Cloud Endpoints Services
-overview: Explains how to manually integrate Google Cloud Endpoints services with Istio.
+description: Explains how to manually integrate Google Cloud Endpoints services with Istio.
 
-order: 42
-layout: docs
-type: markdown
+weight: 42
 ---
 {% include home.html %}
 

--- a/_docs/guides/index.md
+++ b/_docs/guides/index.md
@@ -1,11 +1,9 @@
 ---
 title: Guides
-overview: Guides include a variety of fully working example uses for Istio that you can experiment with.
+description: Guides include a variety of fully working example uses for Istio that you can experiment with.
 
-order: 30
+weight: 30
 
-layout: docs
-type: markdown
 toc: false
 ---
 

--- a/_docs/guides/integrating-vms.md
+++ b/_docs/guides/integrating-vms.md
@@ -1,10 +1,8 @@
 ---
 title: Integrating Virtual Machines
-overview: This sample deploys the Bookinfo services across Kubernetes and a set of virtual machines, and illustrates how to use the Istio service mesh to control this infrastructure as a single mesh.
+description: This sample deploys the Bookinfo services across Kubernetes and a set of virtual machines, and illustrates how to use the Istio service mesh to control this infrastructure as a single mesh.
 
-order: 60
-layout: docs
-type: markdown
+weight: 60
 ---
 {% include home.html %}
 

--- a/_docs/guides/intelligent-routing.md
+++ b/_docs/guides/intelligent-routing.md
@@ -1,10 +1,8 @@
 ---
 title: Intelligent Routing
-overview: This guide demonstrates how to use various traffic management capabilities of an Istio service mesh.
+description: This guide demonstrates how to use various traffic management capabilities of an Istio service mesh.
 
-order: 20
-layout: docs
-type: markdown
+weight: 20
 ---
 {% include home.html %}
 

--- a/_docs/guides/policy-enforcement.md
+++ b/_docs/guides/policy-enforcement.md
@@ -1,11 +1,9 @@
 ---
 title: Policy Enforcement
-overview: This sample uses the Bookinfo application to demonstrate policy enforcement using Istio Mixer.
+description: This sample uses the Bookinfo application to demonstrate policy enforcement using Istio Mixer.
 
-order: 40
+weight: 40
 draft: true
-layout: docs
-type: markdown
 ---
 {% include home.html %}
 

--- a/_docs/guides/security.md
+++ b/_docs/guides/security.md
@@ -1,11 +1,9 @@
 ---
 title: Security
-overview: This sample demonstrates how to obtain uniform metrics, logs, traces across different services using Istio Mixer and Istio sidecar.
+description: This sample demonstrates how to obtain uniform metrics, logs, traces across different services using Istio Mixer and Istio sidecar.
 
-order: 30
+weight: 30
 draft: true
-layout: docs
-type: markdown
 ---
 {% include home.html %}
 

--- a/_docs/guides/telemetry.md
+++ b/_docs/guides/telemetry.md
@@ -1,10 +1,8 @@
 ---
 title: In-Depth Telemetry
-overview: This sample demonstrates how to obtain uniform metrics, logs, traces across different services using Istio Mixer and Istio sidecar.
+description: This sample demonstrates how to obtain uniform metrics, logs, traces across different services using Istio Mixer and Istio sidecar.
 
-order: 30
-layout: docs
-type: markdown
+weight: 30
 ---
 {% include home.html %}
 

--- a/_docs/guides/using-external-services.md
+++ b/_docs/guides/using-external-services.md
@@ -1,11 +1,9 @@
 ---
 title: Integrating with External Services
-overview: This sample integrates third party services with Bookinfo and demonstrates how to use Istio service mesh to provide metrics, and routing functions for these services.
+description: This sample integrates third party services with Bookinfo and demonstrates how to use Istio service mesh to provide metrics, and routing functions for these services.
 
-order: 50
+weight: 50
 draft: true
-layout: docs
-type: markdown
 ---
 {% include home.html %}
 

--- a/_docs/index.md
+++ b/_docs/index.md
@@ -1,11 +1,9 @@
 ---
 title: Welcome
-overview: Istio documentation home page.
+description: Istio documentation home page.
 
-order: 0
+weight: 1
 
-layout: docs
-type: markdown
 toc: false
 ---
 {% include home.html %}

--- a/_docs/reference/api/index.md
+++ b/_docs/reference/api/index.md
@@ -1,11 +1,9 @@
 ---
 title: API
-overview: Detailed information on API parameters.
+description: Detailed information on API parameters.
 
-order: 10
+weight: 10
 
-layout: docs
-type: markdown
 toc: false
 ---
 

--- a/_docs/reference/api/istio.mixer.v1.html
+++ b/_docs/reference/api/istio.mixer.v1.html
@@ -1,6 +1,6 @@
 ---
 title: Mixer
-overview: API definitions to interact with Mixer
+description: API definitions to interact with Mixer
 location: https://istio.io/docs/reference/api/istio.mixer.v1.html
 layout: protoc-gen-docs
 redirect_from: /docs/reference/api/mixer/mixer.html

--- a/_docs/reference/commands/index.md
+++ b/_docs/reference/commands/index.md
@@ -1,11 +1,9 @@
 ---
 title: Commands
-overview: Describes usage and options of the Istio commands and utilities.
+description: Describes usage and options of the Istio commands and utilities.
 
-order: 30
+weight: 30
 
-layout: docs
-type: markdown
 toc: false
 ---
 

--- a/_docs/reference/commands/istio_ca.html
+++ b/_docs/reference/commands/istio_ca.html
@@ -1,6 +1,6 @@
 ---
 title: istio_ca
-overview: Istio Certificate Authority (CA)
+description: Istio Certificate Authority (CA)
 layout: pkg-collateral-docs
 number_of_entries: 4
 ---

--- a/_docs/reference/commands/istioctl.html
+++ b/_docs/reference/commands/istioctl.html
@@ -1,6 +1,6 @@
 ---
 title: istioctl
-overview: Istio control interface
+description: Istio control interface
 layout: pkg-collateral-docs
 number_of_entries: 19
 ---

--- a/_docs/reference/commands/mixc.html
+++ b/_docs/reference/commands/mixc.html
@@ -1,6 +1,6 @@
 ---
 title: mixc
-overview: Utility to trigger direct calls to Mixer&#39;s API.
+description: Utility to trigger direct calls to Mixer&#39;s API.
 layout: pkg-collateral-docs
 number_of_entries: 5
 ---

--- a/_docs/reference/commands/mixs.html
+++ b/_docs/reference/commands/mixs.html
@@ -1,6 +1,6 @@
 ---
 title: mixs
-overview: Mixer is Istio&#39;s abstraction on top of infrastructure backends.
+description: Mixer is Istio&#39;s abstraction on top of infrastructure backends.
 layout: pkg-collateral-docs
 number_of_entries: 9
 ---

--- a/_docs/reference/commands/node_agent.html
+++ b/_docs/reference/commands/node_agent.html
@@ -1,6 +1,6 @@
 ---
 title: node_agent
-overview: Istio security per-node agent
+description: Istio security per-node agent
 layout: pkg-collateral-docs
 number_of_entries: 3
 ---

--- a/_docs/reference/commands/pilot-agent.html
+++ b/_docs/reference/commands/pilot-agent.html
@@ -1,6 +1,6 @@
 ---
 title: pilot-agent
-overview: Istio Pilot agent
+description: Istio Pilot agent
 layout: pkg-collateral-docs
 number_of_entries: 5
 ---

--- a/_docs/reference/commands/pilot-discovery.html
+++ b/_docs/reference/commands/pilot-discovery.html
@@ -1,6 +1,6 @@
 ---
 title: pilot-discovery
-overview: Istio Pilot
+description: Istio Pilot
 layout: pkg-collateral-docs
 number_of_entries: 5
 ---

--- a/_docs/reference/commands/sidecar-injector.html
+++ b/_docs/reference/commands/sidecar-injector.html
@@ -1,6 +1,6 @@
 ---
 title: sidecar-injector
-overview: Kubernetes webhook for automatic Istio sidecar injection
+description: Kubernetes webhook for automatic Istio sidecar injection
 layout: pkg-collateral-docs
 number_of_entries: 4
 ---

--- a/_docs/reference/config/adapters/circonus.html
+++ b/_docs/reference/config/adapters/circonus.html
@@ -1,6 +1,6 @@
 ---
 title: Circonus
-overview: Adapter for circonus.com's monitoring solution.
+description: Adapter for circonus.com's monitoring solution.
 location: https://istio.io/docs/reference/config/adapters/circonus.html
 layout: protoc-gen-docs
 number_of_entries: 3

--- a/_docs/reference/config/adapters/cloudwatch.html
+++ b/_docs/reference/config/adapters/cloudwatch.html
@@ -1,6 +1,6 @@
 ---
 title: CloudWatch
-overview: Adapter for cloudwatch metrics.
+description: Adapter for cloudwatch metrics.
 location: https://istio.io/docs/reference/config/adapters/cloudwatch.html
 layout: protoc-gen-docs
 number_of_entries: 3

--- a/_docs/reference/config/adapters/datadog.html
+++ b/_docs/reference/config/adapters/datadog.html
@@ -1,6 +1,6 @@
 ---
 title: Datadog
-overview: Adapter to deliver metrics to a dogstatsd agent for delivery to DataDog
+description: Adapter to deliver metrics to a dogstatsd agent for delivery to DataDog
 location: https://istio.io/docs/reference/config/adapters/datadog.html
 layout: protoc-gen-docs
 number_of_entries: 3

--- a/_docs/reference/config/adapters/denier.html
+++ b/_docs/reference/config/adapters/denier.html
@@ -1,6 +1,6 @@
 ---
 title: Denier
-overview: Adapter that always returns a precondition denial.
+description: Adapter that always returns a precondition denial.
 location: https://istio.io/docs/reference/config/adapters/denier.html
 layout: protoc-gen-docs
 number_of_entries: 2

--- a/_docs/reference/config/adapters/fluentd.html
+++ b/_docs/reference/config/adapters/fluentd.html
@@ -1,6 +1,6 @@
 ---
 title: Fluentd
-overview: Adapter that delivers logs to a fluentd daemon.
+description: Adapter that delivers logs to a fluentd daemon.
 location: https://istio.io/docs/reference/config/adapters/fluentd.html
 layout: protoc-gen-docs
 number_of_entries: 1

--- a/_docs/reference/config/adapters/index.md
+++ b/_docs/reference/config/adapters/index.md
@@ -1,11 +1,9 @@
 ---
 title: Adapters
-overview: Documentation for Mixer's adapters.
+description: Documentation for Mixer's adapters.
 
-order: 40
+weight: 40
 
-layout: docs
-type: markdown
 toc: false
 ---
 

--- a/_docs/reference/config/adapters/kubernetesenv.html
+++ b/_docs/reference/config/adapters/kubernetesenv.html
@@ -1,6 +1,6 @@
 ---
 title: Kubernetes Env
-overview: Adapter that extracts information from a Kubernetes environment.
+description: Adapter that extracts information from a Kubernetes environment.
 location: https://istio.io/docs/reference/config/adapters/kubernetesenv.html
 layout: protoc-gen-docs
 number_of_entries: 1

--- a/_docs/reference/config/adapters/list.html
+++ b/_docs/reference/config/adapters/list.html
@@ -1,6 +1,6 @@
 ---
 title: List
-overview: Adapter that performs whitelist or blacklist checks
+description: Adapter that performs whitelist or blacklist checks
 location: https://istio.io/docs/reference/config/adapters/list.html
 layout: protoc-gen-docs
 number_of_entries: 2

--- a/_docs/reference/config/adapters/memquota.html
+++ b/_docs/reference/config/adapters/memquota.html
@@ -1,6 +1,6 @@
 ---
 title: Memory quota
-overview: Adapter for a simple in-memory quota management system.
+description: Adapter for a simple in-memory quota management system.
 location: https://istio.io/docs/reference/config/adapters/memquota.html
 layout: protoc-gen-docs
 number_of_entries: 3

--- a/_docs/reference/config/adapters/opa.html
+++ b/_docs/reference/config/adapters/opa.html
@@ -1,6 +1,6 @@
 ---
 title: OPA
-overview: Adapter that implements an Open Policy Agent engine
+description: Adapter that implements an Open Policy Agent engine
 location: https://istio.io/docs/reference/config/adapters/opa.html
 layout: protoc-gen-docs
 number_of_entries: 1

--- a/_docs/reference/config/adapters/prometheus.html
+++ b/_docs/reference/config/adapters/prometheus.html
@@ -1,6 +1,6 @@
 ---
 title: Prometheus
-overview: Adapter that exposes Istio metrics for ingestion by a Prometheus harvester.
+description: Adapter that exposes Istio metrics for ingestion by a Prometheus harvester.
 location: https://istio.io/docs/reference/config/adapters/prometheus.html
 layout: protoc-gen-docs
 number_of_entries: 7

--- a/_docs/reference/config/adapters/rbac.html
+++ b/_docs/reference/config/adapters/rbac.html
@@ -1,6 +1,6 @@
 ---
 title: RBAC
-overview: Adapter that exposes Istio's Role-Based Access Control model.
+description: Adapter that exposes Istio's Role-Based Access Control model.
 location: https://istio.io/docs/reference/config/adapters/rbac.html
 layout: protoc-gen-docs
 number_of_entries: 1

--- a/_docs/reference/config/adapters/redisquota.html
+++ b/_docs/reference/config/adapters/redisquota.html
@@ -1,6 +1,6 @@
 ---
 title: Redis Quota
-overview: Adapter for a Redis-based quota management system.
+description: Adapter for a Redis-based quota management system.
 location: https://istio.io/docs/reference/config/adapters/redisquota.html
 layout: protoc-gen-docs
 number_of_entries: 4

--- a/_docs/reference/config/adapters/servicecontrol.html
+++ b/_docs/reference/config/adapters/servicecontrol.html
@@ -1,6 +1,6 @@
 ---
 title: Service Control
-overview: Adapter that delivers logs and metrics to Google Service Control
+description: Adapter that delivers logs and metrics to Google Service Control
 location: https://istio.io/docs/reference/config/adapters/servicecontrol.html
 layout: protoc-gen-docs
 number_of_entries: 4

--- a/_docs/reference/config/adapters/solarwinds.html
+++ b/_docs/reference/config/adapters/solarwinds.html
@@ -1,6 +1,6 @@
 ---
 title: SolarWinds
-overview: Adapter to deliver logs and metrics to Papertrail and AppOptics backends
+description: Adapter to deliver logs and metrics to Papertrail and AppOptics backends
 location: https://istio.io/docs/reference/config/adapters/solarwinds.html
 layout: protoc-gen-docs
 number_of_entries: 3

--- a/_docs/reference/config/adapters/stackdriver.html
+++ b/_docs/reference/config/adapters/stackdriver.html
@@ -1,6 +1,6 @@
 ---
 title: Stackdriver
-overview: Adapter to deliver logs and metrics to Stackdriver
+description: Adapter to deliver logs and metrics to Stackdriver
 location: https://istio.io/docs/reference/config/adapters/stackdriver.html
 layout: protoc-gen-docs
 number_of_entries: 11

--- a/_docs/reference/config/adapters/statsd.html
+++ b/_docs/reference/config/adapters/statsd.html
@@ -1,6 +1,6 @@
 ---
 title: StatsD
-overview: Adapter to deliver metrics to a StatsD backend
+description: Adapter to deliver metrics to a StatsD backend
 location: https://istio.io/docs/reference/config/adapters/statsd.html
 layout: protoc-gen-docs
 number_of_entries: 3

--- a/_docs/reference/config/adapters/stdio.html
+++ b/_docs/reference/config/adapters/stdio.html
@@ -1,6 +1,6 @@
 ---
 title: Stdio
-overview: Adapter for outputting logs and metrics locally.
+description: Adapter for outputting logs and metrics locally.
 location: https://istio.io/docs/reference/config/adapters/stdio.html
 layout: protoc-gen-docs
 number_of_entries: 3

--- a/_docs/reference/config/index.md
+++ b/_docs/reference/config/index.md
@@ -1,11 +1,9 @@
 ---
 title: Configuration
-overview: Detailed information on configuration options.
+description: Detailed information on configuration options.
 
-order: 20
+weight: 20
 
-layout: docs
-type: markdown
 toc: false
 ---
 

--- a/_docs/reference/config/istio.mesh.v1alpha1.html
+++ b/_docs/reference/config/istio.mesh.v1alpha1.html
@@ -1,6 +1,6 @@
 ---
 title: Service Mesh
-overview: Configuration affecting the service mesh as a whole
+description: Configuration affecting the service mesh as a whole
 location: https://istio.io/docs/reference/config/istio.mesh.v1alpha1.html
 layout: protoc-gen-docs
 redirect_from: /docs/reference/config/service-mesh.html

--- a/_docs/reference/config/istio.networking.v1alpha3.html
+++ b/_docs/reference/config/istio.networking.v1alpha3.html
@@ -1,6 +1,6 @@
 ---
 title: Route Rules v1alpha3
-overview: Configuration affecting traffic routing
+description: Configuration affecting traffic routing
 location: https://istio.io/docs/reference/config/istio.networking.v1alpha3.html
 layout: protoc-gen-docs
 number_of_entries: 39

--- a/_docs/reference/config/istio.policy.v1beta1.html
+++ b/_docs/reference/config/istio.policy.v1beta1.html
@@ -1,6 +1,6 @@
 ---
 title: Policy and Telemetry Rules
-overview: Describes the rules used to configure Mixer's policy and telemetry features.
+description: Describes the rules used to configure Mixer's policy and telemetry features.
 location: https://istio.io/docs/reference/config/istio.policy.v1beta1.html
 layout: protoc-gen-docs
 number_of_entries: 9

--- a/_docs/reference/config/istio.rbac.v1alpha1.html
+++ b/_docs/reference/config/istio.rbac.v1alpha1.html
@@ -1,6 +1,6 @@
 ---
 title: RBAC
-overview: Configuration for Role Based Access Control
+description: Configuration for Role Based Access Control
 location: https://istio.io/docs/reference/config/istio.rbac.v1alpha1.html
 layout: protoc-gen-docs
 number_of_entries: 9

--- a/_docs/reference/config/istio.routing.v1alpha1.html
+++ b/_docs/reference/config/istio.routing.v1alpha1.html
@@ -1,6 +1,6 @@
 ---
 title: Route Rules v1alpha1
-overview: Configuration affecting traffic routing
+description: Configuration affecting traffic routing
 location: https://istio.io/docs/reference/config/istio.routing.v1alpha1.html
 layout: protoc-gen-docs
 redirect_from: /docs/reference/config/traffic-rules/routing-rules.html

--- a/_docs/reference/config/mixer/attribute-vocabulary.md
+++ b/_docs/reference/config/mixer/attribute-vocabulary.md
@@ -1,11 +1,9 @@
 ---
 title: Attribute Vocabulary
-overview: Describes the base attribute vocabulary used for policy and control.
+description: Describes the base attribute vocabulary used for policy and control.
 
-order: 10
+weight: 10
 
-layout: docs
-type: markdown
 ---
 {% include home.html %}
 

--- a/_docs/reference/config/mixer/expression-language.md
+++ b/_docs/reference/config/mixer/expression-language.md
@@ -1,11 +1,9 @@
 ---
 title: Expression Language
-overview: Mixer config expression language reference.
+description: Mixer config expression language reference.
 
-order: 20
+weight: 20
 
-layout: docs
-type: markdown
 ---
 
 {% include home.html %}

--- a/_docs/reference/config/mixer/index.md
+++ b/_docs/reference/config/mixer/index.md
@@ -1,11 +1,9 @@
 ---
 title: Mixer
-overview: Detailed information on configuration and API exposed by Mixer.
+description: Detailed information on configuration and API exposed by Mixer.
 
-order: 30
+weight: 30
 
-layout: docs
-type: markdown
 toc: false
 ---
 

--- a/_docs/reference/config/template/apikey.html
+++ b/_docs/reference/config/template/apikey.html
@@ -1,6 +1,6 @@
 ---
 title: API Key
-overview: A template that represents a single API key.
+description: A template that represents a single API key.
 location: https://istio.io/docs/reference/config/template/apikey.html
 layout: protoc-gen-docs
 number_of_entries: 2

--- a/_docs/reference/config/template/authorization.html
+++ b/_docs/reference/config/template/authorization.html
@@ -1,6 +1,6 @@
 ---
 title: Authorization
-overview: A template used to represent an access control query.
+description: A template used to represent an access control query.
 location: https://istio.io/docs/reference/config/template/authorization.html
 layout: protoc-gen-docs
 number_of_entries: 4

--- a/_docs/reference/config/template/checknothing.html
+++ b/_docs/reference/config/template/checknothing.html
@@ -1,6 +1,6 @@
 ---
 title: Check Nothing
-overview: A template that carries no data, useful for testing.
+description: A template that carries no data, useful for testing.
 location: https://istio.io/docs/reference/config/template/checknothing.html
 layout: protoc-gen-docs
 number_of_entries: 1

--- a/_docs/reference/config/template/index.md
+++ b/_docs/reference/config/template/index.md
@@ -1,11 +1,9 @@
 ---
 title: Templates
-overview: Generated documentation for Mixer's Templates.
+description: Generated documentation for Mixer's Templates.
 
-order: 50
+weight: 50
 
-layout: docs
-type: markdown
 toc: false
 ---
 

--- a/_docs/reference/config/template/kubernetes.html
+++ b/_docs/reference/config/template/kubernetes.html
@@ -1,6 +1,6 @@
 ---
 title: Kubernetes
-overview: A template that is used to control the production of Kubernetes-specific attributes.
+description: A template that is used to control the production of Kubernetes-specific attributes.
 location: https://istio.io/docs/reference/config/template/kubernetes.html
 layout: protoc-gen-docs
 number_of_entries: 3

--- a/_docs/reference/config/template/listentry.html
+++ b/_docs/reference/config/template/listentry.html
@@ -1,6 +1,6 @@
 ---
 title: List Entry
-overview: A template designed to let you perform list checking operations.
+description: A template designed to let you perform list checking operations.
 location: https://istio.io/docs/reference/config/template/listentry.html
 layout: protoc-gen-docs
 number_of_entries: 1

--- a/_docs/reference/config/template/logentry.html
+++ b/_docs/reference/config/template/logentry.html
@@ -1,6 +1,6 @@
 ---
 title: Log Entry
-overview: A template that represents a single runtime log entry.
+description: A template that represents a single runtime log entry.
 location: https://istio.io/docs/reference/config/template/logentry.html
 layout: protoc-gen-docs
 number_of_entries: 3

--- a/_docs/reference/config/template/metric.html
+++ b/_docs/reference/config/template/metric.html
@@ -1,6 +1,6 @@
 ---
 title: Metric
-overview: A template that represents a single runtime metric.
+description: A template that represents a single runtime metric.
 location: https://istio.io/docs/reference/config/template/metric.html
 layout: protoc-gen-docs
 number_of_entries: 2

--- a/_docs/reference/config/template/quota.html
+++ b/_docs/reference/config/template/quota.html
@@ -1,6 +1,6 @@
 ---
 title: Quota
-overview: A template that represents a quota allocation request
+description: A template that represents a quota allocation request
 location: https://istio.io/docs/reference/config/template/quota.html
 layout: protoc-gen-docs
 number_of_entries: 2

--- a/_docs/reference/config/template/reportnothing.html
+++ b/_docs/reference/config/template/reportnothing.html
@@ -1,6 +1,6 @@
 ---
 title: Report Nothing
-overview: A template that carries no data, useful for testing.
+description: A template that carries no data, useful for testing.
 location: https://istio.io/docs/reference/config/template/reportnothing.html
 layout: protoc-gen-docs
 number_of_entries: 1

--- a/_docs/reference/config/template/servicecontrolreport.html
+++ b/_docs/reference/config/template/servicecontrolreport.html
@@ -1,6 +1,6 @@
 ---
 title: Service Control Report
-overview: A template used by the Google Service Control adapter.
+description: A template used by the Google Service Control adapter.
 location: https://istio.io/docs/reference/config/template/servicecontrolreport.html
 layout: protoc-gen-docs
 number_of_entries: 3

--- a/_docs/reference/index.md
+++ b/_docs/reference/index.md
@@ -1,12 +1,10 @@
 ---
 title: Reference
-overview: The Reference section contains detailed authoritative reference material such as command-line options, configuration options, and API calling parameters.
+description: The Reference section contains detailed authoritative reference material such as command-line options, configuration options, and API calling parameters.
 index: true
 
-order: 60
+weight: 60
 
-layout: docs
-type: markdown
 toc: false
 ---
 

--- a/_docs/setup/cloudfoundry/index.md
+++ b/_docs/setup/cloudfoundry/index.md
@@ -1,11 +1,9 @@
 ---
 title: Cloud Foundry
-overview: Instructions for installing the Istio control plane in Cloud Foundry.
+description: Instructions for installing the Istio control plane in Cloud Foundry.
 
-order: 40
+weight: 40
 
-layout: docs
-type: markdown
 toc: false
 ---
 

--- a/_docs/setup/cloudfoundry/install.md
+++ b/_docs/setup/cloudfoundry/install.md
@@ -1,11 +1,9 @@
 ---
 title: Installation
-overview: Instructions for installing the Istio control plane in Cloud Foundry.
+description: Instructions for installing the Istio control plane in Cloud Foundry.
 
-order: 10
+weight: 10
 
-layout: docs
-type: markdown
 ---
 
 We are working with the Cloud Foundry developers to integrate Istio

--- a/_docs/setup/consul/index.md
+++ b/_docs/setup/consul/index.md
@@ -1,11 +1,9 @@
 ---
 title: Nomad & Consul
-overview: Instructions for installing the Istio control plane in a Consul based environment, with or without Nomad.
+description: Instructions for installing the Istio control plane in a Consul based environment, with or without Nomad.
 
-order: 20
+weight: 20
 
-layout: docs
-type: markdown
 toc: false
 ---
 

--- a/_docs/setup/consul/install.md
+++ b/_docs/setup/consul/install.md
@@ -1,11 +1,9 @@
 ---
 title: Installation
-overview: Instructions for installing the Istio control plane in a Consul based environment, with or without Nomad.
+description: Instructions for installing the Istio control plane in a Consul based environment, with or without Nomad.
 
-order: 30
+weight: 30
 
-layout: docs
-type: markdown
 ---
 
 > Setup on Nomad has not been tested.

--- a/_docs/setup/consul/quick-start.md
+++ b/_docs/setup/consul/quick-start.md
@@ -1,11 +1,9 @@
 ---
 title: Quick Start on Docker
-overview: Quick Start instructions to setup the Istio service mesh with Docker Compose.
+description: Quick Start instructions to setup the Istio service mesh with Docker Compose.
 
-order: 10
+weight: 10
 
-layout: docs
-type: markdown
 ---
 
 {% include home.html %}

--- a/_docs/setup/eureka/index.md
+++ b/_docs/setup/eureka/index.md
@@ -1,11 +1,9 @@
 ---
 title: Eureka
-overview: Instructions for installing the Istio control plane in a Eureka based environment.
+description: Instructions for installing the Istio control plane in a Eureka based environment.
 
-order: 30
+weight: 30
 
-layout: docs
-type: markdown
 toc: false
 ---
 

--- a/_docs/setup/eureka/install.md
+++ b/_docs/setup/eureka/install.md
@@ -1,11 +1,9 @@
 ---
 title: Installation
-overview: Instructions for installing the Istio control plane in an Eureka based environment.
+description: Instructions for installing the Istio control plane in an Eureka based environment.
 
-order: 30
+weight: 30
 
-layout: docs
-type: markdown
 ---
 
 Using Istio in a non-Kubernetes environment involves a few key tasks:

--- a/_docs/setup/eureka/quick-start.md
+++ b/_docs/setup/eureka/quick-start.md
@@ -1,11 +1,9 @@
 ---
 title: Quick Start on Docker
-overview: Quick Start instructions to setup the Istio service mesh with Docker Compose.
+description: Quick Start instructions to setup the Istio service mesh with Docker Compose.
 
-order: 10
+weight: 10
 
-layout: docs
-type: markdown
 ---
 
 {% include home.html %}

--- a/_docs/setup/index.md
+++ b/_docs/setup/index.md
@@ -1,11 +1,9 @@
 ---
 title: Setup
-overview: Setup contains instructions for installing the Istio control plane in various environments (e.g., Kubernetes, Consul, etc.), as well as instructions for installing the sidecar in the application deployment.
+description: Setup contains instructions for installing the Istio control plane in various environments (e.g., Kubernetes, Consul, etc.), as well as instructions for installing the sidecar in the application deployment.
 
-order: 15
+weight: 15
 
-layout: docs
-type: markdown
 toc: false
 ---
 

--- a/_docs/setup/kubernetes/advanced-install.md
+++ b/_docs/setup/kubernetes/advanced-install.md
@@ -1,11 +1,9 @@
 ---
 title: Advanced Install Options
-overview: Instructions for customizing the Istio installation.
+description: Instructions for customizing the Istio installation.
 
-order: 20
+weight: 20
 draft: true
-layout: docs
-type: markdown
 ---
 
 {% include home.html %}

--- a/_docs/setup/kubernetes/ansible-install.md
+++ b/_docs/setup/kubernetes/ansible-install.md
@@ -1,11 +1,9 @@
 ---
 title: Installation with Ansible
-overview: Install Istio with the included Ansible playbook.
+description: Install Istio with the included Ansible playbook.
 
-order: 40
+weight: 40
 
-layout: docs
-type: markdown
 ---
 
 {% include home.html %}

--- a/_docs/setup/kubernetes/helm-install.md
+++ b/_docs/setup/kubernetes/helm-install.md
@@ -1,13 +1,11 @@
 ---
 title: Installation with Helm
-overview: Install Istio with the included Helm chart.
+description: Install Istio with the included Helm chart.
 
-order: 30
+weight: 30
 
 redirect_from: /docs/setup/kubernetes/helm.html
 
-layout: docs
-type: markdown
 ---
 
 {% include home.html %}

--- a/_docs/setup/kubernetes/index.md
+++ b/_docs/setup/kubernetes/index.md
@@ -1,11 +1,9 @@
 ---
 title: Kubernetes
-overview: Instructions for installing the Istio control plane on Kubernetes and adding VMs into the mesh.
+description: Instructions for installing the Istio control plane on Kubernetes and adding VMs into the mesh.
 
-order: 10
+weight: 10
 
-layout: docs
-type: markdown
 redirect_from: "/docs/tasks/installing-istio.html"
 toc: false
 ---

--- a/_docs/setup/kubernetes/mesh-expansion.md
+++ b/_docs/setup/kubernetes/mesh-expansion.md
@@ -1,11 +1,9 @@
 ---
 title: Mesh Expansion
-overview: Instructions for integrating VMs and bare metal hosts into an Istio mesh deployed on Kubernetes.
+description: Instructions for integrating VMs and bare metal hosts into an Istio mesh deployed on Kubernetes.
 
-order: 60
+weight: 60
 
-layout: docs
-type: markdown
 ---
 {% include home.html %}
 

--- a/_docs/setup/kubernetes/multicluster-install.md
+++ b/_docs/setup/kubernetes/multicluster-install.md
@@ -1,11 +1,9 @@
 ---
 title: Istio Multicluster
-overview: Install Istio with multicluster support.
+description: Install Istio with multicluster support.
 
-order: 65
+weight: 65
 
-layout: docs
-type: markdown
 ---
 
 {% include home.html %}

--- a/_docs/setup/kubernetes/quick-start-gke-dm.md
+++ b/_docs/setup/kubernetes/quick-start-gke-dm.md
@@ -1,11 +1,9 @@
 ---
 title: Quick Start with Google Kubernetes Engine
-overview: Quick Start instructions to setup the Istio service using Google Kubernetes Engine (GKE)
+description: Quick Start instructions to setup the Istio service using Google Kubernetes Engine (GKE)
 
-order: 11
+weight: 11
 
-layout: docs
-type: markdown
 ---
 
 {% include home.html %}

--- a/_docs/setup/kubernetes/quick-start.md
+++ b/_docs/setup/kubernetes/quick-start.md
@@ -1,11 +1,9 @@
 ---
 title: Quick Start
-overview: Quick start instructions to setup the Istio service mesh in a Kubernetes cluster.
+description: Quick start instructions to setup the Istio service mesh in a Kubernetes cluster.
 
-order: 10
+weight: 10
 
-layout: docs
-type: markdown
 ---
 
 {% include home.html %}

--- a/_docs/setup/kubernetes/sidecar-injection.md
+++ b/_docs/setup/kubernetes/sidecar-injection.md
@@ -1,11 +1,9 @@
 ---
 title: Installing the Istio Sidecar
-overview: Instructions for installing the Istio sidecar in application pods automatically using the sidecar injector webhook or manually using istioctl CLI.
+description: Instructions for installing the Istio sidecar in application pods automatically using the sidecar injector webhook or manually using istioctl CLI.
 
-order: 50
+weight: 50
 
-layout: docs
-type: markdown
 ---
 {% include home.html %}
 

--- a/_docs/setup/kubernetes/upgrading-istio.md
+++ b/_docs/setup/kubernetes/upgrading-istio.md
@@ -1,11 +1,9 @@
 ---
 title: Upgrading Istio
-overview: This guide demonstrates how to upgrade the Istio control plane and data plane independently.
+description: This guide demonstrates how to upgrade the Istio control plane and data plane independently.
 
-order: 70
+weight: 70
 
-layout: docs
-type: markdown
 ---
 {% include home.html %}
 

--- a/_docs/setup/mesos/index.md
+++ b/_docs/setup/mesos/index.md
@@ -1,11 +1,9 @@
 ---
 title: Mesos
-overview: Instructions for installing the Istio control plane in Apache Mesos.
+description: Instructions for installing the Istio control plane in Apache Mesos.
 
-order: 50
+weight: 50
 
-layout: docs
-type: markdown
 toc: false
 ---
 

--- a/_docs/setup/mesos/install.md
+++ b/_docs/setup/mesos/install.md
@@ -1,11 +1,9 @@
 ---
 title: Installation
-overview: Instructions for installing the Istio control plane in Apache Mesos.
+description: Instructions for installing the Istio control plane in Apache Mesos.
 
-order: 10
+weight: 10
 
-layout: docs
-type: markdown
 ---
 {% include home.html %}
 

--- a/_docs/tasks/index.md
+++ b/_docs/tasks/index.md
@@ -1,11 +1,9 @@
 ---
 title: Tasks
-overview: Tasks show you how to do a single specific targeted activity with the Istio system.
+description: Tasks show you how to do a single specific targeted activity with the Istio system.
 
-order: 20
+weight: 20
 
-layout: docs
-type: markdown
 toc: false
 ---
 

--- a/_docs/tasks/policy-enforcement/index.md
+++ b/_docs/tasks/policy-enforcement/index.md
@@ -1,11 +1,9 @@
 ---
 title: Policy Enforcement
-overview: Describes tasks that demonstrate policy enforcement features.
+description: Describes tasks that demonstrate policy enforcement features.
 
-order: 20
+weight: 20
 
-layout: docs
-type: markdown
 toc: false
 ---
 

--- a/_docs/tasks/policy-enforcement/rate-limiting.md
+++ b/_docs/tasks/policy-enforcement/rate-limiting.md
@@ -1,11 +1,9 @@
 ---
 title: Enabling Rate Limits
-overview: This task shows you how to use Istio to dynamically limit the traffic to a service.
+description: This task shows you how to use Istio to dynamically limit the traffic to a service.
 
-order: 10
+weight: 10
 
-layout: docs
-type: markdown
 redirect_from: /docs/tasks/rate-limiting.html
 ---
 {% include home.html %}

--- a/_docs/tasks/security/authn-policy.md
+++ b/_docs/tasks/security/authn-policy.md
@@ -1,11 +1,9 @@
 ---
 title: Basic Istio Authentication Policy
-overview: Shows you how to use Istio authentication policy to setup mutual TLS and simple end-user authentication.
+description: Shows you how to use Istio authentication policy to setup mutual TLS and simple end-user authentication.
 
-order: 10
+weight: 10
 
-layout: docs
-type: markdown
 ---
 {% include home.html %}
 

--- a/_docs/tasks/security/basic-access-control.md
+++ b/_docs/tasks/security/basic-access-control.md
@@ -1,11 +1,9 @@
 ---
 title: Setting up Basic Access Control
-overview: This task shows how to control access to a service using the Kubernetes labels.
+description: This task shows how to control access to a service using the Kubernetes labels.
 
-order: 20
+weight: 20
 
-layout: docs
-type: markdown
 ---
 {% include home.html %}
 

--- a/_docs/tasks/security/health-check.md
+++ b/_docs/tasks/security/health-check.md
@@ -1,11 +1,9 @@
 ---
 title: Enabling Citadel health checking
-overview: This task shows how to enable Citadel health checking.
+description: This task shows how to enable Citadel health checking.
 
-order: 70
+weight: 70
 
-layout: docs
-type: markdown
 ---
 {% include home.html %}
 

--- a/_docs/tasks/security/https-overlay.md
+++ b/_docs/tasks/security/https-overlay.md
@@ -1,11 +1,9 @@
 ---
 title: Mutual TLS over HTTPS services
-overview: This task shows how to enable mTLS on HTTPS services.
+description: This task shows how to enable mTLS on HTTPS services.
 
-order: 80
+weight: 80
 
-layout: docs
-type: markdown
 ---
 {% include home.html %}
 

--- a/_docs/tasks/security/index.md
+++ b/_docs/tasks/security/index.md
@@ -1,11 +1,9 @@
 ---
 title: Security
-overview: Describes tasks that help securing the service mesh traffic.
+description: Describes tasks that help securing the service mesh traffic.
 
-order: 40
+weight: 40
 
-layout: docs
-type: markdown
 toc: false
 redirect_from: /docs/tasks/istio-auth.html
 ---

--- a/_docs/tasks/security/mutual-tls.md
+++ b/_docs/tasks/security/mutual-tls.md
@@ -1,11 +1,9 @@
 ---
 title: Testing Istio mutual TLS authentication
-overview: This task shows you how to verify and test Istio's automatic mutual TLS authentication.
+description: This task shows you how to verify and test Istio's automatic mutual TLS authentication.
 
-order: 10
+weight: 10
 
-layout: docs
-type: markdown
 ---
 {% include home.html %}
 

--- a/_docs/tasks/security/per-service-mtls.md
+++ b/_docs/tasks/security/per-service-mtls.md
@@ -1,11 +1,9 @@
 ---
 title: Per-service mutual TLS authentication control
-overview: This task shows how to change mutual TLS authentication for a single service.
+description: This task shows how to change mutual TLS authentication for a single service.
 
-order: 50
+weight: 50
 
-layout: docs
-type: markdown
 ---
 {% include home.html %}
 

--- a/_docs/tasks/security/plugin-ca-cert.md
+++ b/_docs/tasks/security/plugin-ca-cert.md
@@ -1,11 +1,9 @@
 ---
 title: Plugging in root certificate, signing certificate and key
-overview: This task shows how operators can configure Citadel with existing root certificate, signing certificate and key.
+description: This task shows how operators can configure Citadel with existing root certificate, signing certificate and key.
 
-order: 60
+weight: 60
 
-layout: docs
-type: markdown
 ---
 {% include home.html %}
 

--- a/_docs/tasks/security/role-based-access-control.md
+++ b/_docs/tasks/security/role-based-access-control.md
@@ -1,11 +1,9 @@
 ---
 title: Setting up Istio Role-Based Access Control
-overview: This task shows how to set up role-based access control for services in Istio mesh.
+description: This task shows how to set up role-based access control for services in Istio mesh.
 
-order: 40
+weight: 40
 
-layout: docs
-type: markdown
 ---
 {% include home.html %}
 

--- a/_docs/tasks/security/secure-access-control.md
+++ b/_docs/tasks/security/secure-access-control.md
@@ -1,11 +1,9 @@
 ---
 title: Setting up Secure Access Control
-overview: This task shows how to securely control access to a service using service accounts.
+description: This task shows how to securely control access to a service using service accounts.
 
-order: 30
+weight: 30
 
-layout: docs
-type: markdown
 ---
 {% include home.html %}
 

--- a/_docs/tasks/telemetry/distributed-tracing.md
+++ b/_docs/tasks/telemetry/distributed-tracing.md
@@ -1,11 +1,9 @@
 ---
 title: Distributed Tracing
-overview: How to configure the proxies to send tracing requests to Zipkin or Jaeger
+description: How to configure the proxies to send tracing requests to Zipkin or Jaeger
 
-order: 10
+weight: 10
 
-layout: docs
-type: markdown
 redirect_from: /docs/tasks/zipkin-tracing.html
 ---
 {% include home.html %}

--- a/_docs/tasks/telemetry/fluentd.md
+++ b/_docs/tasks/telemetry/fluentd.md
@@ -1,12 +1,10 @@
 ---
 title: Logging with Fluentd
 
-overview: This task shows you how to configure Istio to log to a Fluentd daemon
+description: This task shows you how to configure Istio to log to a Fluentd daemon
 
-order: 60
+weight: 60
 
-layout: docs
-type: markdown
 ---
 {% include home.html %}
 

--- a/_docs/tasks/telemetry/index.md
+++ b/_docs/tasks/telemetry/index.md
@@ -1,11 +1,9 @@
 ---
 title: Metrics, Logs, and Traces
-overview: Describes tasks that demonstrate how to collect telemetry information from the service mesh.
+description: Describes tasks that demonstrate how to collect telemetry information from the service mesh.
 
-order: 30
+weight: 30
 
-layout: docs
-type: markdown
 toc: false
 ---
 

--- a/_docs/tasks/telemetry/metrics-logs.md
+++ b/_docs/tasks/telemetry/metrics-logs.md
@@ -1,12 +1,10 @@
 ---
 title: Collecting Metrics and Logs
 
-overview: This task shows you how to configure Istio to collect metrics and logs.
+description: This task shows you how to configure Istio to collect metrics and logs.
 
-order: 20
+weight: 20
 
-layout: docs
-type: markdown
 ---
 {% include home.html %}
 

--- a/_docs/tasks/telemetry/querying-metrics.md
+++ b/_docs/tasks/telemetry/querying-metrics.md
@@ -1,12 +1,10 @@
 ---
 title: Querying Metrics from Prometheus
 
-overview: This task shows you how to query for Istio Metrics using Prometheus.
+description: This task shows you how to query for Istio Metrics using Prometheus.
 
-order: 30
+weight: 30
 
-layout: docs
-type: markdown
 ---
 {% include home.html %}
 

--- a/_docs/tasks/telemetry/servicegraph.md
+++ b/_docs/tasks/telemetry/servicegraph.md
@@ -1,12 +1,10 @@
 ---
 title: Generating a Service Graph
 
-overview: This task shows you how to generate a graph of services within an Istio mesh.
+description: This task shows you how to generate a graph of services within an Istio mesh.
 
-order: 50
+weight: 50
 
-layout: docs
-type: markdown
 ---
 {% include home.html %}
 

--- a/_docs/tasks/telemetry/tcp-metrics.md
+++ b/_docs/tasks/telemetry/tcp-metrics.md
@@ -1,12 +1,10 @@
 ---
 title: Collecting Metrics for TCP services
 
-overview: This task shows you how to configure Istio to collect metrics for TCP services.
+description: This task shows you how to configure Istio to collect metrics for TCP services.
 
-order: 25
+weight: 25
 
-layout: docs
-type: markdown
 ---
 
 {% include home.html %}

--- a/_docs/tasks/telemetry/using-istio-dashboard.md
+++ b/_docs/tasks/telemetry/using-istio-dashboard.md
@@ -1,12 +1,10 @@
 ---
 title: Visualizing Metrics with Grafana
 
-overview: This task shows you how to setup and use the Istio Dashboard to monitor mesh traffic.
+description: This task shows you how to setup and use the Istio Dashboard to monitor mesh traffic.
 
-order: 40
+weight: 40
 
-layout: docs
-type: markdown
 ---
 {% include home.html %}
 

--- a/_docs/tasks/traffic-management-v1alpha3/circuit-breaking.md
+++ b/_docs/tasks/traffic-management-v1alpha3/circuit-breaking.md
@@ -1,11 +1,9 @@
 ---
 title: Circuit Breaking
-overview: This task demonstrates the circuit-breaking capability for resilient applications
+description: This task demonstrates the circuit-breaking capability for resilient applications
 
-order: 50
+weight: 50
 
-layout: docs
-type: markdown
 ---
 {% include home.html %}
 

--- a/_docs/tasks/traffic-management-v1alpha3/egress-tcp.md
+++ b/_docs/tasks/traffic-management-v1alpha3/egress-tcp.md
@@ -1,11 +1,9 @@
 ---
 title: Control Egress TCP Traffic
-overview: Describes how to configure Istio to route TCP traffic from services in the mesh to external services.
+description: Describes how to configure Istio to route TCP traffic from services in the mesh to external services.
 
-order: 41
+weight: 41
 
-layout: docs
-type: markdown
 ---
 {% include home.html %}
 

--- a/_docs/tasks/traffic-management-v1alpha3/egress.md
+++ b/_docs/tasks/traffic-management-v1alpha3/egress.md
@@ -1,11 +1,9 @@
 ---
 title: Control Egress Traffic
-overview: Describes how to configure Istio to route traffic from services in the mesh to external services.
+description: Describes how to configure Istio to route traffic from services in the mesh to external services.
 
-order: 40
+weight: 40
 
-layout: docs
-type: markdown
 ---
 {% include home.html %}
 

--- a/_docs/tasks/traffic-management-v1alpha3/fault-injection.md
+++ b/_docs/tasks/traffic-management-v1alpha3/fault-injection.md
@@ -1,11 +1,9 @@
 ---
 title: Fault Injection
-overview: This task shows how to inject delays and test the resiliency of your application.
+description: This task shows how to inject delays and test the resiliency of your application.
 
-order: 20
+weight: 20
 
-layout: docs
-type: markdown
 ---
 {% include home.html %}
 

--- a/_docs/tasks/traffic-management-v1alpha3/index.md
+++ b/_docs/tasks/traffic-management-v1alpha3/index.md
@@ -1,11 +1,9 @@
 ---
 title: Traffic Management (v1alpha3)
-overview: WIP - Describes tasks that demonstrate traffic routing features of Istio service mesh.
+description: WIP - Describes tasks that demonstrate traffic routing features of Istio service mesh.
 
-order: 15
+weight: 15
 
-layout: docs
-type: markdown
 toc: false
 ---
 

--- a/_docs/tasks/traffic-management-v1alpha3/ingress.md
+++ b/_docs/tasks/traffic-management-v1alpha3/ingress.md
@@ -1,11 +1,9 @@
 ---
 title: Control Ingress Traffic
-overview: Describes how to configure Istio to expose a service outside of the service mesh.
+description: Describes how to configure Istio to expose a service outside of the service mesh.
 
-order: 30
+weight: 30
 
-layout: docs
-type: markdown
 redirect_from: /docs/tasks/ingress.html
 ---
 {% include home.html %}

--- a/_docs/tasks/traffic-management-v1alpha3/mirroring.md
+++ b/_docs/tasks/traffic-management-v1alpha3/mirroring.md
@@ -1,11 +1,9 @@
 ---
 title: Mirroring
-overview: This task demonstrates the traffic shadowing/mirroring capabilities of Istio
+description: This task demonstrates the traffic shadowing/mirroring capabilities of Istio
 
-order: 60
+weight: 60
 
-layout: docs
-type: markdown
 ---
 {% include home.html %}
 

--- a/_docs/tasks/traffic-management-v1alpha3/request-routing.md
+++ b/_docs/tasks/traffic-management-v1alpha3/request-routing.md
@@ -1,11 +1,9 @@
 ---
 title: Configuring Request Routing
-overview: This task shows you how to configure dynamic request routing based on weights and HTTP headers.
+description: This task shows you how to configure dynamic request routing based on weights and HTTP headers.
 
-order: 10
+weight: 10
 
-layout: docs
-type: markdown
 ---
 {% include home.html %}
 

--- a/_docs/tasks/traffic-management-v1alpha3/request-timeouts.md
+++ b/_docs/tasks/traffic-management-v1alpha3/request-timeouts.md
@@ -1,11 +1,9 @@
 ---
 title: Setting Request Timeouts
-overview: This task shows you how to setup request timeouts in Envoy using Istio.
+description: This task shows you how to setup request timeouts in Envoy using Istio.
 
-order: 28
+weight: 28
 
-layout: docs
-type: markdown
 ---
 {% include home.html %}
 

--- a/_docs/tasks/traffic-management-v1alpha3/traffic-shifting.md
+++ b/_docs/tasks/traffic-management-v1alpha3/traffic-shifting.md
@@ -1,11 +1,9 @@
 ---
 title: Traffic Shifting
-overview: This task shows you how to migrate traffic from an old to new version of a service.
+description: This task shows you how to migrate traffic from an old to new version of a service.
 
-order: 25
+weight: 25
 
-layout: docs
-type: markdown
 ---
 {% include home.html %}
 

--- a/_docs/tasks/traffic-management/circuit-breaking.md
+++ b/_docs/tasks/traffic-management/circuit-breaking.md
@@ -1,11 +1,9 @@
 ---
 title: Circuit Breaking
-overview: This task demonstrates the circuit-breaking capability for resilient applications
+description: This task demonstrates the circuit-breaking capability for resilient applications
 
-order: 50
+weight: 50
 
-layout: docs
-type: markdown
 ---
 {% include home.html %}
 

--- a/_docs/tasks/traffic-management/egress-tcp.md
+++ b/_docs/tasks/traffic-management/egress-tcp.md
@@ -1,11 +1,9 @@
 ---
 title: Control Egress TCP Traffic
-overview: Describes how to configure Istio to route TCP traffic from services in the mesh to external services.
+description: Describes how to configure Istio to route TCP traffic from services in the mesh to external services.
 
-order: 41
+weight: 41
 
-layout: docs
-type: markdown
 ---
 {% include home.html %}
 

--- a/_docs/tasks/traffic-management/egress.md
+++ b/_docs/tasks/traffic-management/egress.md
@@ -1,11 +1,9 @@
 ---
 title: Control Egress Traffic
-overview: Describes how to configure Istio to route traffic from services in the mesh to external services.
+description: Describes how to configure Istio to route traffic from services in the mesh to external services.
 
-order: 40
+weight: 40
 
-layout: docs
-type: markdown
 redirect_from: /docs/tasks/egress.html
 ---
 {% include home.html %}

--- a/_docs/tasks/traffic-management/fault-injection.md
+++ b/_docs/tasks/traffic-management/fault-injection.md
@@ -1,11 +1,9 @@
 ---
 title: Fault Injection
-overview: This task shows how to inject delays and test the resiliency of your application.
+description: This task shows how to inject delays and test the resiliency of your application.
 
-order: 20
+weight: 20
 
-layout: docs
-type: markdown
 ---
 {% include home.html %}
 

--- a/_docs/tasks/traffic-management/index.md
+++ b/_docs/tasks/traffic-management/index.md
@@ -1,11 +1,9 @@
 ---
 title: Traffic Management
-overview: Describes tasks that demonstrate traffic routing features of Istio service mesh.
+description: Describes tasks that demonstrate traffic routing features of Istio service mesh.
 
-order: 10
+weight: 10
 
-layout: docs
-type: markdown
 toc: false
 ---
 

--- a/_docs/tasks/traffic-management/ingress.md
+++ b/_docs/tasks/traffic-management/ingress.md
@@ -1,11 +1,9 @@
 ---
 title: Istio Ingress
-overview: Describes how to configure Istio Ingress on Kubernetes.
+description: Describes how to configure Istio Ingress on Kubernetes.
 
-order: 30
+weight: 30
 
-layout: docs
-type: markdown
 redirect_from: /docs/tasks/ingress.html
 ---
 {% include home.html %}

--- a/_docs/tasks/traffic-management/mirroring.md
+++ b/_docs/tasks/traffic-management/mirroring.md
@@ -1,11 +1,9 @@
 ---
 title: Mirroring
-overview: Demonstrates Istio's traffic shadowing/mirroring capabilities
+description: Demonstrates Istio's traffic shadowing/mirroring capabilities
 
-order: 60
+weight: 60
 
-layout: docs
-type: markdown
 ---
 {% include home.html %}
 

--- a/_docs/tasks/traffic-management/request-routing.md
+++ b/_docs/tasks/traffic-management/request-routing.md
@@ -1,11 +1,9 @@
 ---
 title: Configuring Request Routing
-overview: This task shows you how to configure dynamic request routing based on weights and HTTP headers.
+description: This task shows you how to configure dynamic request routing based on weights and HTTP headers.
 
-order: 10
+weight: 10
 
-layout: docs
-type: markdown
 redirect_from: /docs/tasks/request-routing.html
 ---
 {% include home.html %}

--- a/_docs/tasks/traffic-management/request-timeouts.md
+++ b/_docs/tasks/traffic-management/request-timeouts.md
@@ -1,11 +1,9 @@
 ---
 title: Setting Request Timeouts
-overview: This task shows you how to setup request timeouts in Envoy using Istio.
+description: This task shows you how to setup request timeouts in Envoy using Istio.
 
-order: 28
+weight: 28
 
-layout: docs
-type: markdown
 ---
 {% include home.html %}
 

--- a/_docs/tasks/traffic-management/traffic-shifting.md
+++ b/_docs/tasks/traffic-management/traffic-shifting.md
@@ -1,11 +1,9 @@
 ---
 title: Traffic Shifting
-overview: This task shows you how to migrate traffic from an old to new version of a service.
+description: This task shows you how to migrate traffic from an old to new version of a service.
 
-order: 25
+weight: 25
 
-layout: docs
-type: markdown
 ---
 {% include home.html %}
 

--- a/_faq/general/how-do-i-contribute.md
+++ b/_faq/general/how-do-i-contribute.md
@@ -1,7 +1,6 @@
 ---
 title: How can I contribute?
-order: 70
-type: markdown
+weight: 70
 ---
 {% include home.html %}
 

--- a/_faq/general/how-do-i-get-started.md
+++ b/_faq/general/how-do-i-get-started.md
@@ -1,7 +1,6 @@
 ---
 title: How do I get started using Istio?
-order: 30
-type: markdown
+weight: 30
 ---
 {% include home.html %}
 

--- a/_faq/general/how-was-istio-started.md
+++ b/_faq/general/how-was-istio-started.md
@@ -1,7 +1,6 @@
 ---
 title: How was Istio started?
-order: 50
-type: markdown
+weight: 50
 ---
 {% include home.html %}
 

--- a/_faq/general/istio-doesnt-work.md
+++ b/_faq/general/istio-doesnt-work.md
@@ -1,7 +1,6 @@
 ---
 title: Istio doesn't work - what do I do?
-order: 90
-type: markdown
+weight: 90
 ---
 {% include home.html %}
 

--- a/_faq/general/istio-partners-and-vendors.md
+++ b/_faq/general/istio-partners-and-vendors.md
@@ -1,7 +1,6 @@
 ---
 title: How can I discover more about Partner and Vendor opportunities?
-order: 75
-type: markdown
+weight: 75
 ---
 {% include home.html %}
 

--- a/_faq/general/roadmap.md
+++ b/_faq/general/roadmap.md
@@ -1,7 +1,6 @@
 ---
 title: What is Istio's roadmap?
-order: 140
-type: markdown
+weight: 140
 ---
 {% include home.html %}
 

--- a/_faq/general/what-deployment-environment.md
+++ b/_faq/general/what-deployment-environment.md
@@ -1,7 +1,6 @@
 ---
 title: What deployment environments are supported?
-order: 60
-type: markdown
+weight: 60
 ---
 {% include home.html %}
 

--- a/_faq/general/what-does-istio-mean.md
+++ b/_faq/general/what-does-istio-mean.md
@@ -1,7 +1,6 @@
 ---
 title: What does the word 'Istio' mean?
-order: 160
-type: markdown
+weight: 160
 ---
 {% include home.html %}
 

--- a/_faq/general/what-is-istio.md
+++ b/_faq/general/what-is-istio.md
@@ -1,7 +1,6 @@
 ---
 title: What is Istio?
-order: 10
-type: markdown
+weight: 10
 ---
 {% include home.html %}
 

--- a/_faq/general/what-is-the-license.md
+++ b/_faq/general/what-is-the-license.md
@@ -1,7 +1,6 @@
 ---
 title: What is the license?
-order: 40
-type: markdown
+weight: 40
 ---
 {% include home.html %}
 

--- a/_faq/general/where-is-the-documentation.md
+++ b/_faq/general/where-is-the-documentation.md
@@ -1,7 +1,6 @@
 ---
 title: Where is the documentation?
-order: 80
-type: markdown
+weight: 80
 ---
 {% include home.html %}
 

--- a/_faq/general/why-use-istio.md
+++ b/_faq/general/why-use-istio.md
@@ -1,7 +1,6 @@
 ---
 title: Why would I want to use Istio?
-order: 20
-type: markdown
+weight: 20
 ---
 {% include home.html %}
 

--- a/_faq/mixer/attribute-expressions.md
+++ b/_faq/mixer/attribute-expressions.md
@@ -1,7 +1,6 @@
 ---
 title: What is the full set of attribute expressions Mixer supports?
-order: 20
-type: markdown
+weight: 20
 ---
 {% include home.html %}
 

--- a/_faq/mixer/mixer-self-monitoring.md
+++ b/_faq/mixer/mixer-self-monitoring.md
@@ -1,7 +1,6 @@
 ---
 title: Does Mixer provide any self-monitoring?
-order: 30
-type: markdown
+weight: 30
 ---
 {% include home.html %}
 

--- a/_faq/mixer/seeing-mixer-config.md
+++ b/_faq/mixer/seeing-mixer-config.md
@@ -1,7 +1,6 @@
 ---
 title: How do I see all Mixer's configuration?
-order: 10
-type: markdown
+weight: 10
 ---
 {% include home.html %}
 

--- a/_faq/mixer/why-mixer.md
+++ b/_faq/mixer/why-mixer.md
@@ -1,7 +1,6 @@
 ---
 title: Why does Istio need Mixer?
-order: 0
-type: markdown
+weight: 1
 ---
 {% include home.html %}
 

--- a/_faq/mixer/writing-custom-adapters.md
+++ b/_faq/mixer/writing-custom-adapters.md
@@ -1,7 +1,6 @@
 ---
 title: How can I write a custom adapter for Mixer?
-order: 40
-type: markdown
+weight: 40
 ---
 {% include home.html %}
 

--- a/_faq/security/accessing-control-services.md
+++ b/_faq/security/accessing-control-services.md
@@ -1,7 +1,6 @@
 ---
 title: How to disable Auth on clients to access the Kubernetes API Server (or any control services that don't have Istio sidecar)?
-order: 60
-type: markdown
+weight: 60
 ---
 
 Starting with release 0.3, edit the `mtlsExcludedServices` list in Istio config

--- a/_faq/security/auth-mix-and-match.md
+++ b/_faq/security/auth-mix-and-match.md
@@ -1,7 +1,6 @@
 ---
 title: Can I enable Istio Auth with some services while disable others in the same cluster?
-order: 30
-type: markdown
+weight: 30
 ---
 Starting with release 0.3, you can use service-level annotations to disable (or enable) Istio Auth for particular service-port.
 The annotation key should be `auth.istio.io/{port_number}`, and the value should be `NONE` (to disable), or `MUTUAL_TLS` (to enable).

--- a/_faq/security/cert-lifetime-config.md
+++ b/_faq/security/cert-lifetime-config.md
@@ -1,7 +1,6 @@
 ---
 title: How to configure the lifetime for Istio certificates?
-order: 70
-type: markdown
+weight: 70
 ---
 {% include home.html %}
 

--- a/_faq/security/does-istio-support-authorization.md
+++ b/_faq/security/does-istio-support-authorization.md
@@ -1,7 +1,6 @@
 ---
 title: Does Istio Auth support authorization?
-order: 110
-type: markdown
+weight: 110
 ---
 {% include home.html %}
 

--- a/_faq/security/enabling-disabling-mtls.md
+++ b/_faq/security/enabling-disabling-mtls.md
@@ -1,7 +1,6 @@
 ---
 title: How can I enable/disable mTLS encryption after I installed Istio?
-order: 10
-type: markdown
+weight: 10
 ---
 {% include home.html %}
 

--- a/_faq/security/https-overlay.md
+++ b/_faq/security/https-overlay.md
@@ -1,7 +1,6 @@
 ---
 title: Can I install Istio sidecar for HTTPS services?
-order: 170
-type: markdown
+weight: 170
 ---
 {% include home.html %}
 

--- a/_faq/security/istio-to-not-istio.md
+++ b/_faq/security/istio-to-not-istio.md
@@ -1,6 +1,5 @@
 ---
 title: Can a service with Istio Auth enabled communicate with a service without Istio?
-order: 20
-type: markdown
+weight: 20
 ---
 This is not supported currently, but will be in the near future.

--- a/_faq/security/k8s-api-server.md
+++ b/_faq/security/k8s-api-server.md
@@ -1,7 +1,6 @@
 ---
 title: Can I access the Kubernetes API Server with Auth enabled?
-order: 50
-type: markdown
+weight: 50
 ---
 The Kubernetes API server does not support mutual TLS authentication, so
 strictly speaking: no. However, if you use version 0.3 or later, see next

--- a/_faq/security/k8s-health-checks.md
+++ b/_faq/security/k8s-health-checks.md
@@ -1,7 +1,6 @@
 ---
 title: How can I use Kubernetes liveness and readiness for service health check with Istio Auth enabled?
-order: 40
-type: markdown
+weight: 40
 ---
 If Istio Auth is enabled, http and tcp health check from kubelet will not
 work since they do not have Istio Auth issued certs. A workaround is to

--- a/_faq/security/secret-encryption.md
+++ b/_faq/security/secret-encryption.md
@@ -1,7 +1,6 @@
 ---
 title: Is the secret encrypted for workload key and cert?
-order: 125
-type: markdown
+weight: 125
 ---
 {% include home.html %}
 

--- a/_faq/security/secure-ingress.md
+++ b/_faq/security/secure-ingress.md
@@ -1,7 +1,6 @@
 ---
 title: How to configure Istio Ingress to only accept TLS traffic?
-order: 130
-type: markdown
+weight: 130
 ---
 {% include home.html %}
 

--- a/_faq/security/use-k8s-secrets.md
+++ b/_faq/security/use-k8s-secrets.md
@@ -1,7 +1,6 @@
 ---
 title: Does Istio Auth use Kubernetes secrets?
-order: 120
-type: markdown
+weight: 120
 ---
 {% include home.html %}
 

--- a/_faq/setup/consul-app-not-working.md
+++ b/_faq/setup/consul-app-not-working.md
@@ -1,7 +1,6 @@
 ---
 title: Consul - My application isn't working, where can I troubleshoot this?
-order: 40
-type: markdown
+weight: 40
 ---
 {% include home.html %}
 

--- a/_faq/setup/consul-unset-context.md
+++ b/_faq/setup/consul-unset-context.md
@@ -1,7 +1,6 @@
 ---
 title: Consul - How do I unset the context changed by istioctl at the end?
-order: 50
-type: markdown
+weight: 50
 ---
 {% include home.html %}
 

--- a/_faq/setup/eureka-app-not-working.md
+++ b/_faq/setup/eureka-app-not-working.md
@@ -1,7 +1,6 @@
 ---
 title: Eureka - My application isn't working, where can I troubleshoot this?
-order: 60
-type: markdown
+weight: 60
 ---
 {% include home.html %}
 

--- a/_faq/setup/eureka-unset-context.md
+++ b/_faq/setup/eureka-unset-context.md
@@ -1,7 +1,6 @@
 ---
 title: Eureka - How do I unset the context changed by `istioctl` at the end?
-order: 70
-type: markdown
+weight: 70
 ---
 {% include home.html %}
 

--- a/_faq/setup/k8s-checking-cluster-alpha-features.md
+++ b/_faq/setup/k8s-checking-cluster-alpha-features.md
@@ -1,7 +1,6 @@
 ---
 title: Kubernetes - How do I check if my cluster has enabled the alpha features required for automatic sidecar injection?
-order: 10
-type: markdown
+weight: 10
 ---
 {% include home.html %}
 

--- a/_faq/setup/k8s-migrating.md
+++ b/_faq/setup/k8s-migrating.md
@@ -1,7 +1,6 @@
 ---
 title: Kubernetes - Can I migrate an existing installation from Istio 0.1.x to 0.2.x?
-order: 30
-type: markdown
+weight: 30
 ---
 {% include home.html %}
 

--- a/_faq/setup/k8s-sidecar-injection-not-working.md
+++ b/_faq/setup/k8s-sidecar-injection-not-working.md
@@ -1,7 +1,6 @@
 ---
 title: Kubernetes - How can I debug problems with automatic sidecar injection?
-order: 20
-type: markdown
+weight: 20
 ---
 {% include home.html %}
 

--- a/_faq/traffic-management/ingress-with-no-route-rules.md
+++ b/_faq/traffic-management/ingress-with-no-route-rules.md
@@ -1,7 +1,6 @@
 ---
 title: Can I use standard Ingress specification without any route rules?
-order: 40
-type: markdown
+weight: 40
 ---
 {% include home.html %}
 

--- a/_faq/traffic-management/unreachable-services.md
+++ b/_faq/traffic-management/unreachable-services.md
@@ -1,7 +1,6 @@
 ---
 title: How come some of my services are unreachable after creating route rules?
-order: 30
-type: markdown
+weight: 30
 ---
 {% include home.html %}
 

--- a/_faq/traffic-management/viewing-current-rules.md
+++ b/_faq/traffic-management/viewing-current-rules.md
@@ -1,7 +1,6 @@
 ---
 title: How can I view the current route rules I have configured with Istio?
-order: 10
-type: markdown
+weight: 10
 ---
 {% include home.html %}
 

--- a/_faq/traffic-management/weighted-rules-not-working.md
+++ b/_faq/traffic-management/weighted-rules-not-working.md
@@ -1,7 +1,6 @@
 ---
 title: Why is creating a weighted route rule to split traffic between two versions of a service not working as expected?
-order: 20
-type: markdown
+weight: 20
 ---
 {% include home.html %}
 

--- a/_glossary/adapters.md
+++ b/_glossary/adapters.md
@@ -1,6 +1,5 @@
 ---
 title: Adapters
-type: markdown
 ---
 {% include home.html %}
 

--- a/_glossary/attribute.md
+++ b/_glossary/attribute.md
@@ -1,6 +1,5 @@
 ---
 title: Attribute
-type: markdown
 ---
 {% include home.html %}
 

--- a/_glossary/destination.md
+++ b/_glossary/destination.md
@@ -1,6 +1,5 @@
 ---
 title: Destination
-type: markdown
 ---
 The remote upstream service [Envoy](#envoy) is talking to on behalf of a [source](#source) [workload](#workload).
 There can be one or more [service versions](#service-version) for a given [service](#service) and Envoy chooses the version based on

--- a/_glossary/envoy.md
+++ b/_glossary/envoy.md
@@ -1,6 +1,5 @@
 ---
 title: Envoy
-type: markdown
 ---
 The high-performance proxy that Istio uses to mediate inbound and outbound traffic for all [services](#service) in the
 [service mesh](#service-mesh). [Learn more about Envoy](https://envoyproxy.github.io/envoy/).

--- a/_glossary/mixer-handler.md
+++ b/_glossary/mixer-handler.md
@@ -1,6 +1,5 @@
 ---
 title: Mixer Handler
-type: markdown
 ---
 {% include home.html %}
 

--- a/_glossary/mixer-instance.md
+++ b/_glossary/mixer-instance.md
@@ -1,6 +1,5 @@
 ---
 title: Mixer Instance
-type: markdown
 ---
 {% include home.html %}
 

--- a/_glossary/mixer.md
+++ b/_glossary/mixer.md
@@ -1,6 +1,5 @@
 ---
 title: Mixer
-type: markdown
 ---
 {% include home.html %}
 

--- a/_glossary/mutual-tls.md
+++ b/_glossary/mutual-tls.md
@@ -1,6 +1,5 @@
 ---
 title: Mutual TLS Authentication
-type: markdown
 ---
 {% include home.html %}
 

--- a/_glossary/pilot.md
+++ b/_glossary/pilot.md
@@ -1,5 +1,4 @@
 ---
 title: Pilot
-type: markdown
 ---
 The Istio component that programs the [Envoy](#envoy) proxies, responsible for service discovery, load balancing, and routing.

--- a/_glossary/secure-naming.md
+++ b/_glossary/secure-naming.md
@@ -1,6 +1,5 @@
 ---
 title: Secure Naming
-type: markdown
 ---
 Provides a mapping between a [service name](#service-name) and the [workload principals](#workload-principal) that are authorized to
 run the [workloads](#workload) implementing a [service](#service).

--- a/_glossary/service-consumer.md
+++ b/_glossary/service-consumer.md
@@ -1,5 +1,4 @@
 ---
 title: Service Consumer
-type: markdown
 ---
 The agent that is using a [service](#service).

--- a/_glossary/service-endpoint.md
+++ b/_glossary/service-endpoint.md
@@ -1,6 +1,5 @@
 ---
 title: Service Endpoint
-type: markdown
 ---
 The network-reachable manifestation of a [service](#service).
 Service endpoints are exposed by [workloads](#workload). Not all services have service endpoints.

--- a/_glossary/service-mesh.md
+++ b/_glossary/service-mesh.md
@@ -1,6 +1,5 @@
 ---
 title: Service Mesh
-type: markdown
 ---
 A shared set of names and identities that allows for common policy enforcement and telemetry collection.
 [Service names](#service-name) and [workload principals](#workload-principal) are unique within a service mesh.

--- a/_glossary/service-name.md
+++ b/_glossary/service-name.md
@@ -1,6 +1,5 @@
 ---
 title: Service Name
-type: markdown
 ---
 A unique name for a [service](#service), identifying it within the [service mesh](#service-mesh).
 A service may not be renamed and maintain its identity, each service name is unique.

--- a/_glossary/service-operator.md
+++ b/_glossary/service-operator.md
@@ -1,6 +1,5 @@
 ---
 title: Service Operator
-type: markdown
 ---
 The agent that manages a [service](#service) within a [service mesh](#service-mesh) by manipulating configuration state
 and monitoring the service's health via a variety of dashboards.

--- a/_glossary/service-producer.md
+++ b/_glossary/service-producer.md
@@ -1,5 +1,4 @@
 ---
 title: Service Producer
-type: markdown
 ---
 The agent that creates a [service](#service).

--- a/_glossary/service-version.md
+++ b/_glossary/service-version.md
@@ -1,6 +1,5 @@
 ---
 title: Service Version
-type: markdown
 ---
 Distinct variants of a [service](#service), typically backed by a different versions of a [workload](#workload) binary.
 Common scenarios where multiple [service versions](#service-version) may be used include A/B testing, canary rollouts, etc.

--- a/_glossary/service.md
+++ b/_glossary/service.md
@@ -1,6 +1,5 @@
 ---
 title: Service
-type: markdown
 ---
 A delineated group of related behaviors within a [service mesh](#service-mesh). Services are identified using a
 [service name](#service-name),

--- a/_glossary/source.md
+++ b/_glossary/source.md
@@ -1,6 +1,5 @@
 ---
 title: Source
-type: markdown
 ---
 The downstream client of the [Envoy](#envoy) proxy.
 Within the [service mesh](#service-mesh) a source is typically a

--- a/_glossary/workload-id.md
+++ b/_glossary/workload-id.md
@@ -1,6 +1,5 @@
 ---
 title: Workload ID
-type: markdown
 ---
 A unique identifier for an individual instance of a [workload](#workload).
 Like [workload name](#workload-name), the workload ID is not a strongly verified property and should not be used

--- a/_glossary/workload-name.md
+++ b/_glossary/workload-name.md
@@ -1,6 +1,5 @@
 ---
 title: Workload Name
-type: markdown
 ---
 A unique name for a [workload](#workload), identifying it within the [service mesh](#service-mesh).
 Unlike the [service name](#service-name) and the [workload principal], the workload name is not a

--- a/_glossary/workload-principal.md
+++ b/_glossary/workload-principal.md
@@ -1,6 +1,5 @@
 ---
 title: Workload Principal
-type: markdown
 ---
 Identifies the verifiable authority under which a [workload](#workload) runs.
 Istio's service-to-service authentication is used to produce the workload principal.

--- a/_glossary/workload.md
+++ b/_glossary/workload.md
@@ -1,6 +1,5 @@
 ---
 title: Workload
-type: markdown
 ---
 A process/binary deployed by operators in Istio, typically represented by entities such as containers, pods, or VMs.
   * A workload can expose zero or more [service endpoints](#service-endpoint).

--- a/_help/bugs.md
+++ b/_help/bugs.md
@@ -1,11 +1,9 @@
 ---
 title: Reporting Bugs
-overview: What to do about bugs
+description: What to do about bugs
 
-order: 35
+weight: 35
 
-layout: help
-type: markdown
 redirect_from: /bugs
 toc: false
 ---

--- a/_help/faq/general.html
+++ b/_help/faq/general.html
@@ -1,8 +1,8 @@
 ---
 title: General
-overview: General Q&amp;A
+description: General Q&amp;A
 
-order: 10
+weight: 10
 
 layout: help
 ---

--- a/_help/faq/index.md
+++ b/_help/faq/index.md
@@ -1,11 +1,9 @@
 ---
 title: FAQ
-overview: Frequently Asked Questions about Istio.
+description: Frequently Asked Questions about Istio.
 
-order: 20
+weight: 20
 
-layout: help
-type: markdown
 toc: false
 
 redirect_from:

--- a/_help/faq/mixer.html
+++ b/_help/faq/mixer.html
@@ -1,8 +1,8 @@
 ---
 title: Mixer
-overview: Mixer Q&amp;A
+description: Mixer Q&amp;A
 
-order: 40
+weight: 40
 
 layout: help
 ---

--- a/_help/faq/security.html
+++ b/_help/faq/security.html
@@ -1,8 +1,8 @@
 ---
 title: Security
-overview: Security Q&amp;A
+description: Security Q&amp;A
 
-order: 30
+weight: 30
 
 layout: help
 ---

--- a/_help/faq/setup.html
+++ b/_help/faq/setup.html
@@ -1,8 +1,8 @@
 ---
 title: Setup
-overview: Setup Q&amp;A
+description: Setup Q&amp;A
 
-order: 20
+weight: 20
 
 layout: help
 ---

--- a/_help/faq/traffic-management.html
+++ b/_help/faq/traffic-management.html
@@ -1,8 +1,8 @@
 ---
 title: Traffic Management
-overview: Traffic Management Q&amp;A
+description: Traffic Management Q&amp;A
 
-order: 50
+weight: 50
 
 layout: help
 ---

--- a/_help/glossary.md
+++ b/_help/glossary.md
@@ -1,11 +1,9 @@
 ---
 title: Glossary
-overview: A glossary of common Istio terms.
+description: A glossary of common Istio terms.
 
-order: 30
+weight: 30
 
-layout: help
-type: markdown
 redirect_from:
   - "/glossary"
   - "/docs/welcome/glossary.html"

--- a/_help/index.md
+++ b/_help/index.md
@@ -1,11 +1,9 @@
 ---
 title: Help!
-overview: A bunch of resources to help you deploy, configure and use Istio.
+description: A bunch of resources to help you deploy, configure and use Istio.
 
-order: 10
+weight: 10
 
-layout: help
-type: markdown
 toc: false
 ---
 {% include home.html %}

--- a/_help/troubleshooting.md
+++ b/_help/troubleshooting.md
@@ -1,11 +1,9 @@
 ---
 title: Troubleshooting Guide
-overview: Practical advice on practical problems with Istio
+description: Practical advice on practical problems with Istio
 
-order: 40
+weight: 40
 
-layout: help
-type: markdown
 redirect_from: /troubleshooting
 force_inline_toc: true
 ---

--- a/_includes/collection_nav.html
+++ b/_includes/collection_nav.html
@@ -1,6 +1,6 @@
 {% comment %}
-Assigns the next_page_url, next_page_title, next_page_overview, prev_page_url, prev_page_title, and prev_page_overview variables the
-URLs, titles and overviews of the next and previous pages within the current collection, relative to the current page.
+Assigns the next_page_url, next_page_title, next_page_description, prev_page_url, prev_page_title, and prev_page_description variables the
+URLs, titles and descriptions of the next and previous pages within the current collection, relative to the current page.
 {% endcomment %}
 
 {% comment %}
@@ -32,7 +32,7 @@ URLs, titles and overviews of the next and previous pages within the current col
     {% if name != "index.html" %}
         {% assign next_page_url = urls[next_index] %}
         {% assign next_page_title = titles[next_index] %}
-        {% assign next_page_overview = overviews[next_index] %}
+        {% assign next_page_description = descriptions[next_index] %}
         {% break %}
     {% endif %}
 {% endfor %}
@@ -53,7 +53,7 @@ URLs, titles and overviews of the next and previous pages within the current col
     {% if name != "index.html" %}
         {% assign prev_page_url = urls[prev_index] %}
         {% assign prev_page_title = titles[prev_index] %}
-        {% assign prev_page_overview = overviews[prev_index] %}
+        {% assign prev_page_description = descriptions[prev_index] %}
         {% break %}
     {% endif %}
 {% endfor %}

--- a/_includes/faq.html
+++ b/_includes/faq.html
@@ -1,5 +1,5 @@
 
-{% assign faqs = site.faq | sort: "order" %}
+{% assign faqs = site.faq | sort: "weight" %}
 {% for q in faqs %}
     {% assign comp = q.path | split: '/' %}
     {% assign qcat = comp[1] %}

--- a/_includes/latest_blog_post.html
+++ b/_includes/latest_blog_post.html
@@ -5,7 +5,7 @@ Assigns the latest_blog_post variable the URL of the latest blog post on the sit
 {% include home.html %}
 {% assign latest_year = "0" %}
 
-{% assign sorted = site.blog | sort: "order" %}
+{% assign sorted = site.blog | sort: "weight" %}
 {% for d in sorted %}
   {% if d.draft == true %}
     {% continue %}

--- a/_includes/primary.html
+++ b/_includes/primary.html
@@ -75,12 +75,12 @@ Usage:
                 <div class="row">
                     <div class="col-6">
                         {% if next_page_url %}
-                            <a title="{{next_page_overview}}" href="{{home}}{{next_page_url}}"><i class="fa fa-arrow-left"></i>{{next_page_title}}</a>
+                            <a title="{{next_page_description}}" href="{{home}}{{next_page_url}}"><i class="fa fa-arrow-left"></i> {{next_page_title}}</a>
                         {% endif %}
                     </div>
                     <div class="col-6" style="text-align: right">
                         {% if prev_page_url %}
-                            <a title="{{prev_page_overview}}" href="{{home}}{{prev_page_url}}">{{prev_page_title}} <i class="fa fa-arrow-right"></i></a>
+                            <a title="{{prev_page_description}}" href="{{home}}{{prev_page_url}}">{{prev_page_title}} <i class="fa fa-arrow-right"></i></a>
                         {% endif %}
                     </div>
                 </div>

--- a/_includes/section-index.html
+++ b/_includes/section-index.html
@@ -21,7 +21,7 @@ Parameters:
 
 {% include sort-hierarchy.html docs=include.docs prefix=prefix %}
 
-<p>{{page.overview}}</p>
+<p>{{page.description}}</p>
 
 {% assign pageComponents = page.url | split: "/" %}
 
@@ -36,7 +36,7 @@ Parameters:
     {% endif %}
 
     {% assign title = titles[forloop.index0] %}
-    {% assign overview = overviews[forloop.index0] %}
+    {% assign description = descriptions[forloop.index0] %}
 
     {% assign components = url | split: "/" %}
     {% assign numComponents = components | size %}
@@ -48,7 +48,7 @@ Parameters:
         {% endfor %}
 
         <li class="directory">
-            <span title="{{overview}}">{{title}}</span>
+            <span title="{{description}}">{{title}}</span>
             <ul>
 
     {% else %}
@@ -57,7 +57,7 @@ Parameters:
             </ul></li>
         {% endfor %}
         <li class="file">
-            <a href="{{home}}{{url}}">{{title}}</a>. {{ overview }}
+            <a href="{{home}}{{url}}">{{title}}</a>. {{ description }}
         </li>
     {% endif %}
     {% assign depth = numComponents %}

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -36,7 +36,7 @@ Usage:
             {% endif %}
 
             {% assign title = titles[forloop.index0] %}
-            {% assign overview = overviews[forloop.index0] %}
+            {% assign description = descriptions[forloop.index0] %}
 
             {% assign components = url | split: "/" %}
             {% assign numComponents = components | size %}
@@ -67,11 +67,11 @@ Usage:
                     <div class="card">
                         <div class="card-header" role="tab" id="header{{forloop.index0}}">
                             {% if include.singlecard %}
-                                <div title="{{overview}}">
+                                <div title="{{description}}">
                                     {{title}}
                                 </div>
                             {% else %}
-                                <a data-toggle="collapse" href="#collapse{{forloop.index0}}" title="{{overview}}" role="button"
+                                <a data-toggle="collapse" href="#collapse{{forloop.index0}}" title="{{description}}" role="button"
                                    aria-controls="collapse{{forloop.index0}}">
                                     <div>
                                         {{title}}
@@ -97,7 +97,7 @@ Usage:
                                 <i class='fa fa-lg fa-caret-right'></i>
                             {% endif %}
                             {% assign niceurl = url | remove: "/index.html" %}
-                            <a class="{% if url == page.url %}current{% endif %}" title="{{overview}}" href="{{home}}{{niceurl}}">{{title}}</a>
+                            <a class="{% if url == page.url %}current{% endif %}" title="{{description}}" href="{{home}}{{niceurl}}">{{title}}</a>
                         </label>
                         <ul class="tree{% if parent == false %} collapse{% endif %}">
                 {% endif %}
@@ -108,9 +108,9 @@ Usage:
                 {% endfor %}
                 <li>
                     {% if url == page.url %}
-                        <span class="current" title="{{overview}}">{{title}}</span>
+                        <span class="current" title="{{description}}">{{title}}</span>
                     {% else %}
-                        <a title="{{overview}}" href="{{home}}{{url}}">{{title}}</a>
+                        <a title="{{description}}" href="{{home}}{{url}}">{{title}}</a>
                     {% endif %}
                 </li>
             {% endif %}

--- a/_includes/sort-hierarchy.html
+++ b/_includes/sort-hierarchy.html
@@ -1,6 +1,6 @@
 {% comment %}
 Purpose:
-    Sorts a document hierarchy by the 'order' front-matter entry of each doc.
+    Sorts a document hierarchy by the 'weight' front-matter entry of each doc.
     This is hard since Liquid doesn't have functions, recursion, scoped variables,
     or data structures. Oh, and Liquid is very slow too.
 
@@ -13,11 +13,11 @@ Parameters:
 Results:
     * urls      (string array) - the sorted document urls
     * titles    (string array) - the sorted document titles
-    * overviews (string array) - the sorted document overviews
+    * descriptions (string array) - the sorted document descriptions
 
 Note:
     This code uses $ and ^ as magic string markers. If any document's
-    URL, title, or overview contain these characters, then this code
+    URL, title, or description contain these characters, then this code
     will get confused and return gibberish.
 
 {% endcomment %}
@@ -34,9 +34,9 @@ Note:
         {% continue %}
     {% endif %}
 
-    {% assign o = "00000" | append: doc.order %}
+    {% assign o = "00000" | append: doc.weight %}
     {% assign start = o | size | minus: 5 %}
-    {% assign order = o | slice: start, 5 %}
+    {% assign weight = o | slice: start, 5 %}
 
     {% assign components = doc.url | split: "/" %}
     {% assign count = components | size | minus:2 %}
@@ -49,9 +49,9 @@ Note:
 
         {% for sub in include.docs %}
             {% if sub.url == p %}
-                {% assign o = "00000" | append: sub.order %}
+                {% assign o = "00000" | append: sub.weight %}
                 {% assign start = o | size | minus: 5 %}
-                {% assign order = o | slice: start, 5 | append:"/" | append: order %}
+                {% assign weight = o | slice: start, 5 | append:"/" | append: weight %}
                 {% break %}
             {% endif %}
         {% endfor %}
@@ -59,13 +59,13 @@ Note:
 
     {% assign name = components | last %}
     {% if name == "index.html" %}
-        {% assign len = order | size | minus: 5 %}
-        {% assign order = order | slice: 0, len | append: "#####" %}
+        {% assign len = weight | size | minus: 5 %}
+        {% assign weight = weight | slice: 0, len | append: "#####" %}
     {% endif %}
 
     {% comment %}
         Take the full doc url and replace the last component of it by the document title, and use that for collation such that
-        docs in the same directory end up sorted first by 'order', then by title
+        docs in the same directory end up sorted first by 'weight', then by title
     {% endcomment %}
     {% assign hackUrl = "" %}
     {% for i in (1..count) %}
@@ -73,8 +73,8 @@ Note:
     {% endfor %}
     {% assign hackUrl = hackUrl | append: "/" | append: doc.title %}
 
-    {% assign a = a | append: "^" | append: order | append: "$" | append: hackUrl | append: "$" | append: doc.url | append: "$" | append: doc.title |
-    append: "$" | append: doc.overview %}
+    {% assign a = a | append: "^" | append: weight | append: "$" | append: hackUrl | append: "$" | append: doc.url | append: "$" | append: doc.title |
+    append: "$" | append: doc.description %}
 {% endfor %}
 
 {% assign sorted = a | split: "^" | sort %}
@@ -82,13 +82,13 @@ Note:
     {% assign parts = s | split: "$" %}
     {% assign urls = urls | append: "$" | append: parts[2] %}
     {% assign titles = titles | append: "$" | append: parts[3] %}
-    {% assign overviews = overviews | append: "$" | append: parts[4] %}
+    {% assign descriptions = descriptions | append: "$" | append: parts[4] %}
 {% endfor %}
 
 {% assign urlslen = urls | size | minus: 2 %}
 {% assign titleslen = titles | size | minus: 2 %}
-{% assign overviewslen = overviews | size | minus: 2 %}
+{% assign descriptionslen = descriptions | size | minus: 2 %}
 
 {% assign urls = urls | slice: 2, urlslen | split: "$" %}
 {% assign titles = titles | slice: 2, titleslen | split: "$" %}
-{% assign overviews = overviews | slice: 2, overviewslen | split: "$" %}
+{% assign descriptions = descriptions | slice: 2, descriptionslen | split: "$" %}

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -11,10 +11,10 @@ layout: compress
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <meta name="theme-color" content="#466BB0"/>
 
-        {% if page.overview == nil %}
+        {% if page.description == nil %}
             {% assign description = "An open platform to connect, manage, and secure microservices." %}
         {% else %}
-            {% assign description = page.overview %}
+            {% assign description = page.description %}
         {% endif %}
 
         <meta name="title" content="{{page.title}}">

--- a/community.md
+++ b/community.md
@@ -1,8 +1,7 @@
 ---
 title: Community
-overview: Information on the various ways to participate and interact with the Istio community.
+description: Information on the various ways to participate and interact with the Istio community.
 layout: community
-type: markdown
 ---
 {% include home.html %}
 


### PR DESCRIPTION
- In front matter, order: and overview: are now weight: and description: respectively.

- In front matter, we generally don't need layout: and use config to assign layouts automatically.

- Remove the useless type: front-matter entries, the type is inferred from the file extension.

There should be no visible different to the generated web site. Staging: https://geeknoid.github.io/istio.github.io/