### PR TITLE
Modification fault-injection doc

### DIFF
--- a/_docs/tasks/traffic-management-v1alpha3/fault-injection.md
+++ b/_docs/tasks/traffic-management-v1alpha3/fault-injection.md
@@ -157,7 +157,7 @@ message.
 
    Login as user "jason". If the rule propagated successfully to all pods, you should see the page load
    immediately with the "product ratings not available" message. Logout from user "jason" and you should
-   see the ratings v2 show up successfully on the productpage web page.
+   see the ratings v1 show up successfully on the productpage web page.
 
 ## Cleanup
 


### PR DESCRIPTION
It seems to be typo on the following page.
https://github.com/istio/istio.github.io/blob/8e271cc89653a70dab088daee2fc5b8268be34d4/_docs/tasks/traffic-management-v1alpha3/fault-injection.md

In Fault injection using HTTP Abort -> 3.Observe application behavior section

I suppose that ratings v1 is right than ratings v2.

Login as user “jason”. If the rule propagated successfully to all pods, you should see the page load immediately with the “product ratings not available” message. Logout from user “jason” and you should see the ratings v2 show up successfully on the productpage web page.

/assign @linsun