### PR TITLE
Add privacy policy link to the footer.

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -50,7 +50,7 @@
                 {% elsif site.data.istio.preliminary %}
                     Preliminary
                 {% endif %}
-                {{site.data.istio.version}}<br>&copy; 2018 Istio Authors<br>
+                {{site.data.istio.version}}<br>&copy; 2018 Istio Authors, <a href="https://policies.google.com/privacy">Privacy Policy</a><br>
                 {% if site.data.istio.archive %}
                     Archived on {{site.data.istio.archive_date}}
                 {% else %}


### PR DESCRIPTION
Since Google currently owns istio.io and we collect usual analytics info about site usage,
we need a link to the Google privacy policy.

@LisaFC 