### PR TITLE
Fix the table format in expression-language.md

### DIFF
--- a/content/docs/reference/config/policy-and-telemetry/expression-language.md
+++ b/content/docs/reference/config/policy-and-telemetry/expression-language.md
@@ -21,14 +21,14 @@ CEXL accepts a subset of **[Go expressions](https://golang.org/ref/spec#Expressi
 
 CEXL supports the following functions.
 
-|Operator/Function |Definition |Example | Description
-|-----------------------------------------
+|Operator/Function |Definition |Example | Description|
+|------------------|-----------|--------|------------|
 |`==` |Equals |`request.size == 200`
 |`!=` |Not Equals |`request.auth.principal != "admin"`
-|`||` |Logical OR | `(request.size == 200) || (request.auth.principal == "admin")`
+|`\|\|` |Logical OR | `(request.size == 200) \|\| (request.auth.principal == "admin")`
 |`&&` |Logical AND | `(request.size == 200) && (request.auth.principal == "admin")`
 |`[ ]` |Map Access | `request.headers["x-id"]`
-|`|` |First non empty | `source.labels["app"] | source.labels["svc"] | "unknown"`
+|`\|` |First non empty | `source.labels["app"] \| source.labels["svc"] \| "unknown"`
 |`match` | Glob match |`match(destination.service, "*.ns1.svc.cluster.local")` | Matches prefix or suffix based on the location of `*`
 |`email` | Convert a textual e-mail into the `EMAIL_ADDRESS` type | `email("awesome@istio.io")` | Use the `email` function to create an `EMAIL_ADDRESS` literal.
 |`dnsName` | Convert a textual DNS name into the `DNS_NAME` type | `dnsName("www.istio.io")` | Use the `dnsName` function to create a `DNS_NAME` literal.
@@ -56,10 +56,10 @@ For example, the expression `request.auth.principal == "user1"` fails evaluation
 
 ## Examples
 
-|Expression |Return Type |Description
-|------------------------------------
-|`request.size| 200` |  **int** | `request.size` if available, otherwise 200.
+|Expression |Return Type |Description|
+|-----------|------------|-----------|
+|`request.size \| 200` |  **int** | `request.size` if available, otherwise 200.
 |`request.headers["X-FORWARDED-HOST"] == "myhost"`| **boolean**
-|`(request.headers["x-user-group"] == "admin") || (request.auth.principal == "admin")`| **boolean**| True if the user is admin or in the admin group.
-|`(request.auth.principal | "nobody" ) == "user1"` | **boolean** | True if `request.auth.principal` is "user1", The expression will not error out if `request.auth.principal` is missing.
+|`(request.headers["x-user-group"] == "admin") \|\| (request.auth.principal == "admin")`| **boolean**| True if the user is admin or in the admin group.
+|`(request.auth.principal \| "nobody" ) == "user1"` | **boolean** | True if `request.auth.principal` is "user1", The expression will not error out if `request.auth.principal` is missing.
 |`source.labels["app"]=="reviews" && source.labels["version"]=="v3"`| **boolean** | True if app label is reviews and version label is v3, false otherwise.


### PR DESCRIPTION
Add `|` to make the table correct and use `\` to escape the `|` character inside the table. Not sure if this is the right way to fix but the preview page looks good.