### PR TITLE
Move the community page into the About section.

### DIFF
--- a/content/about/community/index.md
+++ b/content/about/community/index.md
@@ -1,8 +1,11 @@
 ---
-title: Community
+title: Join Our Community
 description: Information on the various ways to participate and interact with the Istio community.
+weight: 2
 keywords: [community]
-sidebar_none: true
+type: community
+aliases:
+    - /community
 ---
 Istio is an open source project with an active community that supports its use and on-going development. We'd love for you
 to join us and get involved!

--- a/content/about/feature-stages/index.md
+++ b/content/about/feature-stages/index.md
@@ -102,4 +102,4 @@ Below is our list of existing features and their current phases. This informatio
 | [Multicluster Mesh](/docs/setup/kubernetes/multicluster-install/) | Alpha
 
 > {{< idea_icon >}}
-Please get in touch by joining our [community](/community/) if there are features you'd like to see in our future releases!
+Please get in touch by joining our [community](/about/community/) if there are features you'd like to see in our future releases!

--- a/content/help/_index.md
+++ b/content/help/_index.md
@@ -6,5 +6,5 @@ sidebar_singlecard: true
 type: section-index
 ---
 
-And don't forget our vibrant [community](/community/) that's always ready to lend a hand
+And don't forget our vibrant [community](/about/community/) that's always ready to lend a hand
 with thorny problems.

--- a/content/help/faq/general/how-do-i-contribute.md
+++ b/content/help/faq/general/how-do-i-contribute.md
@@ -7,5 +7,5 @@ Contributions are highly welcome. We look forward to community feedback, additio
 
 The code repositories are hosted on [GitHub](https://github.com/istio). Please see our[Contribution Guidelines](https://github.com/istio/community/blob/master/CONTRIBUTING.md) to learn how to contribute.
 
-In addition to the code, there are other ways to contribute to the Istio [community](/community/), including on
+In addition to the code, there are other ways to contribute to the Istio [community](/about/community/), including on
 [Stack Overflow](https://stackoverflow.com/questions/tagged/istio), and the [mailing list](https://groups.google.com/forum/#!forum/istio-users).

--- a/content_zh/help/_index.md
+++ b/content_zh/help/_index.md
@@ -6,4 +6,4 @@ type: section-index
 sidebar_singlecard: true
 ---
 
-不要忘记我们充满活力的[社区](/community/)随时准备为棘手的问题伸出援助之手。
+不要忘记我们充满活力的[社区](/about/community/)随时准备为棘手的问题伸出援助之手。

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -40,11 +40,6 @@
                         <a class="nav-link {{ if eq $section "help" }}active{{ end }}" title="{{ .Description }}" href="{{ .Permalink  }}">{{ .LinkTitle }}</a>
                     </li>
                 {{ end }}
-                {{ with (.Site.GetPage "section" "community") }}
-                    <li class="nav-item">
-                        <a class="nav-link {{ if eq $section "community" }}active{{ end }}" title="{{ .Description }}" href="{{ .Permalink  }}">{{ .LinkTitle }}</a>
-                    </li>
-                {{ end }}
                 {{ with (.Site.GetPage "section" "about") }}
                     <li class="nav-item">
                         <a class="nav-link {{ if eq $section "about" }}active{{ end }}" title="{{ .Description }}" href="{{ .Permalink  }}">{{ .LinkTitle }}</a>


### PR DESCRIPTION
Since we already have all the community links in the footer, we don't also need to have a Community link in the header. So the community page is now accessible from the About section instead.
