### PR TITLE
Update GCP-Quickstart DM link to specify 0.8 directly

### DIFF
--- a/content/docs/setup/kubernetes/quick-start-gke-dm.md
+++ b/content/docs/setup/kubernetes/quick-start-gke-dm.md
@@ -42,7 +42,7 @@ caption="GKE-IAM Role"
 
 1.  Once you have an account and project enabled, click the following link to open the Deployment Manager.
 
-    [Istio GKE Deployment Manager](https://accounts.google.com/signin/v2/identifier?service=cloudconsole&continue=https://console.cloud.google.com/launcher/config?templateurl=https://raw.githubusercontent.com/istio/istio/{{<branch_name>}}/install/gcp/deployment_manager/istio-cluster.jinja&followup=https://console.cloud.google.com/launcher/config?templateurl=https://raw.githubusercontent.com/istio/istio/master/install/gcp/deployment_manager/istio-cluster.jinja&flowName=GlifWebSignIn&flowEntry=ServiceLogin)
+    [Istio GKE Deployment Manager](https://accounts.google.com/signin/v2/identifier?service=cloudconsole&continue=https://console.cloud.google.com/launcher/config?templateurl=https://raw.githubusercontent.com/istio/istio/release-0.8/install/gcp/deployment_manager/istio-cluster.jinja&followup=https://console.cloud.google.com/launcher/config?templateurl=https://raw.githubusercontent.com/istio/istio/release-0.8/install/gcp/deployment_manager/istio-cluster.jinja&flowName=GlifWebSignIn&flowEntry=ServiceLogin)
 
     We recommend that you leave the default settings as the rest of this tutorial shows how to access the installed features. By default the tool creates a
     GKE alpha cluster with the specified settings, then installs the Istio [control plane](/docs/concepts/what-is-istio/overview/#architecture), the


### PR DESCRIPTION
@geeknoid 

Currently the DM link from the ```0.8``` docs istio points to ```master``` when instead it should be to the DM template for the release.  (it seems the ```{{<branch_name}}``` variable translates to ```master```):

so currently for ```0.8```, we have 
- [https://istio.io/docs/setup/kubernetes/quick-start-gke-dm/#launch-deployment-manager](https://istio.io/docs/setup/kubernetes/quick-start-gke-dm/#launch-deployment-manager)

eg. if you hover over or inspect the link to for ```Istio GKE Deployment Manager```, it goes master.  THis change alters it to go to the release template explictly.