### PR TITLE
RSS Feed update

### DIFF
--- a/layouts/feed/single.rss.xml
+++ b/layouts/feed/single.rss.xml
@@ -12,18 +12,23 @@
       <url>{{ $home }}/favicons/android-192x192.png</url>
       <link>{{ $home }}</link>
     </image>
+    <category>Service mesh</category>
 
-    {{ $pages := (where .Site.Pages "Section" "blog").ByPublishDate }}
+    {{ $pages := (where .Site.Pages "Section" "blog").ByPublishDate.Reverse }}
 
     {{ range $post := $pages }}
       {{ if and (not $post.Draft) $post.IsPage }}
         <item>
           <title>{{ $post.Title }}</title>
           <description>{{ $post.Description }}</description>
-          <pubDate>{{ $post.PublishDate }}</pubDate>
+          <pubDate>{{ $post.PublishDate.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
           <link>{{ $post.Permalink }}</link>
           <author>{{ $post.Params.attribution }}</author>
           <guid isPermaLink="true">{{ $post.Permalink }}</guid>
+
+          {{ range $kw := $post.Keywords }}
+              <category>{{ $kw }}</category>
+          {{ end }}
         </item>
       {{ end }}
     {{ end }}


### PR DESCRIPTION
- List items in reverse order of publication

- Fix the publication date format to match what the RSS spec says.

- Include <category> elements for each post, derived from any keywords specified in the post front-matter.

Fixes #1537 