### PR TITLE
Fix missing Gateway apiVersion in egress-gateway.md

### DIFF
--- a/content/docs/tasks/traffic-management/egress-gateway.md
+++ b/content/docs/tasks/traffic-management/egress-gateway.md
@@ -55,6 +55,7 @@ First let's direct HTTP traffic without TLS origination
 
     ```bash
         cat <<EOF | istioctl create -f -
+        apiVersion: networking.istio.io/v1alpha3
         kind: Gateway
         metadata:
           name: istio-egressgateway
@@ -176,6 +177,7 @@ Let's perform TLS origination with the egress `Gateway`, similar to the [TLS Ori
 
     ```bash
         cat <<EOF | istioctl create -f -
+        apiVersion: networking.istio.io/v1alpha3
         kind: Gateway
         metadata:
           name: istio-egressgateway


### PR DESCRIPTION
Gateway apiVersions are missing in content/docs/tasks/traffic-management/egress-gateway.md.