### PR TITLE
A section to demonstrate installing just a minimal set

### DIFF
--- a/content/docs/setup/kubernetes/helm-install.md
+++ b/content/docs/setup/kubernetes/helm-install.md
@@ -97,6 +97,7 @@ following table:
 | `global.tag` | Specifies the TAG for most images used by Istio | valid image tag | `circleci-nightly` |
 | `global.proxy.image` | Specifies the proxy image name | valid proxy name | `proxyv2` |
 | `global.proxy.includeIPRanges` | Specifies the IP ranges for which outbound traffic is redirected to Envoy | List of IP ranges in CIDR notation separated by the escaped comma `\,` . Use `*` to redirect all outbound traffic to Envoy | `*` |
+| `global.proxy.envoyStatsd` | Specifies the Statsd server that Envoy should send its stats to | host/IP and port | `istio-statsd-prom-bridge:9125` |
 | `global.imagePullPolicy` | Specifies the image pull policy | valid image pull policy | `IfNotPresent` |
 | `global.controlPlaneSecurityEnabled` | Specifies whether control plane mTLS is enabled | true/false | `false` |
 | `global.mtls.enabled` | Specifies whether mTLS is enabled by default between services | true/false | `false` |
@@ -110,6 +111,38 @@ following table:
 The Helm chart also offers significant customization options per individual
 service. Customize these per-service options at your own risk. The per-service options are exposed via
 the [`values.yaml`](https://raw.githubusercontent.com/istio/istio/{{<branch_name>}}/install/kubernetes/helm/istio/values.yaml) file.
+
+## Customization Example: Traffic Management Minimal Set
+
+Istio is equipped with a rich and powerful set of features and some users may need only subset of those. For instance, users might be interested only
+in installing the minimal set required to Istio's traffic management.
+[Helm customization](#customization-with-helm) provides the option to install a subset by enabling those features of interest and disabling the ones that aren't required.
+
+In this example we will install Istio with only a minimal set of components necessary to conduct [traffic management](/docs/tasks/traffic-management/).
+
+Execute the following command to install the Pilot, Citadel, IngressGateway and Sidecar-Injector:
+
+```command
+$ helm install install/kubernetes/helm/istio --name istio --namespace istio-system \
+  --set ingress.enabled=false,egressgateway.enabled=false,galley.enabled=false \
+  --set mixer.enabled=false,prometheus.enabled=false,global.proxy.envoyStatsd.enabled=false
+```
+
+Ensure the following Kubernetes pods are deployed and their containers are up and running: `istio-pilot-*`, `istio-ingressgateway-*`,
+`istio-citadel-*` and `istio-sidecar-injector-*`.
+
+```command
+$ kubectl get pods -n istio-system
+NAME                                     READY     STATUS    RESTARTS   AGE
+istio-citadel-b48446f79-wd4tk            1/1       Running   0          1m
+istio-ingressgateway-7b77d995f7-t6ssx    1/1       Running   0          1m
+istio-pilot-58c65f74bc-2f5xn             2/2       Running   0          1m
+istio-sidecar-injector-86cc99578-4t58m   1/1       Running   0          1m
+```
+
+With this minimal set you can proceed to installing the sample [Bookinfo](/docs/guides/bookinfo/) application or install your own application and [configure request routing](/docs/tasks/traffic-management/request-routing/) for instance.
+
+Of course that if no ingress is expected and sidecar is to be [injected manually](/docs/setup/kubernetes/sidecar-injection/#manual-sidecar-injection) then you can reduce this minimal set even further and only have Pilot and Citadel. However, Pilot depends on Citadel therefore you can't install it without the other.
 
 ## What's next
 


### PR DESCRIPTION
Following https://github.com/istio/istio.github.io/issues/1294 and after a long journey to decouple Istio components (https://github.com/istio/istio/issues/5731).

While it was originally planned to have a guide I thought that a section in the Helm guide is more appropriate because beside the Helm command the rest isn't much different than the usual default installation.