### PR TITLE
Add a bunch of redirects

### DIFF
--- a/_about/contribute/creating-a-pull-request.md
+++ b/_about/contribute/creating-a-pull-request.md
@@ -1,10 +1,9 @@
 ---
 title: Creating a Pull Request
 description: Shows you how to create a GitHub pull request in order to submit your docs for approval.
-
 weight: 20
-
-redirect_from: /docs/welcome/contribute/creating-a-pull-request.html
+redirect_from:
+    - /docs/welcome/contribute/creating-a-pull-request.html
 ---
 
 To contribute to Istio documentation, create a pull request against the

--- a/_about/contribute/editing.md
+++ b/_about/contribute/editing.md
@@ -1,10 +1,9 @@
 ---
 title: Editing Docs
 description: Lets you start editing this site's documentation.
-
 weight: 10
-
-redirect_from: /docs/welcome/contribute/editing.html
+redirect_from:
+    - /docs/welcome/contribute/editing.html
 ---
 
 Click the button below to visit the GitHub repository for this whole web site. You can then click the

--- a/_about/contribute/index.md
+++ b/_about/contribute/index.md
@@ -1,11 +1,10 @@
 ---
 title: Contributing to the Docs
 description: Learn how to contribute to improve and expand the Istio documentation.
-
 weight: 100
-
 toc: false
-redirect_from: /docs/welcome/contribute/index.html
+redirect_from:
+    - /docs/welcome/contribute/index.html
 ---
 
 {% include section-index.html docs=site.about %}

--- a/_about/contribute/reviewing-doc-issues.md
+++ b/_about/contribute/reviewing-doc-issues.md
@@ -4,7 +4,8 @@ description: Explains the process involved in accepting documentation updates.
 
 weight: 60
 
-redirect_from: /docs/welcome/contribute/reviewing-doc-issues.html
+redirect_from:
+    - /docs/welcome/contribute/reviewing-doc-issues.html
 ---
 
 This page explains how documentation issues are reviewed and prioritized for the

--- a/_about/contribute/staging-your-changes.md
+++ b/_about/contribute/staging-your-changes.md
@@ -4,7 +4,8 @@ description: Explains how to test your changes locally before submitting them.
 
 weight: 40
 
-redirect_from: /docs/welcome/contribute/staging-your-changes.html
+redirect_from:
+    - /docs/welcome/contribute/staging-your-changes.html
 ---
 
 This page shows how to stage content that you want to contribute

--- a/_about/contribute/style-guide.md
+++ b/_about/contribute/style-guide.md
@@ -4,7 +4,9 @@ description: Explains the dos and donts of writing Istio docs.
 
 weight: 70
 
-redirect_from: /docs/welcome/contribute/style-guide.html
+redirect_from:
+    - /docs/welcome/contribute/style-guide.html
+    - /docs/reference/contribute/style-guide.html
 ---
 
 TBD: This needs to be updated with Istio examples instead of Kubernetes examples.

--- a/_about/contribute/writing-a-new-topic.md
+++ b/_about/contribute/writing-a-new-topic.md
@@ -1,10 +1,9 @@
 ---
 title: Writing a New Topic
 description: Explains the mechanics of creating new documentation pages.
-
 weight: 30
-
-redirect_from: /docs/welcome/contribute/writing-a-new-topic.html
+redirect_from:
+    - /docs/welcome/contribute/writing-a-new-topic.html
 ---
 {% include home.html %}
 
@@ -300,7 +299,7 @@ enabled so it may be used here.
 Note that unlike normal preformatted blocks, dynamically loaded preformatted blocks unfortunately
 do not get syntax colored.
 
-## Adding redirects
+## Renaming or moving pages
 
 If you move pages around and would like to ensure existing links continue to work, you can add
 redirects to the site very easily.
