### PR TITLE
Update quick-start.md

### DIFF
--- a/content/docs/setup/kubernetes/quick-start.md
+++ b/content/docs/setup/kubernetes/quick-start.md
@@ -266,20 +266,6 @@ Install Istio's core components. Choose one of the four _**mutually exclusive**_
 
 *  Install Istio without enabling [mutual TLS authentication](/docs/concepts/security/mutual-tls/) between sidecars. Choose this option for clusters with existing applications, applications where services with an Istio sidecar need to be able to communicate with other non-Istio Kubernetes services, and applications that use [liveness and readiness probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/), headless services, or StatefulSets.
 
-```command
-$ kubectl apply -f install/kubernetes/istio-demo.yaml
-```
-
-OR
-
-*  Install Istio and enforce mutual TLS authentication between sidecars by default. Use this option only on a fresh kubernetes cluster where newly deployed workloads are guaranteed to have Istio sidecars installed.
-
-```command
-$ kubectl apply -f install/kubernetes/istio-demo-auth.yaml
-```
-
-OR
-
 *  [Render Kubernetes manifest with Helm and deploy with kubectl](/docs/setup/kubernetes/helm-install/#option-1-install-with-helm-via-helm-template).
 
 OR


### PR DESCRIPTION
Files don't exist anymore:
* `install/kubernetes/istio-demo.yaml` 
* `install/kubernetes/istio-demo-auth.yaml`
There is only the helm charts.

Related https://github.com/istio/istio/pull/6348