### PR TITLE
update httpbin deployment steps.

### DIFF
--- a/content/docs/tasks/traffic-management/ingress.md
+++ b/content/docs/tasks/traffic-management/ingress.md
@@ -30,7 +30,7 @@ This task describes how to configure Istio to expose a service outside of the se
     ```command
     $ kubectl apply -f samples/httpbin/httpbin.yaml
     ```
-    otherwise, you have to manually inject sidecar before deploying the `httpbin` application:
+    otherwise, you have to manually inject the sidecar before deploying the `httpbin` application:
 
     ```command
     $ kubectl apply -f <(istioctl kube-inject -f samples/httpbin/httpbin.yaml)

--- a/content/docs/tasks/traffic-management/ingress.md
+++ b/content/docs/tasks/traffic-management/ingress.md
@@ -25,10 +25,15 @@ This task describes how to configure Istio to expose a service outside of the se
 *   Start the [httpbin](https://github.com/istio/istio/tree/master/samples/httpbin) sample,
     which will be used as the destination service to be exposed externally.
 
-    If you installed  [Istio-Initializer](/docs/setup/kubernetes/sidecar-injection/#automatic-sidecar-injection), do
+    If you have enabled [automatic sidecar injection](/docs/setup/kubernetes/sidecar-injection/#automatic-sidecar-injection), do
 
     ```command
     $ kubectl apply -f samples/httpbin/httpbin.yaml
+    ```
+    otherwise, you have to manually inject sidecar before deploying the `httpbin` application:
+
+    ```command
+    $ kubectl apply -f <(istioctl kube-inject -f samples/httpbin/httpbin.yaml)
     ```
 
 *   A private key and certificate can be created for testing using [OpenSSL](https://www.openssl.org/).


### PR DESCRIPTION
We have replaced `Istio-Initializer` with `sidecar-webhook` since istio 0.5.0, let's update the `httpbin` deploying steps accordingly.