### PR TITLE
Remove link annotations from command paths

### DIFF
--- a/content/blog/2018/soft-multitenancy/index.md
+++ b/content/blog/2018/soft-multitenancy/index.md
@@ -55,8 +55,8 @@ pods that make up the control plane (mixer, pilot, ingress, CA). Deploying the t
 control plane yaml files:
 
 {{< text bash >}}
-$ kubectl apply -f @install/kubernetes/istio.yaml@
-$ kubectl apply -f @install/kubernetes/istio-system1.yaml@
+$ kubectl apply -f install/kubernetes/istio.yaml
+$ kubectl apply -f install/kubernetes/istio-system1.yaml
 {{< /text >}}
 
 Results in two Istio control planes running in two namespaces.

--- a/content/docs/setup/consul/quick-start/index.md
+++ b/content/docs/setup/consul/quick-start/index.md
@@ -47,7 +47,7 @@ For example, run the following command on a macOS or Linux system:
 1.  Bring up the Istio control plane containers:
 
     {{< text bash >}}
-    $ docker-compose -f @install/consul/istio.yaml@ up -d
+    $ docker-compose -f install/consul/istio.yaml up -d
     {{< /text >}}
 
 1.  Confirm that all docker containers are running:
@@ -86,5 +86,5 @@ $ docker-compose -f <your-app-spec>.yaml up -d
 Uninstall Istio core components by removing the docker containers:
 
 {{< text bash >}}
-$ docker-compose -f @install/consul/istio.yaml@ down
+$ docker-compose -f install/consul/istio.yaml down
 {{< /text >}}

--- a/content/docs/setup/eureka/quick-start/index.md
+++ b/content/docs/setup/eureka/quick-start/index.md
@@ -41,7 +41,7 @@ For example, run the following command on a macOS or Linux system:
 1.  Bring up the Istio control plane containers:
 
     {{< text bash >}}
-    $ docker-compose -f @install/eureka/istio.yaml@ up -d
+    $ docker-compose -f install/eureka/istio.yaml up -d
     {{< /text >}}
 
 1.  Confirm that all docker containers are running:
@@ -80,5 +80,5 @@ $ docker-compose -f <your-app-spec>.yaml up -d
 Uninstall Istio core components by removing the docker containers:
 
 {{< text bash >}}
-$ docker-compose -f @install/eureka/istio.yaml@ down
+$ docker-compose -f install/eureka/istio.yaml down
 {{< /text >}}

--- a/content/docs/setup/kubernetes/sidecar-injection/index.md
+++ b/content/docs/setup/kubernetes/sidecar-injection/index.md
@@ -59,7 +59,7 @@ from local files.
 Inject the sidecar into the deployment using the in-cluster configuration.
 
 {{< text bash >}}
-$ istioctl kube-inject -f @samples/sleep/sleep.yaml@ | kubectl apply -f -
+$ istioctl kube-inject -f samples/sleep/sleep.yaml | kubectl apply -f -
 {{< /text >}}
 
 Alternatively, inject using local copies of the configuration.
@@ -81,7 +81,7 @@ Run `kube-inject` over the input file and deploy.
 $ istioctl kube-inject \
     --injectConfigFile inject-config.yaml \
     --meshConfigFile mesh-config.yaml \
-    --filename @samples/sleep/sleep.yaml@ \
+    --filename samples/sleep/sleep.yaml \
     --output sleep-injected.yaml | kubectl apply -f -
 {{< /text >}}
 
@@ -115,7 +115,7 @@ use [Helm](/docs/setup/kubernetes/helm-install/) to generate an updated istio.ya
 with the option `sidecarInjectorWebhook.enabled` set to `false`. E.g.
 
 {{< text bash >}}
-$ helm template --namespace=istio-system --set sidecarInjectorWebhook.enabled=false @install/kubernetes/helm/istio@ > istio.yaml
+$ helm template --namespace=istio-system --set sidecarInjectorWebhook.enabled=false install/kubernetes/helm/istio > istio.yaml
 $ kubectl create ns istio-system
 $ kubectl apply -n istio-system -f istio.yaml
 {{< /text >}}
@@ -128,7 +128,7 @@ service in `values.yaml`. You can override the default values to customize the i
 Deploy sleep app. Verify both deployment and pod have a single container.
 
 {{< text bash >}}
