### PR TITLE
Add Prometheus as Grafana prerequisite

### DIFF
--- a/_docs/tasks/telemetry/using-istio-dashboard.md
+++ b/_docs/tasks/telemetry/using-istio-dashboard.md
@@ -19,6 +19,8 @@ the example application throughout this task.
 
 * [Install Istio]({{home}}/docs/setup/) in your cluster and deploy an
   application.
+* [Install the Prometheus add-on]({{home}}/docs/tasks/telemetry/querying-metrics.html)
+  in your cluster and deploy an application.
 
 ## Viewing the Istio Dashboard
 


### PR DESCRIPTION
I'm not certain this is the best change since the Prometheus doc doesn't actually include an installation procedure, but this change does inform the user they need Prometheus before proceeding.