### PR TITLE
Fix for encoding errors on commands index page.

### DIFF
--- a/content/docs/reference/commands/mixc/index.html
+++ b/content/docs/reference/commands/mixc/index.html
@@ -1,6 +1,6 @@
 ---
 title: mixc
-description: Utility to trigger direct calls to Mixer&#39;s API.
+description: Utility to trigger direct calls to Mixer's API.
 generator: pkg-collateral-docs
 number_of_entries: 5
 ---

--- a/content/docs/reference/commands/mixs/index.html
+++ b/content/docs/reference/commands/mixs/index.html
@@ -1,6 +1,6 @@
 ---
 title: mixs
-description: Mixer is Istio&#39;s abstraction on top of infrastructure backends.
+description: Mixer is Istio's abstraction on top of infrastructure backends.
 generator: pkg-collateral-docs
 number_of_entries: 9
 ---


### PR DESCRIPTION
The apostrophes in the descriptions of the commands are incorrectly encoded on the commands index page:

<img width="619" alt="istio___commands" src="https://user-images.githubusercontent.com/403387/42102004-5ca19d9c-7b8a-11e8-86bc-1a8de886f3b1.png">

This appears to be because HTML encoding is used in the header of the nested files. The fix is to remove the encoding in the non-HTML portion of the files.