### PR TITLE
Revert one small change that added a link

### DIFF
--- a/content/docs/setup/kubernetes/helm-install/index.md
+++ b/content/docs/setup/kubernetes/helm-install/index.md
@@ -63,7 +63,7 @@ to manage the lifecycle of Istio.
 1. If a service account has not already been installed for Tiller, install one:
 
     {{< text bash >}}
-    $ kubectl create -f @install/kubernetes/helm/helm-service-account.yaml@
+    $ kubectl create -f install/kubernetes/helm/helm-service-account.yaml
     {{< /text >}}
 
 1. Install Tiller on your cluster with the service account:


### PR DESCRIPTION
A @link@ was added inadvertently to the config options autogeneration
helm documentation.