### PR TITLE
Updated OpenShift section to match the new list of service accounts

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -295,7 +295,6 @@ googleapis.com
 googlegroups.com
 goroutine
 goroutines
-grafana
 grafana-istio-dashboard
 grpc
 helloworld

--- a/.spelling
+++ b/.spelling
@@ -295,6 +295,7 @@ googleapis.com
 googlegroups.com
 goroutine
 goroutines
+grafana
 grafana-istio-dashboard
 grpc
 helloworld

--- a/content/docs/setup/kubernetes/quick-start.md
+++ b/content/docs/setup/kubernetes/quick-start.md
@@ -118,8 +118,7 @@ $ oc adm policy add-scc-to-user anyuid -z istio-pilot-service-account -n istio-s
 $ oc adm policy add-scc-to-user anyuid -z istio-sidecar-injector-service-account -n istio-system
 ```
 
-The list above covers the default Istio service accounts.  
-If you enabled other Istio service (e.g. _grafana_) you will need to cover its service account in a similar command.
+The list above covers the default Istio service accounts. If you enabled other Istio service (e.g. _grafana_) you will need to cover its service account in a similar command.
 
 Service account that runs application pods need privileged security context constraints as part of sidecar injection.
 

--- a/content/docs/setup/kubernetes/quick-start.md
+++ b/content/docs/setup/kubernetes/quick-start.md
@@ -102,14 +102,24 @@ Configure `kubectl` CLI based on steps [here](https://www.ibm.com/support/knowle
 ### OpenShift Origin
 
 OpenShift by default does not allow containers running with UID 0. Enable containers running
-with UID 0 for Istio's service accounts for ingress as well the Prometheus and Grafana addons:
+with UID 0 for Istio's service accounts:
 
 ```command
 $ oc adm policy add-scc-to-user anyuid -z istio-ingress-service-account -n istio-system
 $ oc adm policy add-scc-to-user anyuid -z default -n istio-system
-$ oc adm policy add-scc-to-user anyuid -z grafana -n istio-system
 $ oc adm policy add-scc-to-user anyuid -z prometheus -n istio-system
+$ oc adm policy add-scc-to-user anyuid -z istio-egressgateway-service-account -n istio-system
+$ oc adm policy add-scc-to-user anyuid -z istio-citadel-service-account -n istio-system
+$ oc adm policy add-scc-to-user anyuid -z istio-ingressgateway-service-account -n istio-system
+$ oc adm policy add-scc-to-user anyuid -z istio-cleanup-old-ca-service-account -n istio-system
+$ oc adm policy add-scc-to-user anyuid -z istio-mixer-post-install-account -n istio-system
+$ oc adm policy add-scc-to-user anyuid -z istio-mixer-service-account -n istio-system
+$ oc adm policy add-scc-to-user anyuid -z istio-pilot-service-account -n istio-system
+$ oc adm policy add-scc-to-user anyuid -z istio-sidecar-injector-service-account -n istio-system
 ```
+
+The list above covers the default Istio service accounts.  
+If you enabled other Istio service (e.g. _grafana_) you will need to cover its service account in a similar command.
 
 Service account that runs application pods need privileged security context constraints as part of sidecar injection.
 

--- a/content/docs/setup/kubernetes/quick-start.md
+++ b/content/docs/setup/kubernetes/quick-start.md
@@ -118,7 +118,7 @@ $ oc adm policy add-scc-to-user anyuid -z istio-pilot-service-account -n istio-s
 $ oc adm policy add-scc-to-user anyuid -z istio-sidecar-injector-service-account -n istio-system
 ```
 
-The list above covers the default Istio service accounts. If you enabled other Istio service (e.g. _grafana_) you will need to cover its service account in a similar command.
+The list above covers the default Istio service accounts. If you enabled other Istio services (e.g. _Grafana_) you will need to cover its service account in a similar command.
 
 Service account that runs application pods need privileged security context constraints as part of sidecar injection.
 


### PR DESCRIPTION
In https://github.com/istio/issues/issues/354 users reported errors when installing by following the current quick guide.
The reason is that the list of service accounts is not updated to those exists in v0.8.0.