### PR TITLE
Potential typo in rules-configuration.yml

### DIFF
--- a/content/docs/concepts/traffic-management/rules-configuration.md
+++ b/content/docs/concepts/traffic-management/rules-configuration.md
@@ -666,7 +666,7 @@ about accessing external services.
 ## Gateways
 
 A [Gateway](/docs/reference/config/istio.networking.v1alpha3/#Gateway)
-configure a load balancer for HTTP/TCP traffic, most commonly operating at the edge of the
+configures a load balancer for HTTP/TCP traffic, most commonly operating at the edge of the
 mesh to enable ingress traffic for an application.
 
 Unlike Kubernetes Ingress, Istio `Gateway` only configures the L4-L6 functions


### PR DESCRIPTION
The *Gateways* section starts with: `A Gateway configure`.  Shouldn't that be: `A Gateway configures`?