### PR TITLE
Update for installations with mTLS auth enabled

### DIFF
--- a/content/docs/tasks/traffic-management/mirroring.md
+++ b/content/docs/tasks/traffic-management/mirroring.md
@@ -152,6 +152,8 @@ Let's set up a scenario to demonstrate the traffic-mirroring capabilities of Ist
         EOF
     ```
 
+    > NOTE: If you installed/configured istio with mTLS Authentication enabled, you must add the [TLSSettings.TLSmode]( /docs/reference/config/istio.networking.v1alpha3/#TLSSettings.TLS), `mode: ISTIO_MUTUAL` as noted in the [TLSSettings](/docs/reference/config/istio.networking.v1alpha3/#TLSSettings) reference.
+
     Now all traffic should go to `httpbin v1` service. Let's try sending in some traffic:
 
     ```command-output-as-json

--- a/content/docs/tasks/traffic-management/mirroring.md
+++ b/content/docs/tasks/traffic-management/mirroring.md
@@ -152,7 +152,7 @@ Let's set up a scenario to demonstrate the traffic-mirroring capabilities of Ist
         EOF
     ```
 
-    > NOTE: If you installed/configured istio with mTLS Authentication enabled, you must add the [TLSSettings.TLSmode]( /docs/reference/config/istio.networking.v1alpha3/#TLSSettings.TLSmode), `mode: ISTIO_MUTUAL` as noted in the [TLSSettings](/docs/reference/config/istio.networking.v1alpha3/#TLSSettings) reference.
+    > NOTE: If you installed/configured istio with mTLS Authentication enabled, you must add the [TLSSettings.TLSmode]( /docs/reference/config/istio.networking.v1alpha3/#TLSSettings-TLSmode), `mode: ISTIO_MUTUAL` as noted in the [TLSSettings](/docs/reference/config/istio.networking.v1alpha3/#TLSSettings) reference.
 
     Now all traffic should go to `httpbin v1` service. Let's try sending in some traffic:
 

--- a/content/docs/tasks/traffic-management/mirroring.md
+++ b/content/docs/tasks/traffic-management/mirroring.md
@@ -152,7 +152,7 @@ Let's set up a scenario to demonstrate the traffic-mirroring capabilities of Ist
         EOF
     ```
 
-    > NOTE: If you installed/configured istio with mTLS Authentication enabled, you must add the [TLSSettings.TLSmode]( /docs/reference/config/istio.networking.v1alpha3/#TLSSettings.TLS), `mode: ISTIO_MUTUAL` as noted in the [TLSSettings](/docs/reference/config/istio.networking.v1alpha3/#TLSSettings) reference.
+    > NOTE: If you installed/configured istio with mTLS Authentication enabled, you must add the [TLSSettings.TLSmode]( /docs/reference/config/istio.networking.v1alpha3/#TLSSettings.TLSmode), `mode: ISTIO_MUTUAL` as noted in the [TLSSettings](/docs/reference/config/istio.networking.v1alpha3/#TLSSettings) reference.
 
     Now all traffic should go to `httpbin v1` service. Let's try sending in some traffic:
 


### PR DESCRIPTION
The docs do not provide reference to installations with mTLS auth enabled.  If mTLS auth is enabled and the user goes through the instructions, they will encounter `upstream connect error or disconnect/reset before headers` when the DestinationRule is applied.

istio/issues#375 (comment) helped lead to the resolution.