### PR TITLE
fix the kubectl logs command usage

### DIFF
--- a/content/docs/tasks/telemetry/metrics-logs/index.md
+++ b/content/docs/tasks/telemetry/metrics-logs/index.md
@@ -168,7 +168,7 @@ as the example application throughout this task.
     follows:
 
     ```command-output-as-json
-    $ kubectl -n istio-system logs $(kubectl -n istio-system get pods -l istio-mixer-type=telemetry -o jsonpath='{.items[0].metadata.name}') mixer | grep \"instance\":\"newlog.logentry.istio-system\"
+    $ kubectl -n istio-system logs $(kubectl -n istio-system get pods -l istio-mixer-type=telemetry -o jsonpath='{.items[0].metadata.name}') -c mixer | grep \"instance\":\"newlog.logentry.istio-system\"
     {"level":"warn","ts":"2017-09-21T04:33:31.249Z","instance":"newlog.logentry.istio-system","destination":"details","latency":"6.848ms","responseCode":200,"responseSize":178,"source":"productpage","user":"unknown"}
     {"level":"warn","ts":"2017-09-21T04:33:31.291Z","instance":"newlog.logentry.istio-system","destination":"ratings","latency":"6.753ms","responseCode":200,"responseSize":48,"source":"reviews","user":"unknown"}
     {"level":"warn","ts":"2017-09-21T04:33:31.263Z","instance":"newlog.logentry.istio-system","destination":"reviews","latency":"39.848ms","responseCode":200,"responseSize":379,"source":"productpage","user":"unknown"}

--- a/content/help/faq/mixer/mixer-self-monitoring.md
+++ b/content/help/faq/mixer/mixer-self-monitoring.md
@@ -16,7 +16,7 @@ function:
 Mixer logs can be accessed via a `kubectl logs` command, as follows:
 
 ```command
-$ kubectl -n istio-system logs $(kubectl -n istio-system get pods -listio=mixer -o jsonpath='{.items[0].metadata.name}') mixer
+$ kubectl -n istio-system logs $(kubectl -n istio-system get pods -listio=mixer -o jsonpath='{.items[0].metadata.name}') -c mixer
 ```
 Mixer trace generation is controlled by the command-line flag `traceOutput`. If
 the flag value is set to `STDOUT` or `STDERR` trace data will be written

--- a/content/help/troubleshooting/index.md
+++ b/content/help/troubleshooting/index.md
@@ -252,7 +252,7 @@ or [manual](/docs/setup/kubernetes/sidecar-injection/#manual-sidecar-injection) 
         In Kubernetes environments, retrieve the Mixer logs via:
 
         ```command
-        $ kubectl -n istio-system logs <mixer pod> mixer
+        $ kubectl -n istio-system logs <mixer pod> -c mixer
         ```
 
         Look for errors related to your configuration or your service in the
@@ -292,7 +292,7 @@ More on viewing Mixer configuration can be found [here](/help/faq/mixer/#mixer-s
     In Kubernetes environment, check the Mixer logs via:
 
     ```command
-    $ kubectl -n istio-system logs <mixer pod> mixer
+    $ kubectl -n istio-system logs <mixer pod> -c mixer
     ```
 
     Filter for lines including something like `Report 0 returned with: INTERNAL


### PR DESCRIPTION
Accordingly with the kubectl help documentation for the logs
command, the container name is a flag and not an argument:

`
Usage:
  kubectl logs [-f] [-p] (POD | TYPE/NAME) [-c CONTAINER] [options]
`

The use of an argument instead of a flag is to keep compatible
with legacy systems, but it is not recommended as it can be removed
at any time.