### PR TITLE
Added route rule to virtual service in Egress task

### DIFF
--- a/_docs/tasks/traffic-management/egress.md
+++ b/_docs/tasks/traffic-management/egress.md
@@ -148,6 +148,10 @@ to set a timeout rule on calls to the httpbin.org service.
         - httpbin.org
       http:
       - timeout: 3s
+        route:
+          - destination:
+              host: httpbin.org
+            weight: 100
     EOF
     ```
 


### PR DESCRIPTION
The example virtual service in Egress task was missing route rules which was
causing istioctl to reject the configuration.