### PR TITLE
put links to the previous docs (0.7) in the 0.8 documents

### DIFF
--- a/content/docs/tasks/traffic-management/circuit-breaking.md
+++ b/content/docs/tasks/traffic-management/circuit-breaking.md
@@ -4,7 +4,7 @@ description: This task demonstrates the circuit-breaking capability for resilien
 weight: 50
 ---
 
-> This task uses the new [v1alpha3 traffic management API](/blog/2018/v1alpha3-routing/). The old API has been deprecated and will be removed in the next Istio release. If you need to use the old version, follow the docs [here](https://archive.istio.io/v0.6/docs/tasks/).
+> This task uses the new [v1alpha3 traffic management API](/blog/2018/v1alpha3-routing/). The old API has been deprecated and will be removed in the next Istio release. If you need to use the old version, follow the docs [here](https://archive.istio.io/v0.7/docs/tasks/traffic-management/).
 
 This task demonstrates the circuit-breaking capability for resilient applications. Circuit breaking allows developers to write applications that limit the impact of failures, latency spikes, and other undesirable effects of network peculiarities. This task will show how to configure circuit breaking for connections, requests, and outlier detection.
 

--- a/content/docs/tasks/traffic-management/egress-tcp.md
+++ b/content/docs/tasks/traffic-management/egress-tcp.md
@@ -4,7 +4,7 @@ description: Describes how to configure Istio to route TCP traffic from services
 weight: 41
 ---
 
-> This task uses the new [v1alpha3 traffic management API](/blog/2018/v1alpha3-routing/). The old API has been deprecated and will be removed in the next Istio release. If you need to use the old version, follow the docs [here](https://archive.istio.io/v0.6/docs/tasks/).
+> This task uses the new [v1alpha3 traffic management API](/blog/2018/v1alpha3-routing/). The old API has been deprecated and will be removed in the next Istio release. If you need to use the old version, follow the docs [here](https://archive.istio.io/v0.7/docs/tasks/traffic-management/).
 
 The [Control Egress Traffic](/docs/tasks/traffic-management/egress/) task demonstrates how external (outside the Kubernetes cluster) HTTP and HTTPS services can be accessed from applications inside the mesh. A quick reminder: by default, Istio-enabled applications are unable to access URLs outside the cluster. To enable such access, a [ServiceEntry](/docs/reference/config/istio.networking.v1alpha3/#ServiceEntry) for the external service must be defined, or, alternatively, [direct access to external services](/docs/tasks/traffic-management/egress/#calling-external-services-directly) must be configured.
 

--- a/content/docs/tasks/traffic-management/egress.md
+++ b/content/docs/tasks/traffic-management/egress.md
@@ -4,7 +4,7 @@ description: Describes how to configure Istio to route traffic from services in 
 weight: 40
 ---
 
-> This task uses the new [v1alpha3 traffic management API](/blog/2018/v1alpha3-routing/). The old API has been deprecated and will be removed in the next Istio release. If you need to use the old version, follow the docs [here](https://archive.istio.io/v0.6/docs/tasks/).
+> This task uses the new [v1alpha3 traffic management API](/blog/2018/v1alpha3-routing/). The old API has been deprecated and will be removed in the next Istio release. If you need to use the old version, follow the docs [here](https://archive.istio.io/v0.7/docs/tasks/traffic-management/).
 
 By default, Istio-enabled services are unable to access URLs outside of the cluster because
 iptables is used in the pod to transparently redirect all outbound traffic to the sidecar proxy,

--- a/content/docs/tasks/traffic-management/fault-injection.md
+++ b/content/docs/tasks/traffic-management/fault-injection.md
@@ -6,7 +6,7 @@ aliases:
     - /docs/tasks/fault-injection.html
 ---
 
-> Note: This task uses the new [v1alpha3 traffic management API](/blog/2018/v1alpha3-routing/). The old API has been deprecated and will be removed in the next Istio release. If you need to use the old version, follow the docs [here](https://archive.istio.io/v0.6/docs/tasks/).
+> Note: This task uses the new [v1alpha3 traffic management API](/blog/2018/v1alpha3-routing/). The old API has been deprecated and will be removed in the next Istio release. If you need to use the old version, follow the docs [here](https://archive.istio.io/v0.7/docs/tasks/traffic-management/).
 
 This task shows how to inject delays and test the resiliency of your application.
 

--- a/content/docs/tasks/traffic-management/ingress.md
+++ b/content/docs/tasks/traffic-management/ingress.md
@@ -6,7 +6,7 @@ aliases:
     - /docs/tasks/ingress.html
 ---
 
-> Note: This task uses the new [v1alpha3 traffic management API](/blog/2018/v1alpha3-routing/). The old API has been deprecated and will be removed in the next Istio release. If you need to use the old version, follow the docs [here](https://archive.istio.io/v0.6/docs/tasks/).
+> Note: This task uses the new [v1alpha3 traffic management API](/blog/2018/v1alpha3-routing/). The old API has been deprecated and will be removed in the next Istio release. If you need to use the old version, follow the docs [here](https://archive.istio.io/v0.7/docs/tasks/traffic-management/).
 
 In a Kubernetes environment, the [Kubernetes Ingress Resource](https://kubernetes.io/docs/concepts/services-networking/ingress/)
 is used to specify services that should be exposed outside the cluster.

--- a/content/docs/tasks/traffic-management/mirroring.md
+++ b/content/docs/tasks/traffic-management/mirroring.md
@@ -4,7 +4,7 @@ description: This task demonstrates the traffic shadowing/mirroring capabilities
 weight: 60
 ---
 
-> This task uses the new [v1alpha3 traffic management API](/blog/2018/v1alpha3-routing/). The old API has been deprecated and will be removed in the next Istio release. If you need to use the old version, follow the docs [here](https://archive.istio.io/v0.6/docs/tasks/).
+> This task uses the new [v1alpha3 traffic management API](/blog/2018/v1alpha3-routing/). The old API has been deprecated and will be removed in the next Istio release. If you need to use the old version, follow the docs [here](https://archive.istio.io/v0.7/docs/tasks/traffic-management/).
 
 This task demonstrates the traffic shadowing/mirroring capabilities of Istio. Traffic mirroring is a powerful concept that allows feature teams to bring changes to production with as little risk as possible. Mirroring brings a copy of live traffic to a mirrored service and happens out of band of the critical request path for the primary service.
 

--- a/content/docs/tasks/traffic-management/request-routing.md
+++ b/content/docs/tasks/traffic-management/request-routing.md
@@ -4,7 +4,7 @@ description: This task shows you how to configure dynamic request routing based 
 weight: 10
 ---
 
-> This task uses the new [v1alpha3 traffic management API](/blog/2018/v1alpha3-routing/). The old API has been deprecated and will be removed in the next Istio release. If you need to use the old version, follow the docs [here](https://archive.istio.io/v0.6/docs/tasks/).
+> This task uses the new [v1alpha3 traffic management API](/blog/2018/v1alpha3-routing/). The old API has been deprecated and will be removed in the next Istio release. If you need to use the old version, follow the docs [here](https://archive.istio.io/v0.7/docs/tasks/traffic-management/).
 
 This task shows you how to configure dynamic request routing based on weights and HTTP headers.
 

--- a/content/docs/tasks/traffic-management/request-timeouts.md
+++ b/content/docs/tasks/traffic-management/request-timeouts.md
@@ -4,7 +4,7 @@ description: This task shows you how to setup request timeouts in Envoy using Is
 weight: 28
 ---
 
-> This task uses the new [v1alpha3 traffic management API](/blog/2018/v1alpha3-routing/). The old API has been deprecated and will be removed in the next Istio release. If you need to use the old version, follow the docs [here](https://archive.istio.io/v0.6/docs/tasks/).
+> This task uses the new [v1alpha3 traffic management API](/blog/2018/v1alpha3-routing/). The old API has been deprecated and will be removed in the next Istio release. If you need to use the old version, follow the docs [here](https://archive.istio.io/v0.7/docs/tasks/traffic-management/).
 
 This task shows you how to setup request timeouts in Envoy using Istio.
 

--- a/content/docs/tasks/traffic-management/traffic-shifting.md
+++ b/content/docs/tasks/traffic-management/traffic-shifting.md
@@ -6,7 +6,7 @@ aliases:
     - /docs/tasks/traffic-management/version-migration.html
 ---
 
-> This task uses the new [v1alpha3 traffic management API](/blog/2018/v1alpha3-routing/). The old API has been deprecated and will be removed in the next Istio release. If you need to use the old version, follow the docs [here](https://archive.istio.io/v0.6/docs/tasks/).
+> This task uses the new [v1alpha3 traffic management API](/blog/2018/v1alpha3-routing/). The old API has been deprecated and will be removed in the next Istio release. If you need to use the old version, follow the docs [here](https://archive.istio.io/v0.7/docs/tasks/traffic-management/).
 
 This task shows you how to gradually migrate traffic from an old to new version of a service.
 With Istio, we can migrate the traffic in a gradual fashion by using a sequence of rules


### PR DESCRIPTION
instead of 0.6

```bash
sed -e 's/https:\/\/archive.istio.io\/v0.6\/docs\/tasks\//https:\/\/archive.istio.io\/v0.7\/docs\/tasks\/traffic-management\//g' *.md
```