### PR TITLE
Fix spec port name used to obtain ingress gateway port

### DIFF
--- a/content/docs/tasks/traffic-management/ingress/index.md
+++ b/content/docs/tasks/traffic-management/ingress/index.md
@@ -58,7 +58,7 @@ In this case, you can access the gateway using the service's [node port](https:/
 
 {{< text bash >}}
 $ export INGRESS_HOST=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-$ export INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="http")].port}')
+$ export INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="http2")].port}')
 $ export SECURE_INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="https")].port}')
 {{< /text >}}
 
@@ -67,7 +67,7 @@ $ export SECURE_INGRESS_PORT=$(kubectl -n istio-system get service istio-ingress
 Determine the ports:
 
 {{< text bash >}}
-$ export INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="http")].nodePort}')
+$ export INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="http2")].nodePort}')
 $ export SECURE_INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="https")].nodePort}')
 {{< /text >}}
 


### PR DESCRIPTION
When testing out the latest build for a [reported issue](https://github.com/istio/istio/issues/6950), I noticed that the `INGRESS_PORT` wasn't being detected correctly.

When I looked at the istio-ingressgateway details, I got:

```
kubectl -n istio-system get service istio-ingressgateway -o json
{
    "apiVersion": "v1",
    "kind": "Service",
    "metadata": {
        "annotations": {
            "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"chart\":\"gateways-1.0.0\",\"heritage\":\"Tiller\",\"istio\":\"ingressgateway\",\"release\":\"istio\"},\"name\":\"istio-ingressgateway\",\"namespace\":\"istio-system\"},\"spec\":{\"ports\":[{\"name\":\"http2\",\"nodePort\":31380,\"port\":80,\"targetPort\":80},{\"name\":\"https\",\"nodePort\":31390,\"port\":443},{\"name\":\"tcp\",\"nodePort\":31400,\"port\":31400}],\"selector\":{\"istio\":\"ingressgateway\"},\"type\":\"LoadBalancer\"}}\n"
        },
        "creationTimestamp": "2018-07-10T09:16:48Z",
        "labels": {
            "chart": "gateways-1.0.0",
            "heritage": "Tiller",
            "istio": "ingressgateway",
            "release": "istio"
        },
        "name": "istio-ingressgateway",
        "namespace": "istio-system",
        "resourceVersion": "968",
        "selfLink": "/api/v1/namespaces/istio-system/services/istio-ingressgateway",
        "uid": "f97bb54d-8421-11e8-9943-146de72945e1"
    },
    "spec": {
        "clusterIP": "10.104.239.193",
        "externalTrafficPolicy": "Cluster",
        "ports": [
            {
                "name": "http2",
                "nodePort": 31380,
                "port": 80,
                "protocol": "TCP",
                "targetPort": 80
            },
            {
                "name": "https",
                "nodePort": 31390,
                "port": 443,
                "protocol": "TCP",
                "targetPort": 443
            },
            {
                "name": "tcp",
                "nodePort": 31400,
                "port": 31400,
                "protocol": "TCP",
                "targetPort": 31400
            }
        ],
        "selector": {
            "istio": "ingressgateway"
        },
        "sessionAffinity": "None",
        "type": "LoadBalancer"
    },
    "status": {
        "loadBalancer": {}
    }
}
```

The port name had changed from `http` to `http2`. This PR updates the docs to reflect this.
