### PR TITLE
Updated maxConnections to 1.

### DIFF
--- a/content/docs/tasks/traffic-management/circuit-breaking.md
+++ b/content/docs/tasks/traffic-management/circuit-breaking.md
@@ -37,7 +37,7 @@ Let's set up a scenario to demonstrate the circuit-breaking capabilities of Isti
       trafficPolicy:
         connectionPool:
           tcp:
-            maxConnections: 100
+            maxConnections: 1
           http:
             http1MaxPendingRequests: 1
             maxRequestsPerConnection: 1


### PR DESCRIPTION
The example in https://preliminary.istio.io/docs/tasks/traffic-management/circuit-breaking/ want to use  `maxConnections: 1`, but the destinationrules is setting `maxConnections: 100`, we should update document to set it as 1.

/cc @geeknoid @frankbu 