### PR TITLE
Update the Istio security tasks for V0.8.

### DIFF
--- a/content/docs/tasks/security/authn-policy.md
+++ b/content/docs/tasks/security/authn-policy.md
@@ -106,7 +106,7 @@ EOF
 * `*.foo.svc.cluster.local` matches all services in namespace `foo`.
 * With `ISTIO_MUTUAL` TLS mode, Istio will set the path for key and certificates (e.g `clientCertificate`, `privateKey` and `caCertificates`) according to its internal implementation.
 
-Run the same testing command as above. You should see requests from `sleep.legacy` to `httpbin.foo` start to fail, as the result of enabling mutual TLS for `httpbin.foo` but `sleep.legacy` doesn't have a sidecar to support it. On the other hand, for clients with sidecar (`sleep.foo` and `sleep.bar`), Istio automatically configures them to using mTLS where talking to `http.foo`, so they continue to work. Also, requests to `httpbin.bar` are not affected as the policy is only effective on the `foo` namespace.
+Run the same testing command as above. You should see requests from `sleep.legacy` to `httpbin.foo` start to fail, as the result of enabling mutual TLS for `httpbin.foo` but `sleep.legacy` doesn't have a sidecar to support it. On the other hand, for clients with sidecar (`sleep.foo` and `sleep.bar`), Istio automatically configures them to using mutual TLS where talking to `http.foo`, so they continue to work. Also, requests to `httpbin.bar` are not affected as the policy is only effective on the `foo` namespace.
 
 ```command
 $ for from in "foo" "bar" "legacy"; do for to in "foo" "bar"; do kubectl exec $(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name}) -c sleep -n ${from} -- curl http://httpbin.${to}:8000/ip -s -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
@@ -202,7 +202,7 @@ spec:
 EOF
 ```
 
-This new policy will apply only to the `httpbin` service on port `1234`. As a result, mTLS is disabled (again) on port `8000` and requests from `sleep.legacy` will resume working.
+This new policy will apply only to the `httpbin` service on port `1234`. As a result, mutual TLS is disabled (again) on port `8000` and requests from `sleep.legacy` will resume working.
 
 ```command
 $ kubectl exec $(kubectl get pod -l app=sleep -n legacy -o jsonpath={.items..metadata.name}) -c sleep -n legacy -- curl http://httpbin.bar:8000/ip -s -o /dev/null -w "%{http_code}\n"
@@ -292,7 +292,7 @@ $ curl $INGRESS_HOST/headers -s -o /dev/null -w "%{http_code}\n"
 200
 ```
 
-Now, let's add a policy that requires end-user JWT for `httpbin.foo`. The next command assumes policy with name "httpbin" already exists (which should be if you follow previous sections). You can run `kubectl get policies.authentication.istio.io -n foo` to confirm, and use `istio create` (instead of `istio replace`) if resource is not found. Also note in this policy, peer authentication (mTLS) is also set, though it can be removed without affecting origin authentication settings.
+Now, let's add a policy that requires end-user JWT for `httpbin.foo`. The next command assumes policy with name "httpbin" already exists (which should be if you follow previous sections). You can run `kubectl get policies.authentication.istio.io -n foo` to confirm, and use `istio create` (instead of `istio replace`) if resource is not found. Also note in this policy, peer authentication (mutual TLS) is also set, though it can be removed without affecting origin authentication settings.
 
 ```bash
 cat <<EOF | istioctl replace -n foo -f -

--- a/content/docs/tasks/security/health-check.md
+++ b/content/docs/tasks/security/health-check.md
@@ -26,9 +26,15 @@ this feature is not needed if the production setup is not using the
 ## Before you begin
 
 * Set up Istio by following the instructions in the
-  [quick start](/docs/setup/kubernetes/quick-start/).
-  Note that authentication should be enabled at step 5 in the
-  [installation steps](/docs/setup/kubernetes/quick-start/#installation-steps).
+  [quick start](/docs/setup/kubernetes/quick-start/) with global mutual TLS enabled:
+
+    ```command
+    $ kubectl apply -f install/kubernetes/istio-demo-auth.yaml
+    ```
+    _**OR**_
+    Using [Helm](/docs/setup/kubernetes/helm-install/) with `global.mtls.enabled` to `true`.
+
+> Starting with Istio 0.7, you can use [authentication policy](/docs/concepts/security/authn-policy/) to configure mutual TLS for all/selected services in a namespace (repeated for all namespaces to get global setting). See [authentication policy task](/docs/tasks/security/authn-policy/)
 
 ## Deploying Citadel with health checking
 

--- a/content/docs/tasks/security/https-overlay.md
+++ b/content/docs/tasks/security/https-overlay.md
@@ -1,16 +1,16 @@
 ---
 title: Mutual TLS over HTTPS
-description: Shows how to enable mTLS on HTTPS services.
+description: Shows how to enable mutual TLS on HTTPS services.
 weight: 80
 ---
 
 This task shows how Istio Mutual TLS works with HTTPS services. It includes: 1)
 Deploy an HTTPS service without Istio sidecar; 2) Deploy an HTTPS service with
-Istio with mTLS disabled; 3) Deploy an HTTPS service with mTLS enabled. For each
+Istio with mutual TLS disabled; 3) Deploy an HTTPS service with mutual TLS enabled. For each
 deployment, connect to this service and verify it works.
 
 When the Istio sidecar is deployed with an HTTPS service, the proxy automatically downgrades
-from L7 to L4 (no matter mTLS is enabled or not), which means it does not terminate the
+from L7 to L4 (no matter mutual TLS is enabled or not), which means it does not terminate the
 original HTTPS traffic. And this is the reason Istio can work on HTTPS services.
 
 ## Before you begin
@@ -86,9 +86,9 @@ $ kubectl exec $(kubectl get pod -l app=sleep -o jsonpath={.items..metadata.name
 ...
 ```
 
