### PR TITLE
Add TOC to reference pages.

### DIFF
--- a/layouts/partials/primary-bottom.html
+++ b/layouts/partials/primary-bottom.html
@@ -1,5 +1,5 @@
-{{ $toc := (trim .TableOfContents " ") }}
-{{ $needTOC := .Params.toc | (ne $toc "") }}
+{{ $toc := partial "toc.html" (dict "page" .) }}
+{{ $needTOC := .Scratch.Get "needTOC" }}
 
             </main>
 
@@ -33,7 +33,7 @@
                 <nav class="toc">
                     <div class="spacer"></div>
                     <div id="toc" class="directory" role="directory">
-                        {{ .TableOfContents }}
+                        {{ $toc }}
                     </div>
                 </nav>
             </div>

--- a/layouts/partials/primary-top.html
+++ b/layouts/partials/primary-top.html
@@ -1,3 +1,6 @@
+{{ $toc := partial "toc.html" (dict "page" .) }}
+{{ $needTOC := .Scratch.Get "needTOC" }}
+
 <div class="container-fluid">
     <div class="row row-offcanvas">
         <div class="col-0 col-md-3 col-xl-2 sidebar-offcanvas">
@@ -9,9 +12,6 @@
                 {{ partial "sidebar-singlecard.html" . }}
             {{ end }}
         </div>
-
-        {{ $toc := (trim .TableOfContents " ") }}
-        {{ $needTOC := .Params.toc | (ne $toc "") }}
 
         {{ if and $needTOC (ne .Params.force_inline_toc true) }}
             <div class="col-12 col-md-9 col-xl-8">
@@ -44,8 +44,7 @@
                 {{ if $needTOC }}
                     <nav class="toc-inlined d-xl-none d-print-none" {{ if .Params.force_inline_toc }}style="display:block!important" {{ end }}>
                         <div class="directory" role="directory">
-                            {{ $t := replace .TableOfContents "TableOfContents" "InlinedTableOfContents" }}
-                            {{ safeHTML $t }}
+                            {{ replace $toc "TableOfContents" "InlinedTableOfContents" | safeHTML }}
                         </div>
                     </nav>
                 {{ end }}

--- a/layouts/partials/toc.html
+++ b/layouts/partials/toc.html
@@ -1,0 +1,39 @@
+{{ $page := .page }}
+{{ $toc := (trim $page.TableOfContents " ") }}
+{{ $page.Scratch.Set "needTOC" false }}
+
+{{ if (eq $toc "") }}
+    {{ $headers := findRE "<h[23456].*?id=\".*?\".*?>.*?</h[23456]>" $page.Content }}
+    {{ $len := len $headers }}
+
+    {{ if gt $len 0 }}
+        {{ $page.Scratch.Set "needTOC" true }}
+        <nav id="TableOfContents">
+            <ul>
+                {{ $page.Scratch.Set "level" 50 }}
+                {{ range $h := $headers }}
+                    {{ $level := index (index (findRE "<h[23456].*?" $h) 0) 2 | int }}
+                    {{ $id := replaceRE "<h[23456].*?id=\"(.*?)\".*?>.*?</h[23456]>" "$1" $h }}
+                    {{ $title := replaceRE "<h[23456].*?>(.*?)</h[23456]>" "$1" $h }}
+                    {{ $current := $page.Scratch.Get "level" | int }}
+
+                    {{ if gt $level $current }}
+                        <ul>
+                    {{ else if lt $level $current }}
+                        {{ $delta := sub ($page.Scratch.Get "level") $level }}
+                        {{ range $index, $num := (seq $delta) }}
+                            </ul>
+                        {{ end }}
+                    {{ end }}
+
+                    <li><a href="#{{ $id }}">{{ $title }}</a></li>
+
+                    {{ $page.Scratch.Set "level" $level }}
+                {{ end }}
+            </ul>
+        </nav>
+    {{ end }}
+{{ else }}
+    {{ $page.Scratch.Set "needTOC" true }}
+    {{ safeHTML $toc }}
+{{ end }}


### PR DESCRIPTION
I didn't realize the Hugo's TOC support features only work for markdown files.
Since our reference pages are HTML, none of these were getting TOCs. I now roll
my own TOC functionality in that case, to bring up back TOCs for our reference
pages.