-$ kubectl apply -f @samples/sleep/sleep.yaml@
+$ kubectl apply -f samples/sleep/sleep.yaml
 $ kubectl get deployment -o wide
 NAME      DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE       CONTAINERS   IMAGES       SELECTOR
 sleep     1         1         1            1           12m       sleep        tutum/curl   app=sleep
@@ -291,7 +291,7 @@ containers:
   - sleep
 {{< /text >}}
 
-when applied over a pod defined by the pod template spec in `@samples/sleep/sleep.yaml@`
+when applied over a pod defined by the pod template spec in `samples/sleep/sleep.yaml`
 
 #### Uninstalling the automatic sidecar injector
 

--- a/content/docs/setup/kubernetes/upgrading-istio/index.md
+++ b/content/docs/setup/kubernetes/upgrading-istio/index.md
@@ -22,16 +22,16 @@ First, generate the desired Istio control plane yaml file, e.g.
 
 {{< text bash >}}
 $ helm template --namespace istio-system --set global.proxy.image=proxy \
-  --values @install/kubernetes/helm/istio/values-istio.yaml@ \
-  @install/kubernetes/helm/istio@ >> install/kubernetes/istio.yaml
+  --values install/kubernetes/helm/istio/values-istio.yaml \
+  install/kubernetes/helm/istio >> install/kubernetes/istio.yaml
 {{< /text >}}
 
 or
 
 {{< text bash >}}
 $ helm template --namespace istio-system --set global.proxy.image=proxy \
-  --values @install/kubernetes/helm/istio/values-istio-auth.yaml@ \
-  @install/kubernetes/helm/istio@ >> install/kubernetes/istio-auth.yaml
+  --values install/kubernetes/helm/istio/values-istio-auth.yaml \
+  install/kubernetes/helm/istio >> install/kubernetes/istio-auth.yaml
 {{< /text >}}
 
 If using Kubernetes versions prior to 1.9, you should add `--set sidecarInjectorWebhook.enabled=false`.
