### PR TITLE
Remove the deprecated --debug in istioctl

### DIFF
--- a/content/docs/guides/bookinfo.md
+++ b/content/docs/guides/bookinfo.md
@@ -84,7 +84,7 @@ To start the application, follow the instructions below corresponding to your Is
         use the following command
 
         ```command
-        $ kubectl apply -f <(istioctl kube-inject --debug -f @samples/bookinfo/kube/bookinfo.yaml@)
+        $ kubectl apply -f <(istioctl kube-inject -f @samples/bookinfo/kube/bookinfo.yaml@)
         ```
 
         The `istioctl kube-inject` command is used to manually modify the `bookinfo.yaml`

--- a/content/docs/tasks/security/https-overlay.md
+++ b/content/docs/tasks/security/https-overlay.md
@@ -50,7 +50,7 @@ replicationcontroller "my-nginx" created
 Then, create another pod to call this service.
 
 ```command
-$ kubectl apply -f <(bin/istioctl kube-inject --debug -f @samples/sleep/sleep.yaml@)
+$ kubectl apply -f <(bin/istioctl kube-inject -f @samples/sleep/sleep.yaml@)
 ```
 
 Get the pods
@@ -100,7 +100,7 @@ $ kubectl delete -f nginx-app.yaml
 Deploy it with a sidecar
 
 ```command
-$ kubectl apply -f <(bin/istioctl kube-inject --debug -f @samples/https/nginx-app.yaml@)
+$ kubectl apply -f <(bin/istioctl kube-inject -f @samples/https/nginx-app.yaml@)
 ```
 
 Make sure the pod is up and running
@@ -168,10 +168,10 @@ istio-pilot-6954dcd96d-phh5z     2/2       Running   0          2m
 Then redeploy the HTTPS service and sleep service
 
 ```command
-$ kubectl delete -f <(bin/istioctl kube-inject --debug -f @samples/sleep/sleep.yaml@)
-$ kubectl apply -f <(bin/istioctl kube-inject --debug -f @samples/sleep/sleep.yaml@)
-$ kubectl delete -f <(bin/istioctl kube-inject --debug -f @samples/https/nginx-app.yaml@)
-$ kubectl apply -f <(bin/istioctl kube-inject --debug -f @samples/https/nginx-app.yaml@)
+$ kubectl delete -f <(bin/istioctl kube-inject -f @samples/sleep/sleep.yaml@)
+$ kubectl apply -f <(bin/istioctl kube-inject -f @samples/sleep/sleep.yaml@)
+$ kubectl delete -f <(bin/istioctl kube-inject -f @samples/https/nginx-app.yaml@)
+$ kubectl apply -f <(bin/istioctl kube-inject -f @samples/https/nginx-app.yaml@)
 ```
 
 Make sure the pod is up and running

--- a/content/docs/tasks/security/mutual-tls.md
+++ b/content/docs/tasks/security/mutual-tls.md
@@ -27,10 +27,9 @@ This task assumes you have a Kubernetes cluster:
 * For demo, deploy [httpbin](https://github.com/istio/istio/blob/{{<branch_name>}}/samples/httpbin) and [sleep](https://github.com/istio/istio/tree/master/samples/sleep) with Envoy sidecar. For simplicity, the demo is setup in the `default` namespace. If you wish to use a different namespace,  please add `-n yournamespace` appropriately to the example commands in the next section.
 
     ```command
-    $ kubectl apply -f <(istioctl kube-inject -f @samples/httpbin/httpbin.yaml@ --debug)
-    $ kubectl apply -f <(istioctl kube-inject -f @samples/sleep/sleep.yaml@ --debug)
+    $ kubectl apply -f <(istioctl kube-inject -f @samples/httpbin/httpbin.yaml@)
+    $ kubectl apply -f <(istioctl kube-inject -f @samples/sleep/sleep.yaml@)
     ```
-    > Use `--debug` to inject the sidecar container with proxy-debug image, which is needed to run `curl` command from istio-proxy container later in the demo.
 
 ## Verifying Istio's mutual TLS authentication setup
 

--- a/content/docs/tasks/traffic-management/circuit-breaking.md
+++ b/content/docs/tasks/traffic-management/circuit-breaking.md
@@ -17,7 +17,7 @@ This task demonstrates the circuit-breaking capability for resilient application
     which will be used as the backend service for our task
 
     ```command
-    $ kubectl apply -f <(istioctl kube-inject --debug -f @samples/httpbin/httpbin.yaml@)
+    $ kubectl apply -f <(istioctl kube-inject -f @samples/httpbin/httpbin.yaml@)
     ```
 
 ## Circuit breaker
@@ -81,7 +81,7 @@ Let's set up a scenario to demonstrate the circuit-breaking capabilities of Isti
 Now that we've set up rules for calling the `httpbin` service, let's create a client we can use to send traffic to our service and see whether we can trip the circuit breaking policies. We're going to use a simple load-testing client called [fortio](https://github.com/istio/fortio). With this client we can control the number of connections, concurrency, and delays of outgoing HTTP calls. In this step, we'll set up a client that is injected with the istio sidecar proxy so our network interactions are governed by Istio:
 
 ```command
-$ kubectl apply -f <(istioctl kube-inject --debug -f @samples/httpbin/sample-client/fortio-deploy.yaml@)
+$ kubectl apply -f <(istioctl kube-inject -f @samples/httpbin/sample-client/fortio-deploy.yaml@)
 ```
 
 Now we should be able to log into that client pod and use the simple fortio tool to call `httpbin`. We'll pass in `-curl` to indicate we just want to make one call:

--- a/content/help/troubleshooting.md
+++ b/content/help/troubleshooting.md
@@ -26,13 +26,6 @@ Verifying connectivity to Pilot is a useful troubleshooting step. Every proxy co
     $ kubectl exec -it $INGRESS_POD_NAME -n istio-system /bin/bash
     ```
 
-1.  Unless you installed Istio using the debug proxy image (`istioctl kube-inject --debug=true`), you need to
-install curl.
-
-    ```command
-    $ apt-get update && apt-get install -y curl
-    ```
-
 1.  Test connectivity to Pilot using cURL. The following example cURL's the v1 registration API using default Pilot configuration parameters and mTLS enabled:
 
     ```command


### PR DESCRIPTION
Currently the default proxy image has curl already, which means --debug option is not needed, and it's deprecated as well. 