### PR TITLE
Add support for snippets and file content insertion.

### DIFF
--- a/content/about/contribute/writing-a-new-topic.md
+++ b/content/about/contribute/writing-a-new-topic.md
@@ -294,18 +294,44 @@ This will be rendered as:
 $ istioctl create -f @samples/bookinfo/kube/route-rule-reviews-v3.yaml@
 ```
 
+## Displaying file snippets
+
+It is often useful to display portions of a larger file. You can annotate a text file to create named snippets within the file by
+using the `$snippet` and `$endsnippet` annotations. For example, you could have a text file that looks like this:
+
+{{< file_content file="examples/snippet_example.txt" lang="plain" >}}
+
+and in your markdown file, you can then reference a particular snippet with:
+
+```markdown
+{{</* file_content file="examples/snippet_example.txt" lang="plain" snippet="SNIP1" */>}}
+```
+
+where `file` specifies the relative path of the text file within the documentation repo, `lang` specifies
+the language to use for syntax coloring (use `plain` for generic text), and `snippet` specifies the name of the
+snippet. If you omit the `snippet` attribute, then the whole file is inserted verbatim.
+
+The above snippet produces this output:
+
+{{< file_content file="examples/snippet_example.txt" lang="plain" snippet="SNIP1" >}}
+
+A common thing to is to copy an example script or yaml file from GitHub into the documentation
+repo and then use snippets within the file to produce examples in the documentation. To pull
+in annotated files from GitHub, add the needed entries at the end of the
+script `scripts/grab_reference_docs.sh` in the documentation repo.
+
 ## Displaying file content
 
 You can pull in an external file and display its content as a preformatted block. This is handy to display a
 config file or a test file. To do so, you use a statement such as:
 
 ```markdown
-{{</* file_content url="https://raw.githubusercontent.com/istio/istio/master/samples/bookinfo/kube/mixer-rule-ratings-ratelimit.yaml" lang="yaml" */>}}
+{{</* fetch_content url="https://raw.githubusercontent.com/istio/istio/master/samples/bookinfo/kube/mixer-rule-ratings-ratelimit.yaml" lang="yaml" */>}}
 ```
 
 which produces the following result:
 
-{{< file_content url="https://raw.githubusercontent.com/istio/istio/master/samples/bookinfo/kube/mixer-rule-ratings-ratelimit.yaml" lang="yaml" >}}
+{{< fetch_content url="https://raw.githubusercontent.com/istio/istio/master/samples/bookinfo/kube/mixer-rule-ratings-ratelimit.yaml" lang="yaml" >}}
 
 If the file is from a different origin site, CORS should be enabled on that site. Note that the
 GitHub raw content site (raw.githubusercontent.com) is may be used here.

--- a/examples/snippet_example.txt
+++ b/examples/snippet_example.txt
@@ -1,0 +1,11 @@
+BEFORE
+
+# $snippet SNIP1
+This is snippet 1
+# $endsnippet
+
+# $snippet SNIP2
+This is snippet 2
+# $endsnippet
+
+AFTER

--- a/layouts/shortcodes/fetch_content.html
+++ b/layouts/shortcodes/fetch_content.html
@@ -1,0 +1,1 @@
+<pre data-src='{{ .Get "url" }}'><code class='language-{{ .Get "lang" }}'></code></pre>

--- a/layouts/shortcodes/file_content.html
+++ b/layouts/shortcodes/file_content.html
@@ -1,1 +1,8 @@
-<pre data-src="{{ .Get "url" }}"><code class="language-{{ .Get "lang" }}"></code></pre>
+{{ $file := readFile (.Get "file") }}
+{{ if (.Get "snippet") }}
+{{ $pattern := printf "(?msU)(.*\\$snippet %s.*$\\n)(.*)(?-s)(\\n^.*\\$endsnippet.*$)(?s-U)(.*)" (.Get "snippet") }}
+{{ $match := replaceRE $pattern "$2" $file }}
+<pre><code class='language-{{ .Get "lang" }}'>{{ $match }}</code></pre>
+{{ else }}
+<pre><code class='language-{{ .Get "lang" }}'>{{ $file }}</code></pre>
+{{ end }}

--- a/scripts/grab_reference_docs.sh
+++ b/scripts/grab_reference_docs.sh
@@ -11,6 +11,10 @@
 
 #set -e
 
+ISTIO_BRANCH=master
+
+#####################
+
 ISTIO_BASE=$(cd "$(dirname "$0")" ; pwd -P)/..
 export GOPATH=$(mktemp -d)
 WORK_DIR=${GOPATH}/src/istio.io
@@ -20,7 +24,13 @@ COMMAND_DIR=$ISTIO_BASE/content/docs/reference/commands
 mkdir -p ${WORK_DIR}
 pushd $WORK_DIR
 git clone https://github.com/istio/api.git
+cd api
+git checkout $ISTIO_BRANCH
+cd ..
 git clone https://github.com/istio/istio.git
+cd istio
+git checkout $ISTIO_BRANCH
+cd ..
 popd
 
 # Given the name of a .pb.html file, extracts the $location marker and then proceeds to
@@ -73,7 +83,6 @@ do
     locate_file $f
 done
 
-# get_command_doc $WORK_DIR/istio/broker/cmd/brks brks
 get_command_doc $WORK_DIR/istio/mixer/cmd/mixc mixc
 get_command_doc $WORK_DIR/istio/mixer/cmd/mixs mixs
 get_command_doc $WORK_DIR/istio/istioctl/cmd/istioctl istioctl
@@ -82,5 +91,8 @@ get_command_doc $WORK_DIR/istio/pilot/cmd/pilot-discovery pilot-discovery
 get_command_doc $WORK_DIR/istio/pilot/cmd/sidecar-injector sidecar-injector
 get_command_doc $WORK_DIR/istio/security/cmd/istio_ca istio_ca
 get_command_doc $WORK_DIR/istio/security/cmd/node_agent node_agent
+
+# Copy all the example files over into the examples directory
+# cp $WORK_DIR/istio/Makefile examples/Makefile
 
 rm -fr $WORK_DIR


### PR DESCRIPTION
- You can now use {{< file_content >}} to pull in files from the doc repo
into generated documentation. If you include the `snippet` attribute, you can
pull in only pieces of the file instead. This makes it possible to annotate
scripts and yaml files and extract those annotated bits and pieces into the
docs. This should let us have fully tested examples which are then incorporated
into the docs

- The previous {{< file_content >}} feature that lets you dynamically pull
content from a URL has been renamed to {{< fetch_content >}} instead.