### PR TITLE
Fix Istio version variable in quick start

### DIFF
--- a/content/docs/setup/kubernetes/quick-start.md
+++ b/content/docs/setup/kubernetes/quick-start.md
@@ -237,10 +237,10 @@ installation directory contains:
     * The `istioctl` client binary in the `bin/` directory. `istioctl` is used when manually injecting Envoy as a sidecar proxy and for creating routing rules and policies.
     * The `istio.VERSION` configuration file
 
-1.  Change directory to istio package. For example, if the package is istio-{{site.data.istio.version}}
+1.  Change directory to istio package. For example, if the package is istio-{{< istio_version >}}
 
     ```command
-    $ cd istio-{{site.data.istio.version}}
+    $ cd istio-{{< istio_version >}}
     ```
 
 1.  Add the `istioctl` client to your PATH.


### PR DESCRIPTION
{{site.data.istio.version}} -> {{< istio_version >}}

As in https://github.com/istio/istio.github.io/blob/76545ee3be6c585e0a57fb6744726b4e01b9dc31/content/about/notes/_index.md#L13