### PR TITLE
use a specific host instead of "*" wildcard in a virtual service of ingress

### DIFF
--- a/_docs/tasks/traffic-management/ingress.md
+++ b/_docs/tasks/traffic-management/ingress.md
@@ -142,7 +142,7 @@ In the following subsections we configure a `Gateway` on port 80 for unencrypted
       name: httpbin
     spec:
       hosts:
-      - "*"
+      - "httpbin.example.com"
       gateways:
       - httpbin-gateway
       http:


### PR DESCRIPTION
to make things more strict, it is not required currently.