### PR TITLE
Shorten long titles and descriptions.

### DIFF
--- a/_docs/tasks/security/authn-policy.md
+++ b/_docs/tasks/security/authn-policy.md
@@ -1,6 +1,6 @@
 ---
-title: Basic Istio Authentication Policy
-description: Shows you how to use Istio authentication policy to setup mutual TLS and simple end-user authentication.
+title: Basic Authentication Policy
+description: Shows you how to use Istio authentication policy to setup mutual TLS and basic end-user authentication.
 
 weight: 10
 

--- a/_docs/tasks/security/basic-access-control.md
+++ b/_docs/tasks/security/basic-access-control.md
@@ -1,6 +1,6 @@
 ---
-title: Setting up Basic Access Control
-description: This task shows how to control access to a service using the Kubernetes labels.
+title: Basic Access Control
+description: Shows how to control access to a service using the Kubernetes labels.
 
 weight: 20
 

--- a/_docs/tasks/security/health-check.md
+++ b/_docs/tasks/security/health-check.md
@@ -1,13 +1,13 @@
 ---
-title: Enabling Citadel health checking
-description: This task shows how to enable Citadel health checking.
+title: Citadel health checking
+description: Shows how to enable Citadel health checking with Kubernetes.
 
 weight: 70
 
 ---
 {% include home.html %}
 
-This task shows how to enable Citadel health checking. Note this is an Alpha feature since Istio 0.6.
+This task shows how to enable Kubernetes health checking for Citadel. Note this is an Alpha feature.
 
 Since Istio 0.6, Citadel has a health checking feature that can be optionally enabled.
 By default, the normal Istio deployment process does not enable this feature.

--- a/_docs/tasks/security/https-overlay.md
+++ b/_docs/tasks/security/https-overlay.md
@@ -1,6 +1,6 @@
 ---
-title: Mutual TLS over HTTPS services
-description: This task shows how to enable mTLS on HTTPS services.
+title: Mutual TLS over HTTPS
+description: Shows how to enable mTLS on HTTPS services.
 
 weight: 80
 

--- a/_docs/tasks/security/mutual-tls.md
+++ b/_docs/tasks/security/mutual-tls.md
@@ -1,6 +1,6 @@
 ---
-title: Testing Istio mutual TLS authentication
-description: This task shows you how to verify and test Istio's automatic mutual TLS authentication.
+title: Testing mutual TLS
+description: Shows you how to verify and test Istio's automatic mutual TLS authentication.
 
 weight: 10
 

--- a/_docs/tasks/security/per-service-mtls.md
+++ b/_docs/tasks/security/per-service-mtls.md
@@ -1,6 +1,6 @@
 ---
 title: Per-service mutual TLS authentication control
-description: This task shows how to change mutual TLS authentication for a single service.
+description: Shows how to change mutual TLS authentication for a single service.
 
 weight: 50
 

--- a/_docs/tasks/security/plugin-ca-cert.md
+++ b/_docs/tasks/security/plugin-ca-cert.md
@@ -1,6 +1,6 @@
 ---
-title: Plugging in root certificate, signing certificate and key
-description: This task shows how operators can configure Citadel with existing root certificate, signing certificate and key.
+title: Plugging in external CA key and certificate
+description: Shows how operators can configure Citadel with existing root certificate, signing certificate and key.
 
 weight: 60
 

--- a/_docs/tasks/security/role-based-access-control.md
+++ b/_docs/tasks/security/role-based-access-control.md
@@ -1,6 +1,6 @@
 ---
-title: Setting up Istio Role-Based Access Control
-description: This task shows how to set up role-based access control for services in Istio mesh.
+title: Role-Based Access Control
+description: Shows how to set up role-based access control for services in Istio mesh.
 
 weight: 40
 

--- a/_docs/tasks/security/secure-access-control.md
+++ b/_docs/tasks/security/secure-access-control.md
@@ -1,6 +1,6 @@
 ---
-title: Setting up Secure Access Control
-description: This task shows how to securely control access to a service using service accounts.
+title: Secure Access Control
+description: Shows how to securely control access to a service using service accounts.
 
 weight: 30
 


### PR DESCRIPTION
Shorter titles improves readability and the appearance of the website.
As an example, refer to the short task titles of Traffic Management (v1alpha3):
https://preliminary.istio.io/docs/tasks/traffic-management-v1alpha3/

Also remove "This task" before each description since it's redundant:
https://preliminary.istio.io/docs/tasks/security/