### PR TITLE
Automate and clarify determining ingress gateway's IP and ports

### DIFF
--- a/content/docs/examples/bookinfo/index.md
+++ b/content/docs/examples/bookinfo/index.md
@@ -138,7 +138,7 @@ To start the application, follow the instructions below corresponding to your Is
 
 #### Determining the ingress IP and port
 
-1.  Follow [these instructions](/docs/tasks/traffic-management/ingress/#determining-the-ingress-ip-and-ports) to set the `INGRESS_HOST` and `INGRESS_PORT` variables.
+1.  Follow [these instructions](/docs/tasks/traffic-management/ingress/#setting-the-ingress-ip-and-ports) to set the `INGRESS_HOST` and `INGRESS_PORT` variables.
 
 1.  Set `GATEWAY_URL`:
 

--- a/content/docs/examples/endpoints/index.md
+++ b/content/docs/examples/endpoints/index.md
@@ -53,7 +53,7 @@ Otherwise, ESP won't be able to access Google cloud service control.
     EOF
     {{< /text >}}
 
-1.  Get the Ingress IP and port by following the [instructions](/docs/tasks/traffic-management/ingress#determining-the-ingress-ip-and-ports).
+1.  Get the Ingress IP and port by following the [instructions](/docs/tasks/traffic-management/ingress#setting-the-ingress-ip-and-ports).
 You can verify accessing the Endpoints service through Ingress:
 
     {{< text bash >}}

--- a/content/docs/tasks/traffic-management/ingress/index.md
+++ b/content/docs/tasks/traffic-management/ingress/index.md
@@ -77,7 +77,8 @@ No load balancer is provided in your environment. $INGRESS_PORT=31380, $SECURE_I
 
 #### Determining the ingress IP when using a node port
 
-Determining the ingress IP depends on the cluster provider.
+Follow the instructions in this subsection only if the commands in the previous section did not manage to detect the
+ingress IP. Determining the ingress IP depends on the cluster provider.
 
 1.  _GKE:_
 

--- a/content/docs/tasks/traffic-management/ingress/index.md
+++ b/content/docs/tasks/traffic-management/ingress/index.md
@@ -49,7 +49,6 @@ If your environment does not provide an external load balancer for the ingress g
  you to follow the steps in the next subsection (to use the ingress gateway service's
 [node port](https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport)).
 
-
 {{< text bash >}}
 $ export INGRESS_HOST=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
 $ if [[ -n $INGRESS_HOST ]]; then

--- a/content/docs/tasks/traffic-management/ingress/index.md
+++ b/content/docs/tasks/traffic-management/ingress/index.md
@@ -40,36 +40,43 @@ This task describes how to configure Istio to expose a service outside of the se
 
 *   Determine the ingress IP and ports as described in the following subsection.
 
-### Determining the ingress IP and ports
+### Setting the ingress IP and ports
 
-Execute the following command to determine if your Kubernetes cluster is running in an environment that supports external load balancers.
+Execute the commands below to set the ingress IP and ports. The commands will determine if your Kubernetes cluster is
+running in an environment that provides external load balancers, and will set the IP and the ports accordingly.
 
-{{< text bash >}}
-$ kubectl get svc istio-ingressgateway -n istio-system
-NAME                   TYPE           CLUSTER-IP       EXTERNAL-IP     PORT(S)                                      AGE
-istio-ingressgateway   LoadBalancer   172.21.109.129   130.211.10.121  80:31380/TCP,443:31390/TCP,31400:31400/TCP   17h
-{{< /text >}}
+If your environment does not provide an external load balancer for the ingress gateway, the commands below will instruct
+ you to follow the steps in the next subsection (to use the ingress gateway service's
+[node port](https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport)).
 
-If the `EXTERNAL-IP` value is set, your environment has an external load balancer that you can use for the ingress gateway.
-If the `EXTERNAL-IP` value is `<none>` (or perpetually `<pending>`), your environment does not provide an external load balancer for the ingress gateway.
-In this case, you can access the gateway using the service's [node port](https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport).
-
-#### Determining the ingress IP and ports when using an external load balancer
 
 {{< text bash >}}
 $ export INGRESS_HOST=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+$ if [[ -n $INGRESS_HOST ]]; then
 $ export INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="http")].port}')
 $ export SECURE_INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="https")].port}')
-{{< /text >}}
-
-#### Determining the ingress IP and ports when using a node port
-
-Determine the ports:
-
-{{< text bash >}}
+$ echo "The ingress gateway's IP and ports have been set successfully: \$INGRESS_HOST=${INGRESS_HOST}, \$INGRESS_PORT=${INGRESS_PORT}, \$SECURE_INGRESS_PORT=${SECURE_INGRESS_PORT}."
+$ else
 $ export INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="http")].nodePort}')
 $ export SECURE_INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="https")].nodePort}')
+$ echo "No load balancer is provided in your environment. \$INGRESS_PORT=${INGRESS_PORT}, \$SECURE_INGRESS_PORT=${SECURE_INGRESS_PORT}. Follow the steps in https://istio.io/docs/tasks/traffic-management/ingress/#determining-the-ingress-ip-when-using-a-node-port to set \$INGRESS_HOST."
+$ fi
 {{< /text >}}
+
+If the output is similar to the following:
+
+{{< text plain >}}
+The ingress gateway's IP and ports have been set successfully: $INGRESS_HOST=<some IP>, $INGRESS_PORT=80, $SECURE_INGRESS_PORT=443.
+{{< /text >}}
+
+Then you have determined the ingress gateway's IP and ports successfully, no need to configure anything else. However,
+if the output is similar to the following line, proceed to the next subsection to set `$INGRESS_HOST`.
+
+{{< text plain >}}
+No load balancer is provided in your environment. $INGRESS_PORT=31380, $SECURE_INGRESS_PORT=31390. Follow the steps in https://istio.io/docs/tasks/traffic-management/ingress/#determining-the-ingress-ip-when-using-a-node-port to set $INGRESS_HOST.
+{{< /text >}}
+
+#### Determining the ingress IP when using a node port
 
 Determining the ingress IP depends on the cluster provider.
 

--- a/content/docs/tasks/traffic-management/secure-ingress/index.md
+++ b/content/docs/tasks/traffic-management/secure-ingress/index.md
@@ -12,7 +12,7 @@ gateway to expose an HTTP endpoint of a service to external traffic. This task e
 
 ## Before you begin
 
-1.  Perform the steps in the [Before you begin](/docs/tasks/traffic-management/ingress#before-you-begin) and [Determining the ingress IP and ports](/docs/tasks/traffic-management/ingress#determining-the-ingress-ip-and-ports) sections of the
+1.  Perform the steps in the [Before you begin](/docs/tasks/traffic-management/ingress#before-you-begin) and [Setting the ingress IP and ports](/docs/tasks/traffic-management/ingress#setting-the-ingress-ip-and-ports) sections of the
 [Control Ingress Traffic](/docs/tasks/traffic-management/ingress) task. After performing those steps you should have Istio and _httpbin_ service deployed, and the environment variables `INGRESS_HOST` and `SECURE_INGRESS_PORT` set.
 
 1.  For macOS users, verify that you use _curl_ compiled with the [LibreSSL](http://www.libressl.org) library:


### PR DESCRIPTION
Check load balancer's ip automatically, print more information, direct the user how to proceed

The current ingress gateway instructions are tricky and may cause confusion. The proposed instructions are still rather tricky, careful review is required.