@@ -39,13 +39,13 @@ If using Kubernetes versions prior to 1.9, you should add `--set sidecarInjector
 Second, simply apply the new version of the desired Istio control plane yaml file directly, e.g.
 
 {{< text bash >}}
-$ kubectl apply -f @install/kubernetes/istio.yaml@
+$ kubectl apply -f install/kubernetes/istio.yaml
 {{< /text >}}
 
 or
 
 {{< text bash >}}
-$ kubectl apply -f @install/kubernetes/istio-auth.yaml@
+$ kubectl apply -f install/kubernetes/istio-auth.yaml
 {{< /text >}}
 
 The rolling update process will upgrade all deployments and configmaps to the new version. After this process finishes,

--- a/content/docs/tasks/security/health-check/index.md
+++ b/content/docs/tasks/security/health-check/index.md
@@ -44,7 +44,7 @@ this feature is not needed if the production setup is not using the
 Deploy Citadel with health checking enabled.
 
 {{< text bash >}}
-$ kubectl apply -f @install/kubernetes/istio-citadel-with-health-check.yaml@
+$ kubectl apply -f install/kubernetes/istio-citadel-with-health-check.yaml
 {{< /text >}}
 
 Deploy the `istio-citadel` service so that the CSR service can be found by the health checker.
@@ -133,13 +133,13 @@ continuously failed health checks.
 *   To disable health checking on Citadel:
 
     {{< text bash >}}
-    $ kubectl apply -f @install/kubernetes/istio-auth.yaml@
+    $ kubectl apply -f install/kubernetes/istio-auth.yaml
     $ kubectl delete svc istio-citadel -n istio-system
     {{< /text >}}
 
 *   To remove Citadel:
 
     {{< text bash >}}
-    $ kubectl delete -f @install/kubernetes/istio-citadel-with-health-check.yaml@
+    $ kubectl delete -f install/kubernetes/istio-citadel-with-health-check.yaml
     $ kubectl delete svc istio-citadel -n istio-system
     {{< /text >}}

--- a/content/docs/tasks/security/https-overlay/index.md
+++ b/content/docs/tasks/security/https-overlay/index.md
@@ -46,7 +46,7 @@ configmap "nginxconfigmap" created
 This section creates a NGINX-based HTTPS service.
 
 {{< text bash >}}
-$ kubectl apply -f @samples/https/nginx-app.yaml@
+$ kubectl apply -f samples/https/nginx-app.yaml
 service "my-nginx" created
 replicationcontroller "my-nginx" created
 {{< /text >}}
@@ -54,7 +54,7 @@ replicationcontroller "my-nginx" created
 Then, create another pod to call this service.
 
 {{< text bash >}}
-$ kubectl apply -f <(bin/istioctl kube-inject -f @samples/sleep/sleep.yaml@)
+$ kubectl apply -f <(bin/istioctl kube-inject -f samples/sleep/sleep.yaml)
 {{< /text >}}
 
 Get the pods
@@ -98,13 +98,13 @@ disabled. So you only need to redeploy the NGINX HTTPS service with sidecar.
 Delete the HTTPS service.
 
 {{< text bash >}}
-$ kubectl delete -f @samples/https/nginx-app.yaml@
+$ kubectl delete -f samples/https/nginx-app.yaml
 {{< /text >}}
 
 Deploy it with a sidecar
 
 {{< text bash >}}
-$ kubectl apply -f <(bin/istioctl kube-inject -f @samples/https/nginx-app.yaml@)
+$ kubectl apply -f <(bin/istioctl kube-inject -f samples/https/nginx-app.yaml)
 {{< /text >}}
 
 Make sure the pod is up and running
@@ -142,7 +142,7 @@ You need to deploy Istio control plane with mutual TLS enabled. If you have isti
 control plane with mutual TLS disabled installed, please delete it:
 
 {{< text bash >}}
-$ kubectl delete -f @install/kubernetes/istio-demo.yaml@
+$ kubectl delete -f install/kubernetes/istio-demo.yaml
 {{< /text >}}
 
 And wait for everything is down, i.e., there is no pod in control plane namespace (istio-system).
@@ -155,7 +155,7 @@ No resources found.
 Then deploy the Istio control plane with mutual TLS enabled:
 
 {{< text bash >}}
-$ kubectl apply -f @install/kubernetes/istio-demo-auth.yaml@
+$ kubectl apply -f install/kubernetes/istio-demo-auth.yaml
 {{< /text >}}
 
 Make sure everything is up and running:
@@ -182,10 +182,10 @@ servicegraph-5849b7d696-jrk8h              1/1       Running     0          23h
 Then redeploy the HTTPS service and sleep service
 
 {{< text bash >}}
-$ kubectl delete -f <(bin/istioctl kube-inject -f @samples/sleep/sleep.yaml@)
-$ kubectl apply -f <(bin/istioctl kube-inject -f @samples/sleep/sleep.yaml@)
-$ kubectl delete -f <(bin/istioctl kube-inject -f @samples/https/nginx-app.yaml@)
-$ kubectl apply -f <(bin/istioctl kube-inject -f @samples/https/nginx-app.yaml@)
+$ kubectl delete -f <(bin/istioctl kube-inject -f samples/sleep/sleep.yaml)
+$ kubectl apply -f <(bin/istioctl kube-inject -f samples/sleep/sleep.yaml)
+$ kubectl delete -f <(bin/istioctl kube-inject -f samples/https/nginx-app.yaml)
+$ kubectl apply -f <(bin/istioctl kube-inject -f samples/https/nginx-app.yaml)
 {{< /text >}}
 
 Make sure the pod is up and running
@@ -227,8 +227,8 @@ since the traffic will be downgraded to http from nginx-proxy to nginx.
 ## Cleanup
 
 {{< text bash >}}
-$ kubectl delete -f @samples/sleep/sleep.yaml@
-$ kubectl delete -f @samples/https/nginx-app.yaml@
+$ kubectl delete -f samples/sleep/sleep.yaml
+$ kubectl delete -f samples/https/nginx-app.yaml
 $ kubectl delete configmap nginxconfigmap
 $ kubectl delete secret nginxsecret
 {{< /text >}}

--- a/content/docs/tasks/security/plugin-ca-cert/index.md
+++ b/content/docs/tasks/security/plugin-ca-cert/index.md
@@ -55,7 +55,7 @@ The following steps enable plugging in the certificates and key into Citadel:
 1.  Redeploy Citadel, which reads the certificates and key from the secret-mount files:
 
     {{< text bash >}}
-    $ kubectl apply -f @install/kubernetes/istio-citadel-plugin-certs.yaml@
+    $ kubectl apply -f install/kubernetes/istio-citadel-plugin-certs.yaml
     {{< /text >}}
 
     > Note: if you are using different certificate/key file or secret names,
@@ -139,5 +139,5 @@ This requires you have `openssl` installed on your machine.
 *   To remove the Istio components:
 
     {{< text bash >}}
-    $ kubectl delete -f @install/kubernetes/istio-auth.yaml@
+    $ kubectl delete -f install/kubernetes/istio-auth.yaml
     {{< /text >}}

--- a/content/docs/tasks/telemetry/servicegraph/index.md
+++ b/content/docs/tasks/telemetry/servicegraph/index.md
@@ -25,7 +25,7 @@ the example application throughout this task.
     In Kubernetes environments, execute the following command:
 
     {{< text bash >}}
-    $ kubectl apply -f @install/kubernetes/addons/servicegraph.yaml@
+    $ kubectl apply -f install/kubernetes/addons/servicegraph.yaml
     {{< /text >}}
 
 1.  Verify that the service is running in your cluster.
@@ -118,7 +118,7 @@ depends on the standard Istio metric configuration.
 Servicegraph add-on:
 
     {{< text bash >}}
-    $ kubectl delete -f @install/kubernetes/addons/servicegraph.yaml@
+    $ kubectl delete -f install/kubernetes/addons/servicegraph.yaml
     {{< /text >}}
 
 * If you are not planning to explore any follow-on tasks, refer to the

--- a/content/docs/tasks/telemetry/using-istio-dashboard/index.md
+++ b/content/docs/tasks/telemetry/using-istio-dashboard/index.md
@@ -25,7 +25,7 @@ the example application throughout this task.
     In Kubernetes environments, execute the following command:
 
     {{< text bash >}}
-    $ kubectl apply -f @install/kubernetes/addons/grafana.yaml@
+    $ kubectl apply -f install/kubernetes/addons/grafana.yaml
     {{< /text >}}
 
 1.  Verify that the service is running in your cluster.

--- a/content/docs/tasks/traffic-management/egress/index.md
+++ b/content/docs/tasks/traffic-management/egress/index.md
@@ -29,13 +29,13 @@ or alternatively, to simply bypass the Istio proxy for a specific range of IPs.
     If you have enabled [automatic sidecar injection](/docs/setup/kubernetes/sidecar-injection/#automatic-sidecar-injection), do
 
     {{< text bash >}}
-    $ kubectl apply -f @samples/sleep/sleep.yaml@
+    $ kubectl apply -f samples/sleep/sleep.yaml
     {{< /text >}}
 
     otherwise, you have to manually inject the sidecar before deploying the `sleep` application:
 
     {{< text bash >}}
-    $ kubectl apply -f <(istioctl kube-inject -f @samples/sleep/sleep.yaml@)
+    $ kubectl apply -f <(istioctl kube-inject -f samples/sleep/sleep.yaml)
     {{< /text >}}
 
     Note that any pod that you can `exec` and `curl` from would do.
@@ -178,7 +178,7 @@ The values used for internal IP range(s), however, depends on where your cluster
 For example, with Minikube the range is 10.0.0.1&#47;24, so you would update your `ConfigMap` _istio-sidecar-injector_ like this:
 
 {{< text bash >}}
-$ helm template @install/kubernetes/helm/istio@ <the flags you used to install Istio> --set global.proxy.includeIPRanges="10.0.0.1/24" -x @templates/sidecar-injector-configmap.yaml@ | kubectl apply -f -
+$ helm template @install/kubernetes/helm/istio@ <the flags you used to install Istio> --set global.proxy.includeIPRanges="10.0.0.1/24" -x templates/sidecar-injector-configmap.yaml | kubectl apply -f -
 {{< /text >}}
 
 Note that you should use the same Helm command you used [to install Istio](/docs/setup/kubernetes/helm-install),
@@ -270,11 +270,11 @@ cloud provider specific knowledge and configuration.
 1.  Shutdown the [sleep]({{< github_tree >}}/samples/sleep) service.
 
     {{< text bash >}}
-    $ kubectl delete -f @samples/sleep/sleep.yaml@
+    $ kubectl delete -f samples/sleep/sleep.yaml
     {{< /text >}}
 
 1.  Update the `ConfigMap` _istio-sidecar-injector_ to redirect all outbound traffic to the sidecar proxies:
 
     {{< text bash >}}
-    $ helm template @install/kubernetes/helm/istio@ <the flags you used to install Istio> -x @templates/sidecar-injector-configmap.yaml@ | kubectl apply -f -
+    $ helm template @install/kubernetes/helm/istio@ <the flags you used to install Istio> -x templates/sidecar-injector-configmap.yaml | kubectl apply -f -
     {{< /text >}}


### PR DESCRIPTION
The link annotations on a command paths generate a doc with dead links in it.
Also breaks CircleCI build (e.g. #1686)

cc @sdake 