### PR TITLE
Renamed the VirtualService's destination name to host

### DIFF
--- a/_docs/concepts/traffic-management/rules-configuration.md
+++ b/_docs/concepts/traffic-management/rules-configuration.md
@@ -270,7 +270,7 @@ spec:
   http:
   - route:
     - destination:
-        name: ratings
+        host: ratings
         subset: v1
     timeout: 10s
 ```
@@ -290,7 +290,7 @@ spec:
   http:
   - route:
     - destination:
-        name: ratings
+        host: ratings
         subset: v1
     retries:
       attempts: 3
@@ -653,7 +653,7 @@ spec:
   http:
   - route:
     - destination:
-        name: ratings
+        host: ratings
         subset: v1
     timeout: 10s
 ```

--- a/_docs/concepts/traffic-management/rules-configuration.md
+++ b/_docs/concepts/traffic-management/rules-configuration.md
@@ -495,7 +495,7 @@ kind: DestinationRule
 metadata:
   name: reviews
 spec:
-  name: reviews
+  host: reviews
   subsets:
   - name: v1
     labels:
@@ -533,7 +533,7 @@ kind: DestinationRule
 metadata:
   name: reviews
 spec:
-  name: reviews
+  host: reviews
   subsets:
   - name: v1
     labels:

--- a/_docs/reference/config/istio.networking.v1alpha3.html
+++ b/_docs/reference/config/istio.networking.v1alpha3.html
@@ -770,7 +770,7 @@ spec:
     - destination:
         port:
           number: 7777
-        name: reviews.qa.svc.cluster.local
+        host: reviews.qa.svc.cluster.local
   - match:
       uri:
         prefix: /reviews/
@@ -781,7 +781,7 @@ spec:
         name: reviews.prod.svc.cluster.local
       weight: 80
     - destination:
-        name: reviews.qa.svc.cluster.local
+        host: reviews.qa.svc.cluster.local
       weight: 20
 </code></pre>
 
@@ -806,7 +806,7 @@ spec:
       sourceSubnet: &quot;172.17.16.0/24&quot;
     route:
     - destination:
-        name: mongo.prod.svc.cluster.local
+        host: mongo.prod.svc.cluster.local
 </code></pre>
 
 <table class="message-fields">

--- a/_docs/tasks/traffic-management/circuit-breaking.md
+++ b/_docs/tasks/traffic-management/circuit-breaking.md
@@ -36,7 +36,7 @@ Let's set up a scenario to demonstrate the circuit-breaking capabilities of Isti
     metadata:
       name: httpbin
     spec:
-      name: httpbin
+      host: httpbin
       trafficPolicy:
         connectionPool:
           tcp:
@@ -63,7 +63,7 @@ Let's set up a scenario to demonstrate the circuit-breaking capabilities of Isti
       name: httpbin
       ...
     spec:
-      name: httpbin
+      host: httpbin
       trafficPolicy:
         connectionPool:
           http:

--- a/_docs/tasks/traffic-management/fault-injection.md
+++ b/_docs/tasks/traffic-management/fault-injection.md
@@ -65,11 +65,11 @@ continue without any errors.
               regex: ^(.*?;)?(user=jason)(;.*)?$
         route:
         - destination:
-            name: ratings
+            host: ratings
             subset: v1
       - route:
         - destination:
-            name: ratings
+            host: ratings
             subset: v1
     ```
 
@@ -145,11 +145,11 @@ message.
               regex: ^(.*?;)?(user=jason)(;.*)?$
         route:
         - destination:
-            name: ratings
+            host: ratings
             subset: v1
       - route:
         - destination:
-            name: ratings
+            host: ratings
             subset: v1
     ```
 

--- a/_docs/tasks/traffic-management/request-routing.md
+++ b/_docs/tasks/traffic-management/request-routing.md
@@ -55,7 +55,7 @@ you'll need to use `replace` rather than `create` in the following command.
       http:
       - route:
         - destination:
-            name: details
+            host: details
             subset: v1
     ---
     apiVersion: networking.istio.io/v1alpha3
@@ -72,7 +72,7 @@ you'll need to use `replace` rather than `create` in the following command.
       http:
       - route:
         - destination:
-            name: productpage
+            host: productpage
             subset: v1
     ---
     apiVersion: networking.istio.io/v1alpha3
@@ -86,7 +86,7 @@ you'll need to use `replace` rather than `create` in the following command.
       http:
       - route:
         - destination:
-            name: ratings
+            host: ratings
             subset: v1
     ---
     apiVersion: networking.istio.io/v1alpha3
@@ -100,7 +100,7 @@ you'll need to use `replace` rather than `create` in the following command.
       http:
       - route:
         - destination:
-            name: reviews
+            host: reviews
             subset: v1
     ---
     ```
@@ -143,11 +143,11 @@ you'll need to use `replace` rather than `create` in the following command.
               regex: ^(.*?;)?(user=jason)(;.*)?$
         route:
         - destination:
-            name: reviews
+            host: reviews
             subset: v2
       - route:
         - destination:
-            name: reviews
+            host: reviews
             subset: v1
     ```
 

--- a/_docs/tasks/traffic-management/request-timeouts.md
+++ b/_docs/tasks/traffic-management/request-timeouts.md
@@ -46,7 +46,7 @@ to the `ratings` service.
       http:
       - route:
         - destination:
-            name: reviews
+            host: reviews
             subset: v2
     EOF
     ```
@@ -69,7 +69,7 @@ to the `ratings` service.
             fixedDelay: 2s
         route:
         - destination:
-            name: ratings
+            host: ratings
             subset: v1
     EOF
     ```
@@ -93,7 +93,7 @@ to the `ratings` service.
       http:
       - route:
         - destination:
-            name: reviews
+            host: reviews
             subset: v2
         timeout: 1s
     EOF

--- a/_docs/tasks/traffic-management/traffic-shifting.md
+++ b/_docs/tasks/traffic-management/traffic-shifting.md
@@ -56,12 +56,12 @@ two steps: 50%, 100%.
       http:
       - route:
         - destination:
-            name: reviews
+            host: reviews
             subset: v1
           weight: 50
       - route:
         - destination:
-            name: reviews
+            host: reviews
             subset: v3
           weight: 50
     ```


### PR DESCRIPTION
Otherwise users would experience an `istioctl` error when trying to create the sample VirtualService snippet.