@@ -309,7 +308,8 @@ In the page that is the target of the redirect (where you'd like users to land),
 following to the front-matter:
 
 ```plain
-redirect_from: <url>
+redirect_from:
+    - <url>
 ```
 
 For example
@@ -318,10 +318,9 @@ For example
 ---
 title: Frequently Asked Questions
 description: Questions Asked Frequently
-
 weight: 12
-
-redirect_from: /faq
+redirect_from:
+    - /faq
 ---
 
 ```
@@ -335,9 +334,7 @@ You can also add many redirects like so:
 ---
 title: Frequently Asked Questions
 description: Questions Asked Frequently
-
 weight: 12
-
 redirect_from:
     - /faq
     - /faq2

--- a/_about/feature-stages.md
+++ b/_about/feature-stages.md
@@ -1,13 +1,11 @@
 ---
 title: Feature Status
 description: List of features and their release stages.
-
 weight: 10
-
 redirect_from:
-  - "/docs/reference/release-roadmap.html"
-  - "/docs/reference/feature-stages.html"
-  - "/docs/welcome/feature-stages.html"
+  - /docs/reference/release-roadmap.html
+  - /docs/reference/feature-stages.html
+  - /docs/welcome/feature-stages.html
 ---
 {% include home.html %}
 

--- a/_about/notes/0.1.md
+++ b/_about/notes/0.1.md
@@ -4,7 +4,8 @@ title: Istio 0.1
 weight: 100
 
 toc: false
-redirect_from: /docs/welcome/notes/0.1.html
+redirect_from:
+    - /docs/welcome/notes/0.1.html
 ---
 
 Istio 0.1 is the initial [release](https://github.com/istio/istio/releases) of Istio. It works in a single Kubernetes cluster and supports the following features:

--- a/_about/notes/0.2.md
+++ b/_about/notes/0.2.md
@@ -3,7 +3,8 @@ title: Istio 0.2
 
 weight: 99
 
-redirect_from: /docs/welcome/notes/0.2.html
+redirect_from:
+    - /docs/welcome/notes/0.2.html
 ---
 
 ## General

--- a/_about/notes/0.3.md
+++ b/_about/notes/0.3.md
@@ -3,7 +3,8 @@ title: Istio 0.3
 
 weight: 98
 
-redirect_from: /docs/welcome/notes/0.3.html
+redirect_from:
+    - /docs/welcome/notes/0.3.html
 ---
 
 {% include home.html %}

--- a/_about/notes/0.4.md
+++ b/_about/notes/0.4.md
@@ -4,7 +4,8 @@ title: Istio 0.4
 weight: 97
 
 toc: false
-redirect_from: /docs/welcome/notes/0.4.html
+redirect_from:
+    - /docs/welcome/notes/0.4.html
 ---
 {% include home.html %}
 

--- a/_about/notes/index.md
+++ b/_about/notes/index.md
@@ -1,14 +1,12 @@
 ---
 title: Release Notes
 description: Description of features and improvements for every Istio release.
-
 weight: 5
-
 redirect_from:
-  - "/docs/reference/release-notes.html"
-  - "/release-notes"
-  - "/docs/welcome/notes/index.html"
-  - "/docs/references/notes"
+  - /docs/reference/release-notes.html
+  - /release-notes
+  - /docs/welcome/notes/index.html
+  - /docs/references/notes
 toc: false
 ---
 {% include section-index.html docs=site.about %}

--- a/_blog/2017/0.1-announcement.md
+++ b/_blog/2017/0.1-announcement.md
@@ -4,12 +4,10 @@ description: Istio 0.1 announcement
 publishdate: 2018-05-24
 subtitle: A robust service mesh for microservices
 attribution: The Istio Team
-
 weight: 100
-
 redirect_from:
-  - "/blog/istio-service-mesh-for-microservices.html"
-  - "/blog/0.1-announcement.html"
+  - /blog/istio-service-mesh-for-microservices.html
+  - /blog/0.1-announcement.html
 ---
 {% include home.html %}
 

--- a/_blog/2017/0.1-auth.md
+++ b/_blog/2017/0.1-auth.md
@@ -4,12 +4,10 @@ description: Istio Auth 0.1 announcement
 publishdate: 2017-05-25
 subtitle: Secure by default service to service communications
 attribution: The Istio Team
-
 weight: 99
-
 redirect_from:
-  - "/blog/0.1-auth.html"
-  - "/blog/istio-auth-for-microservices.html"
+  - /blog/0.1-auth.html
+  - /blog/istio-auth-for-microservices.html
 ---
 {% include home.html %}
 

--- a/_blog/2017/0.1-canary.md
+++ b/_blog/2017/0.1-canary.md
@@ -7,7 +7,8 @@ attribution: Frank Budinsky
 
 weight: 98
 
-redirect_from: "/blog/canary-deployments-using-istio.html"
+redirect_from:
+    - /blog/canary-deployments-using-istio.html
 ---
 
 {% include home.html %}

--- a/_blog/2017/0.1-using-network-policy.md
+++ b/_blog/2017/0.1-using-network-policy.md
@@ -7,7 +7,8 @@ attribution: Spike Curtis
 
 weight: 97
 
-redirect_from: "/blog/using-network-policy-in-concert-with-istio.html"
+redirect_from: 
+    - /blog/using-network-policy-in-concert-with-istio.html
 ---
 {% include home.html %}
 

--- a/_blog/2017/0.2-announcement.md
+++ b/_blog/2017/0.2-announcement.md
@@ -8,7 +8,8 @@ attribution: The Istio Team
 weight: 96
 
 toc: false
-redirect_from: "/blog/istio-0.2-announcement.html"
+redirect_from:
+    - /blog/istio-0.2-announcement.html
 ---
 {% include home.html %}
 

--- a/_blog/2017/adapter-model.md
+++ b/_blog/2017/adapter-model.md
@@ -7,7 +7,8 @@ attribution: Martin Taillefer
 
 weight: 95
 
-redirect_from: "/blog/mixer-adapter-model.html"
+redirect_from: 
+    - /blog/mixer-adapter-model.html
 ---
 {% include home.html %}
 

--- a/_blog/2017/mixer-spof-myth.md
+++ b/_blog/2017/mixer-spof-myth.md
@@ -7,7 +7,9 @@ attribution: Martin Taillefer
 
 weight: 94
 
-redirect_from: /blog/posts/2017/mixer-spof-myth.html
+redirect_from:
+    - /blog/posts/2017/mixer-spof-myth.html
+    - /blog/mixer-spof-myth.html
 ---
 {% include home.html %}
 

--- a/_blog/2018/aws-nlb.md
+++ b/_blog/2018/aws-nlb.md
@@ -4,10 +4,7 @@ description: Describes how to configure Istio ingress with a network load balanc
 publishdate: 2018-04-20
 subtitle: Ingress AWS Network Load Balancer
 attribution: Julien SENON
-
 weight: 89
-
-redirect_from: "/blog/aws-nlb.html"
 ---
 {% include home.html %}
 

--- a/_blog/2018/egress-https.md
+++ b/_blog/2018/egress-https.md
@@ -4,10 +4,7 @@ description: Describes a simple scenario based on Istio Bookinfo sample
 publishdate: 2018-01-31
 subtitle: Egress Rules for HTTPS traffic
 attribution: Vadim Eisenberg
-
 weight: 93
-
-redirect_from: "/blog/egress-https.html"
 ---
 {% include home.html %}
 

--- a/_blog/2018/egress-tcp.md
+++ b/_blog/2018/egress-tcp.md
@@ -4,10 +4,7 @@ description: Describes a simple scenario based on Istio Bookinfo sample
 publishdate: 2018-02-06
 subtitle: Egress rules for TCP traffic
 attribution: Vadim Eisenberg
-
 weight: 92
-
-redirect_from: "/blog/egress-tcp.html"
 ---
 {% include home.html %}
 

--- a/_blog/2018/soft-multitenancy.md
+++ b/_blog/2018/soft-multitenancy.md
@@ -4,10 +4,7 @@ description: Using Kubernetes namespace and RBAC to create an Istio soft multi-t
 publishdate: 2018-04-19
 subtitle: Using multiple Istio control planes and RBAC to create multi-tenancy
 attribution: John Joyce and Rich Curran
-
 weight: 90
-
-redirect_from: "/blog/soft-multitenancy.html"
 ---
 {% include home.html %}
 Multi-tenancy is commonly used in many environments across many different applications,

--- a/_blog/2018/traffic-mirroring.md
+++ b/_blog/2018/traffic-mirroring.md
@@ -4,10 +4,7 @@ description: An introduction to safer, lower-risk deployments and release to pro
 publishdate: 2018-02-08
 subtitle: Routing rules for HTTP traffic
 attribution: Christian Posta
-
 weight: 91
-
-redirect_from: "/blog/traffic-mirroring.html"
 ---
 {% include home.html %}
 

--- a/_blog/2018/v1alpha3-routing.md
+++ b/_blog/2018/v1alpha3-routing.md
@@ -4,10 +4,7 @@ description: Introduction, motivation and design principles for the Istio v1alph
 publishdate: 2018-04-25
 subtitle:
 attribution: Frank Budinsky (IBM) and Shriram Rajagopalan (VMware)
-
 weight: 88
-
-redirect_from: "/blog/v1alpha3-routing.html"
 ---
 
 {% include home.html %}

--- a/_docs/concepts/security/authn-policy.md
+++ b/_docs/concepts/security/authn-policy.md
@@ -1,9 +1,9 @@
 ---
 title: Istio Authentication Policy
 description: Describes Istio authentication policy
-
 weight: 10
-
+redirect_from:
+    - /docs/concepts/network-and-auth/auth.html
 ---
 {% include home.html %}
 

--- a/_docs/concepts/traffic-management/pilot.md
+++ b/_docs/concepts/traffic-management/pilot.md
@@ -5,7 +5,8 @@ description: Introduces Pilot, the component responsible for managing a distribu
 weight: 10
 
 toc: false
-redirect_from: /docs/concepts/traffic-management/manager.html
+redirect_from:
+    - /docs/concepts/traffic-management/manager.html
 ---
 {% include home.html %}
 

--- a/_docs/guides/bookinfo.md
+++ b/_docs/guides/bookinfo.md
@@ -1,9 +1,9 @@
 ---
-1;95;0ctitle: Bookinfo Sample Application
+title: Bookinfo Sample Application
 description: This guide deploys a sample application composed of four separate microservices which will be used to demonstrate various features of the Istio service mesh.
-
 weight: 10
-
+redirect_from:
+    - /docs/samples/bookinfo.html
 ---
 {% include home.html %}
 

--- a/_docs/guides/index.md
+++ b/_docs/guides/index.md
@@ -1,10 +1,10 @@
 ---
 title: Guides
 description: Guides include a variety of fully working example uses for Istio that you can experiment with.
-
 weight: 30
-
 toc: false
+redirect_from:
+    /docs/samples/index.html
 ---
 
 {% include section-index.html docs=site.docs %}

--- a/_docs/reference/config/policy-and-telemetry/attribute-vocabulary.md
+++ b/_docs/reference/config/policy-and-telemetry/attribute-vocabulary.md
@@ -1,9 +1,9 @@
 ---
 title: Attribute Vocabulary
 description: Describes the base attribute vocabulary used for policy and control.
-
 weight: 10
-redirect_from: /docs/reference/config/policy-and-telemetry/attribute-vocabulary.html
+redirect_from:
+    - /docs/reference/config/policy-and-telemetry/attribute-vocabulary.html
 ---
 {% include home.html %}
 

--- a/_docs/reference/config/policy-and-telemetry/expression-language.md
+++ b/_docs/reference/config/policy-and-telemetry/expression-language.md
@@ -1,9 +1,9 @@
 ---
 title: Expression Language
 description: Mixer config expression language reference.
-
 weight: 20
-redirect_from: /docs/reference/config/policy-and-telemetry/expression-language.html
+redirect_from:
+    - /docs/reference/config/policy-and-telemetry/expression-language.html
 ---
 
 {% include home.html %}

--- a/_docs/reference/config/policy-and-telemetry/index.md
+++ b/_docs/reference/config/policy-and-telemetry/index.md
@@ -2,7 +2,8 @@
 title: Policies and Telemetry
 description: Describes how to configure Istio's policy and telemetry features.
 weight: 30
-redirect_from: /docs/reference/config/mixer/index.html
+redirect_from:
+    - /docs/reference/config/mixer/index.html
 ---
 
 {% include section-index.html docs=site.docs %}

--- a/_docs/setup/kubernetes/helm-install.md
+++ b/_docs/setup/kubernetes/helm-install.md
@@ -1,11 +1,10 @@
 ---
 title: Installation with Helm
 description: Install Istio with the included Helm chart.
-
 weight: 30
-
-redirect_from: /docs/setup/kubernetes/helm.html
-
+redirect_from:
+    - /docs/setup/kubernetes/helm.html
+    - /docs/tasks/integrating-services-into-istio.html
 ---
 
 {% include home.html %}

--- a/_docs/setup/kubernetes/index.md
+++ b/_docs/setup/kubernetes/index.md
@@ -1,10 +1,10 @@
 ---
 title: Kubernetes
 description: Instructions for installing the Istio control plane on Kubernetes and adding VMs into the mesh.
-
 weight: 10
-
-redirect_from: "/docs/tasks/installing-istio.html"
+redirect_from:
+    - /docs/tasks/installing-istio.html
+    - /docs/setup/install-kubernetes.html
 toc: false
 ---
 

--- a/_docs/setup/kubernetes/sidecar-injection.md
+++ b/_docs/setup/kubernetes/sidecar-injection.md
@@ -1,9 +1,9 @@
 ---
 title: Installing the Istio Sidecar
 description: Instructions for installing the Istio sidecar in application pods automatically using the sidecar injector webhook or manually using istioctl CLI.
-
 weight: 50
-
+redirect_from:
+    - /docs/setup/kubernetes/automatic-sidecar-inject.html
 ---
 {% include home.html %}
 

--- a/_docs/tasks/policy-enforcement/rate-limiting.md
+++ b/_docs/tasks/policy-enforcement/rate-limiting.md
@@ -1,10 +1,9 @@
 ---
 title: Enabling Rate Limits
 description: This task shows you how to use Istio to dynamically limit the traffic to a service.
-
 weight: 10
-
-redirect_from: /docs/tasks/rate-limiting.html
+redirect_from:
+    - /docs/tasks/rate-limiting.html
 ---
 {% include home.html %}
 

--- a/_docs/tasks/security/authn-policy.md
+++ b/_docs/tasks/security/authn-policy.md
@@ -1,9 +1,9 @@
 ---
 title: Basic Authentication Policy
 description: Shows you how to use Istio authentication policy to setup mutual TLS and basic end-user authentication.
-
 weight: 10
-
+redirect_from:
+    - /docs/tasks/security/istio-auth.html
 ---
 {% include home.html %}
 

--- a/_docs/tasks/security/basic-access-control.md
+++ b/_docs/tasks/security/basic-access-control.md
@@ -1,9 +1,9 @@
 ---
 title: Basic Access Control
 description: Shows how to control access to a service using the Kubernetes labels.
-
 weight: 20
-
+redirect_from:
+    - /docs/tasks/basic-access-control.html
 ---
 {% include home.html %}
 

--- a/_docs/tasks/security/index.md
+++ b/_docs/tasks/security/index.md
@@ -5,7 +5,8 @@ description: Describes tasks that help securing the service mesh traffic.
 weight: 40
 
 toc: false
-redirect_from: /docs/tasks/istio-auth.html
+redirect_from:
+    - /docs/tasks/istio-auth.html
 ---
 
 {% include section-index.html docs=site.docs %}

--- a/_docs/tasks/telemetry/distributed-tracing.md
+++ b/_docs/tasks/telemetry/distributed-tracing.md
@@ -1,10 +1,9 @@
 ---
 title: Distributed Tracing
 description: How to configure the proxies to send tracing requests to Zipkin or Jaeger
-
 weight: 10
-
-redirect_from: /docs/tasks/zipkin-tracing.html
+redirect_from:
+    - /docs/tasks/zipkin-tracing.html
 ---
 {% include home.html %}
 

--- a/_docs/tasks/telemetry/metrics-logs.md
+++ b/_docs/tasks/telemetry/metrics-logs.md
@@ -1,10 +1,9 @@
 ---
 title: Collecting Metrics and Logs
-
 description: This task shows you how to configure Istio to collect metrics and logs.
-
 weight: 20
-
+redirect_from:
+    - /docs/tasks/metrics-logs.html
 ---
 {% include home.html %}
 

--- a/_docs/tasks/traffic-management/egress.md
+++ b/_docs/tasks/traffic-management/egress.md
@@ -1,9 +1,9 @@
 ---
 title: Control Egress Traffic
 description: Describes how to configure Istio to route traffic from services in the mesh to external services.
-
 weight: 40
-
+redirect_from:
+    - /docs/tasks/traffic-management/egress/index.html
 ---
 {% include home.html %}
 

--- a/_docs/tasks/traffic-management/fault-injection.md
+++ b/_docs/tasks/traffic-management/fault-injection.md
@@ -1,9 +1,9 @@
 ---
 title: Fault Injection
 description: This task shows how to inject delays and test the resiliency of your application.
-
 weight: 20
-
+redirect_from:
+    - /docs/tasks/fault-injection.html
 ---
 {% include home.html %}
 

--- a/_docs/tasks/traffic-management/ingress.md
+++ b/_docs/tasks/traffic-management/ingress.md
@@ -1,10 +1,9 @@
 ---
 title: Control Ingress Traffic
 description: Describes how to configure Istio to expose a service outside of the service mesh.
-
 weight: 30
-
-redirect_from: /docs/tasks/ingress.html
+redirect_from:
+     - /docs/tasks/ingress.html
 ---
 {% include home.html %}
 

--- a/_docs/tasks/traffic-management/mirroring.md
+++ b/_docs/tasks/traffic-management/mirroring.md
@@ -1,9 +1,9 @@
 ---
 title: Mirroring
 description: This task demonstrates the traffic shadowing/mirroring capabilities of Istio
-
 weight: 60
-
+redirect_from:
+    - /docs/tasks/traffic-management/mirroring/index.html
 ---
 {% include home.html %}
 

--- a/_docs/tasks/traffic-management/request-timeouts.md
+++ b/_docs/tasks/traffic-management/request-timeouts.md
@@ -1,9 +1,9 @@
 ---
 title: Setting Request Timeouts
 description: This task shows you how to setup request timeouts in Envoy using Istio.
-
 weight: 28
-
+redirect_from:
+    - /docs/tasks/traffic-management/request-timeouts/index.html
 ---
 {% include home.html %}
 

--- a/_docs/tasks/traffic-management/traffic-shifting.md
+++ b/_docs/tasks/traffic-management/traffic-shifting.md
@@ -1,9 +1,9 @@
 ---
 title: Traffic Shifting
 description: This task shows you how to migrate traffic from an old to new version of a service.
-
 weight: 25
-
+redirect_from:
+    - /docs/tasks/traffic-management/version-migration.html
 ---
 {% include home.html %}
 

--- a/_help/bugs.md
+++ b/_help/bugs.md
@@ -4,7 +4,9 @@ description: What to do about bugs
 
 weight: 35
 
-redirect_from: /bugs
+redirect_from:
+    - /bugs.html
+    - /bugs/index.html
 toc: false
 ---
 {% include home.html %}

--- a/_help/faq/general.html
+++ b/_help/faq/general.html
@@ -1,9 +1,9 @@
 ---
 title: General
-description: General Q&amp;A
-
+description: General Q&amp;A\
 weight: 10
-
 layout: help
+redirect_from:
+    - /help/faq/general/index.html
 ---
 {% include faq.html category='general' %}

--- a/_help/faq/index.md
+++ b/_help/faq/index.md
@@ -1,14 +1,14 @@
 ---
 title: FAQ
 description: Frequently Asked Questions about Istio.
-
 weight: 20
-
 toc: false
-
 redirect_from:
-  - "/faq"
-  - "/docs/welcome/faq.html"
+  - /faq.html
+  - /faq/index.html
+  - /docs/welcome/faq.html
+  - /docs/welcome/faq/index.html
+  - /help/faq.html
 ---
 {% include home.html %}
 

--- a/_help/faq/mixer.html
+++ b/_help/faq/mixer.html
@@ -1,9 +1,9 @@
 ---
 title: Mixer
 description: Mixer Q&amp;A
-
 weight: 40
-
 layout: help
+redirect_from:
+    - /help/faq/mixer/index.html
 ---
 {% include faq.html category='mixer' %}

--- a/_help/faq/security.html
+++ b/_help/faq/security.html
@@ -1,9 +1,9 @@
 ---
 title: Security
 description: Security Q&amp;A
-
 weight: 30
-
 layout: help
+redirect_from:
+    - /help/faq/security/index.html
 ---
 {% include faq.html category='security' %}

--- a/_help/faq/setup.html
+++ b/_help/faq/setup.html
@@ -1,9 +1,9 @@
 ---
 title: Setup
 description: Setup Q&amp;A
-
 weight: 20
-
 layout: help
+redirect_from:
+    - /help/faq/setup/index.html
 ---
 {% include faq.html category='setup' %}

--- a/_help/faq/traffic-management.html
+++ b/_help/faq/traffic-management.html
@@ -1,9 +1,9 @@
 ---
 title: Traffic Management
 description: Traffic Management Q&amp;A
-
 weight: 50
-
 layout: help
+redirect_from:
+    - /help/faq/traffic-management/index.html
 ---
 {% include faq.html category='traffic-management' %}

--- a/_help/troubleshooting.md
+++ b/_help/troubleshooting.md
@@ -1,10 +1,11 @@
 ---
 title: Troubleshooting Guide
 description: Practical advice on practical problems with Istio
-
 weight: 40
-
-redirect_from: /troubleshooting
+redirect_from:
+    - /troubleshooting.html
+    - /troubleshooting/index.html
+    - /help/troubleshooting/index.html
 force_inline_toc: true
 ---
 {% include home.html %}

--- a/_layouts/redirect.html
+++ b/_layouts/redirect.html
@@ -1,0 +1,17 @@
+---
+layout: compress
+---
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Redirecting&hellip;</title>
+        <link rel="canonical" href="{{page.redirect.to}}">
+        <meta name="robots" content="noindex">
+        <meta http-equiv="content-type" content="text/html; charset=utf-8"/>
+        <meta http-equiv="refresh" content="0; url={{page.redirect.to}}">
+    </head>
+    <body>
+        <h1>Redirecting&hellip;</h1>
+        <a href="{{page.redirect.to}}">Click here if you are not redirected.</a>
+    </body>
+</html>

--- a/community.md
+++ b/community.md
@@ -2,6 +2,8 @@
 title: Community
 description: Information on the various ways to participate and interact with the Istio community.
 layout: community
+redirect_from:
+    - /community/index.html
 ---
 {% include home.html %}
 


### PR DESCRIPTION
- Google Search Console has been reporting a bunch of errors about other sites
linking to pages on istio.io which are no longer there. This addresses the
highest priority cases.