### PR TITLE
Format the output of curl to json.

### DIFF
--- a/content/docs/tasks/traffic-management/mirroring.md
+++ b/content/docs/tasks/traffic-management/mirroring.md
@@ -155,7 +155,7 @@ Let's set up a scenario to demonstrate the traffic-mirroring capabilities of Ist
 
     ```command-output-as-json
     $ export SLEEP_POD=$(kubectl get pod -l app=sleep -o jsonpath={.items..metadata.name})
-    $ kubectl exec -it $SLEEP_POD -c sleep -- sh -c 'curl  http://httpbin:8080/headers'
+    $ kubectl exec -it $SLEEP_POD -c sleep -- sh -c 'curl  http://httpbin:8080/headers' | python -m json.tool
     {
       "headers": {
         "Accept": "*/*",
@@ -212,7 +212,7 @@ Let's set up a scenario to demonstrate the traffic-mirroring capabilities of Ist
     Now if we send in traffic:
 
     ```command
-    $ kubectl exec -it $SLEEP_POD -c sleep -- sh -c 'curl  http://httpbin:8080/headers'
+    $ kubectl exec -it $SLEEP_POD -c sleep -- sh -c 'curl  http://httpbin:8080/headers' | python -m json.tool
     ```
 
     We should see access logging for both `v1` and `v2`. The access logs created in `v2` is the mirrored requests that are actually going to `v1`.


### PR DESCRIPTION
With json format:
```
[root@gyliu-icp-1 istio-0.8.0]# kubectl exec -it $SLEEP_POD -c sleep -- sh -c 'curl  http://httpbin:8080/headers' | python -m json.tool
{
    "headers": {
        "Accept": "*/*",
        "Content-Length": "0",
        "Host": "httpbin:8080",
        "User-Agent": "curl/7.35.0",
        "X-B3-Sampled": "1",
        "X-B3-Spanid": "9e707b357acf81aa",
        "X-B3-Traceid": "9e707b357acf81aa",
        "X-Envoy-Expected-Rq-Timeout-Ms": "15000"
    }
}
```
Without json format:
```
[root@gyliu-icp-1 istio-0.8.0]# kubectl exec -it $SLEEP_POD -c sleep -- sh -c 'curl  http://httpbin:8080/headers'
{"headers":{"Accept":"*/*","Content-Length":"0","Host":"httpbin:8080","User-Agent":"curl/7.35.0","X-B3-Sampled":"1","X-B3-Spanid":"6e3f5844e238e570","X-B3-Traceid":"6e3f5844e238e570","X-Envoy-Expected-Rq-Timeout-Ms":"15000"}}
```

/cc @geeknoid