### PR TITLE
Adapt servicegraph task description to istio

### DIFF
--- a/content/docs/tasks/telemetry/servicegraph.md
+++ b/content/docs/tasks/telemetry/servicegraph.md
@@ -19,7 +19,7 @@ the example application throughout this task.
 ## Generating a Service Graph
 
 1.  To view a graphical representation of your service mesh, use the Servicegraph add-on
-    which is installed with istio. Verify that the service is running in your cluster.
+    which is installed with Istio. Verify that the service is running in your cluster.
 
     In Kubernetes environments, execute the following command:
 

--- a/content/docs/tasks/telemetry/servicegraph.md
+++ b/content/docs/tasks/telemetry/servicegraph.md
@@ -18,8 +18,8 @@ the example application throughout this task.
 
 ## Generating a Service Graph
 
-1.  To view a graphical representation of your service mesh, use servicegraph which is installed with istio.
-    Verify that the service is running in your cluster.
+1.  To view a graphical representation of your service mesh, use the Servicegraph add-on
+    which is installed with istio. Verify that the service is running in your cluster.
 
     In Kubernetes environments, execute the following command:
 

--- a/content/docs/tasks/telemetry/servicegraph.md
+++ b/content/docs/tasks/telemetry/servicegraph.md
@@ -18,16 +18,8 @@ the example application throughout this task.
 
 ## Generating a Service Graph
 
-1.  To view a graphical representation of your service mesh, install the
-    Servicegraph add-on.
-
-    In Kubernetes environments, execute the following command:
-
-    ```command
-    $ kubectl apply -f @install/kubernetes/addons/servicegraph.yaml@
-    ```
-
-1.  Verify that the service is running in your cluster.
+1.  To view a graphical representation of your service mesh, use servicegraph which is installed with istio.
+    Verify that the service is running in your cluster.
 
     In Kubernetes environments, execute the following command:
 


### PR DESCRIPTION
installation, as it already contains servicegraph by default.
Also the file install/kubernetes/addons/servicegraph.yml no longer
exists.

Co-authored-by: Holger Oehm <holger.oehm@sap.com>