-### Create an HTTPS service with the Istio sidecar and mTLS disabled
+### Create an HTTPS service with the Istio sidecar and mutual TLS disabled
 
-In "Before you begin" section, the Istio control plane is deployed with mTLS
+In "Before you begin" section, the Istio control plane is deployed with mutual TLS
 disabled. So you only need to redeploy the NGINX HTTPS service with sidecar.
 
 Delete the HTTPS service.
@@ -132,10 +132,10 @@ $ kubectl exec sleep-847544bbfc-d27jg -c istio-proxy -- curl https://my-nginx -k
 
 > This example is borrowed from [kubernetes examples](https://github.com/kubernetes/examples/blob/master/staging/https-nginx/README.md).
 
-### Create an HTTPS service with Istio sidecar with mTLS enabled
+### Create an HTTPS service with Istio sidecar with mutual TLS enabled
 
-You need to deploy Istio control plane with mTLS enabled. If you have istio
-control plane with mTLS disabled installed, please delete it:
+You need to deploy Istio control plane with mutual TLS enabled. If you have istio
+control plane with mutual TLS disabled installed, please delete it:
 
 ```command
 $ kubectl delete -f @install/kubernetes/istio.yaml@
@@ -148,7 +148,7 @@ $ kubectl get pod -n istio-system
 No resources found.
 ```
 
-Then deploy the Istio control plane with mTLS enabled:
+Then deploy the Istio control plane with mutual TLS enabled:
 
 ```command
 $ kubectl apply -f @install/kubernetes/istio-auth.yaml@
@@ -193,7 +193,7 @@ $ kubectl exec sleep-77f457bfdd-hdknx -c sleep -- curl https://my-nginx -k
 ```
 
 The reason is that for the workflow "sleep -> sleep-proxy -> nginx-proxy -> nginx",
-the whole flow is L7 traffic, and there is a L4 mTLS encryption between sleep-proxy
+the whole flow is L7 traffic, and there is a L4 mutual TLS encryption between sleep-proxy
 and nginx-proxy. In this case, everything works fine.
 
 However, if you run this command from istio-proxy container, it will not work.
@@ -205,7 +205,7 @@ command terminated with exit code 35
 ```
 
 The reason is that for the workflow "sleep-proxy -> nginx-proxy -> nginx",
-nginx-proxy is expected mTLS traffic from sleep-proxy. In the command above,
+nginx-proxy is expected mutual TLS traffic from sleep-proxy. In the command above,
 sleep-proxy does not provide client cert. As a result, it won't work. Moreover,
 even sleep-proxy provides client cert in above command, it won't work either
 since the traffic will be downgraded to http from nginx-proxy to nginx.

--- a/content/docs/tasks/security/mutual-tls.md
+++ b/content/docs/tasks/security/mutual-tls.md
@@ -14,7 +14,7 @@ Through this task, you will learn how to:
 
 This task assumes you have a Kubernetes cluster:
 
-* Installed Istio with global mTLS enabled:
+* Installed Istio with global mutual TLS enabled:
 
     ```command
     $ kubectl apply -f @install/kubernetes/istio-auth.yaml@
@@ -22,7 +22,7 @@ This task assumes you have a Kubernetes cluster:
     _**OR**_
     Using [Helm](/docs/setup/kubernetes/helm-install/) with `global.mtls.enabled` to `true`.
 
-> Starting with Istio  0.7, you can use [authentication policy](/docs/concepts/security/authn-policy/) to config mTLS for all/selected services in a namespace (repeated for all namespaces to get global setting). See [authentication policy task](/docs/tasks/security/authn-policy/)
+> Starting with Istio 0.7, you can use [authentication policy](/docs/concepts/security/authn-policy/) to configure mutual TLS for all/selected services in a namespace (repeated for all namespaces to get global setting). See [authentication policy task](/docs/tasks/security/authn-policy/)
 
 * For demo, deploy [httpbin](https://github.com/istio/istio/blob/{{<branch_name>}}/samples/httpbin) and [sleep](https://github.com/istio/istio/tree/master/samples/sleep) with Envoy sidecar. For simplicity, the demo is setup in the `default` namespace. If you wish to use a different namespace,  please add `-n yournamespace` appropriately to the example commands in the next section.
 
@@ -48,13 +48,13 @@ Citadel is up if the "AVAILABLE" column is 1.
 
 ### Verifying service configuration
 
-* Check installation mode. If mutual TLS is enabled by default (e.g `istio-auth.yaml` was used when installing Istio), you can expect to see uncommented `authPolicy: MUTUAL_TLS` in configmap.
+* Check installation mode. If mutual TLS is enabled by default (e.g `istio-demo-auth.yaml` was used when installing Istio), you can expect to see uncommented `authPolicy: MUTUAL_TLS` in the configmap.
 
     ```command
     $ kubectl get configmap istio -o yaml -n istio-system | grep authPolicy | head -1
     ```
 
-* Check authentication policies. mTLS can also be enabled (or disabled) per service(s) by authentication policy. A policy, if exist, will overwrite the configmap setting for the targeted services. Unfortunately, there is no quick way to get relevant policies for a service, other than examining all policies in the applicable namespace:
+* Check authentication policies. Mutual TLS can also be enabled (or disabled) per service(s) by authentication policy. A policy, if exist, will overwrite the configmap setting for the targeted services. Unfortunately, there is no quick way to get relevant policies for a service, other than examining all policies in the applicable namespace:
 
     ```command
     $ kubectl get policies.authentication.istio.io -n default -o yaml
@@ -152,5 +152,5 @@ Assuming mutual TLS authentication is properly turned on, it should not affect c
 
 ## What's next
 
-* Learn more about the design principles behind Istio's automatic mTLS authentication
+* Learn more about the design principles behind Istio's automatic mutual TLS authentication
   between all services in this [blog](/blog/2017/0.1-auth/).

--- a/content/docs/tasks/security/plugin-ca-cert.md
+++ b/content/docs/tasks/security/plugin-ca-cert.md
@@ -13,9 +13,15 @@ operator-specified root certificate. This task demonstrates an example to plug c
 ## Before you begin
 
 * Set up Istio by following the instructions in the
-  [quick start](/docs/setup/kubernetes/quick-start/).
-  Note that authentication should be enabled at step 5 in the
-  [installation steps](/docs/setup/kubernetes/quick-start/#installation-steps).
+  [quick start](/docs/setup/kubernetes/quick-start/) with global mutual TLS enabled:
+
+    ```command
+    $ kubectl apply -f install/kubernetes/istio-demo-auth.yaml
+    ```
+    _**OR**_
+    Using [Helm](/docs/setup/kubernetes/helm-install/) with `global.mtls.enabled` to `true`.
+
+> From Istio 0.7, you can use [authentication policy](/docs/concepts/security/authn-policy/) to configure mutual TLS for all/selected services in a namespace (repeated for all namespaces to get global setting). See [authentication policy task](/docs/tasks/security/authn-policy/)
 
 ## Plugging in the existing certificate and key
 


### PR DESCRIPTION
* Remove the Istio Citadel service from the health check task because it is by default defined.
* Update the clean up steps.