### PR TITLE
annotation in metadata not directly in template

### DIFF
--- a/content/docs/setup/kubernetes/upgrading-istio.md
+++ b/content/docs/setup/kubernetes/upgrading-istio.md
@@ -92,8 +92,9 @@ one of the options below:
     ...
     spec:
       template:
-        annotations:
-           sidecar.istio.io/proxyImage: docker.io/istio/proxyv2:0.8.0
+        metadata:
+          annotations:
+            sidecar.istio.io/proxyImage: docker.io/istio/proxyv2:0.8.0
     ```
 
     Then replace your deployment with your updated application yaml file:


### PR DESCRIPTION
needed to avoid this error:

```
error: error validating "samples/bookinfo/kube/bookinfo.yaml": error validating data: ValidationError(Deployment.spec.template): unknown field "annotations" in io.k8s.api.core.v1.PodTemplateSpec; if you choose to ignore these errors, turn validation off with --validate=false
```