### PR TITLE
edit reviews virtualservice yaml output

### DIFF
--- a/content/docs/tasks/traffic-management/traffic-shifting/index.md
+++ b/content/docs/tasks/traffic-management/traffic-shifting/index.md
@@ -59,7 +59,6 @@ two steps: 50%, 100%.
             host: reviews
             subset: v1
           weight: 50
-      - route:
         - destination:
             host: reviews
             subset: v3


### PR DESCRIPTION
**Where is the problem?**

_https://istio.io/docs/tasks/traffic-management/traffic-shifting/#weight-based-version-routing_

**What is the problem?**

As shown in step 3, the below configuration is invalid.  The extra **`route`** attribute in the review virtualservice yaml output breaks the functionality which the example represents, as shown below:

```
$ istioctl get virtualservice reviews -o yaml
apiVersion: networking.istio.io/v1alpha3
kind: VirtualService
metadata:
  name: reviews
  ...
spec:
  hosts:
  - reviews
  http:
  - route:
    - destination:
        host: reviews
        subset: v1
      weight: 50
  - route: # invalid configuration 
    - destination:
        host: reviews
        subset: v3
      weight: 50
```

The github sample yaml in the url _https://raw.githubusercontent.com/istio/istio/release-0.8/samples/bookinfo/routing/route-rule-reviews-50-v3.yaml_  in the mentioned command 

`istioctl replace -f samples/bookinfo/routing/route-rule-reviews-50-v3.yaml`

is correct and works as expected. 

**Correction made as follows:**

```
apiVersion: networking.istio.io/v1alpha3
kind: VirtualService
metadata:
  name: reviews
  ...
spec:
  hosts:
  - reviews
  http:
  - route:
    - destination:
        host: reviews
        subset: v1
      weight: 50
    - destination:
        host: reviews
        subset: v3
      weight: 50
```