### PR TITLE
add istio.io/tools to golang vanity redirects

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -6,6 +6,7 @@
 /extensions/* go-get=1 /golang/extensions.html 200
 /contrib/* go-get=1 /golang/contrib.html 200
 /test-infra/* go-get=1 /golang/test-infra.html 200
+/tools/* go-get=1 /golang/tools.html 200
 
 # Redirect default Netlify subdomain to primary domain
 https://istio.netlify.com/* https://istio.io/:splat 301!

--- a/static/golang/tools.html
+++ b/static/golang/tools.html
@@ -1,0 +1,4 @@
+<html><head>
+    <meta name="go-import" content="istio.io/tools git https://github.com/istio/tools">
+    <meta name="go-source" content="istio.io/tools     https://github.com/istio/tools https://github.com/istio/tools/tree/master{/dir} https://github.com/istio/tools/blob/master{/dir}/{file}#L{line}">
+</head></html>


### PR DESCRIPTION
We also need to cherry-pick this into 0.8 branch so that it's served by the main site (istio.io) and not just preliminary.istio.io.