### PR TITLE
First round of edits.

### DIFF
--- a/content/docs/tasks/policy-enforcement/rate-limiting/index.md
+++ b/content/docs/tasks/policy-enforcement/rate-limiting/index.md
@@ -22,7 +22,7 @@ service.
     * Version v1 doesn’t call the `ratings` service.
     * Version v2 calls the `ratings` service, and displays each rating as 1 to 5 black stars.
     * Version v3 calls the `ratings` service, and displays each rating as 1 to 5 red stars.
-  
+
     You need to set a default route to one of the versions. Otherwise, when you send requests to the `reviews` service, Istio routes requests to all available versions randomly, and sometimes the output contains star ratings and sometimes it doesn't.
 
 1. Set the default version for all services to v1. If you’ve already created route rules for the sample, use `replace` rather than `create` in the following command.
@@ -260,12 +260,12 @@ with the given namespace.
     $ istioctl delete -f @samples/bookinfo/policy/mixer-rule-ratings-ratelimit.yaml@
     {{< /text >}}
 
-2. Remove the application routing rules:
+1. Remove the application routing rules:
 
     {{< text bash >}}
     $ istioctl delete -f @samples/bookinfo/networking/virtual-service-all-v1.yaml@
     {{< /text >}}
 
-3. If you are not planning to explore any follow-on tasks, refer to the
+1. If you are not planning to explore any follow-on tasks, refer to the
   [Bookinfo cleanup](/docs/examples/bookinfo/#cleanup) instructions
   to shutdown the application.

--- a/content/docs/tasks/policy-enforcement/rate-limiting/index.md
+++ b/content/docs/tasks/policy-enforcement/rate-limiting/index.md
@@ -12,43 +12,47 @@ service.
 
 ## Before you begin
 
-* Setup Istio in a Kubernetes cluster by following the quick start instructions
-  in the [Installation guide](/docs/setup/kubernetes/quick-start/).
+1. Setup Istio in a Kubernetes cluster by following the instructions in the
+   [Installation Guide](/docs/setup/kubernetes/quick-start/).
 
-* Deploy the [Bookinfo](/docs/examples/bookinfo/) sample application.
+1. Deploy the [Bookinfo](/docs/examples/bookinfo/) sample application.
 
-* Initialize the application version routing to direct `reviews` service
-  requests from test user "jason" to version v2 and requests from any other
-  user to v3.
+    The Bookinfo sample deploys 3 versions of the `reviews` service:
 
-  {{< text bash >}}
-  $ istioctl create -f @samples/bookinfo/networking/virtual-service-all-v1.yaml@
-  {{< /text >}}
+    * Version v1 doesn’t call the `ratings` service.
+    * Version v2 calls the `ratings` service, and displays each rating as 1 to 5 black stars.
+    * Version v3 calls the `ratings` service, and displays each rating as 1 to 5 red stars.
+  
+    You need to set a default route to one of the versions. Otherwise, when you send requests to the `reviews` service, Istio routes requests to all available versions randomly, and sometimes the output contains star ratings and sometimes it doesn't.
 
-   and then run the following command:
+1. Set the default version for all services to v1. If you’ve already created route rules for the sample, use `replace` rather than `create` in the following command.
 
-  {{< text bash >}}
-  $ istioctl replace -f @samples/bookinfo/networking/virtual-service-reviews-jason-v2-v3.yaml@
-  {{< /text >}}
+    {{< text bash >}}
+    $ istioctl create -f @samples/bookinfo/networking/virtual-service-all-v1.yaml@
+    {{< /text >}}
 
-> If you have a conflicting rule that you set in previous tasks,
-use `istioctl replace` instead of `istioctl create`.
+1. Initialize application version routing on the `reviews` service to
+   direct requests from the test user "jason" to version v2 and requests from any other user to v3.
+
+    {{< text bash >}}
+    $ istioctl replace -f @samples/bookinfo/networking/virtual-service-reviews-jason-v2-v3.yaml@
+    {{< /text >}}
 
 ## Rate limits
 
-Istio enables you to rate limit traffic to a service.
+Istio allows you to rate limit traffic to a service.
 
 Consider `ratings` as an external paid service like Rotten Tomatoes® with
-`1qps` free quota. Using Istio we can ensure that `1qps` is not breached.
+`1 qps` free quota. Using Istio, you can ensure that `1 qps` is not breached.
 
 1. Point your browser at the Bookinfo `productpage`
-   (http://$GATEWAY_URL/productpage).
+   (`http://$GATEWAY_URL/productpage`).
 
     If you log in as user "jason", you should see black ratings stars with
     each review, indicating that the `ratings` service is being called by the
     "v2" version of the `reviews` service.
 
-    If you log in as any other user (or logout) you should see red ratings
+    If you log in as any other user, you should see red ratings
     stars with each review, indicating that the `ratings` service is being
     called by the "v3" version of the `reviews` service.
 
@@ -154,7 +158,7 @@ Consider `ratings` as an external paid service like Rotten Tomatoes® with
           quota: requestcount
     {{< /text >}}
 
-    This `QuotaSpec` defines the requestcount `quota` we created above with a
+    This `QuotaSpec` defines the requestcount `quota` you created above with a
     charge of `1`.
 
 1. Confirm the `QuotaSpecBinding` was created:
@@ -180,26 +184,26 @@ Consider `ratings` as an external paid service like Rotten Tomatoes® with
         namespace: default
     {{< /text >}}
 
-    This `QuotaSpecBinding` binds the `QuotaSpec` we created above to the
-    services we want to apply it to. Note we have to define the namespace for
+    This `QuotaSpecBinding` binds the `QuotaSpec` you created above to the
+    services you want to apply it to. You have to define the namespace for
     each service since it is not in the same namespace this `QuotaSpecBinding`
     resource was deployed into.
 
 1. Refresh the `productpage` in your browser.
 
-    If you are logged out, reviews-v3 service is rate limited to 1 request
+    If you are logged out, `reviews-v3` service is rate limited to 1 request
     every 5 seconds. If you keep refreshing the page the stars should only
     load around once every 5 seconds.
 
-    If you log in as user "jason", reviews-v2 service is rate limited to 5
+    If you log in as user "jason", `reviews-v2` service is rate limited to 5
     requests every 10 seconds. If you keep refreshing the page the stars
     should only load 5 times every 10 seconds.
 
-    For all other services the default 5000qps rate limit will apply.
+    For all other services, the default 5000 qps rate limit will apply.
 
 ## Conditional rate limits
 
-In the previous example we applied a rate limit to the `ratings` service
+In the previous example you applied a rate limit to the `ratings` service
 without regard to non-dimension attributes. It is possible to conditionally
 apply rate limits based on arbitrary attributes using a match condition in
 the quota rule.
@@ -225,7 +229,7 @@ destination namespaces are different.
 
 ## Understanding rate limits
 
-In the preceding examples we saw how Mixer applies rate limits to requests
+In the preceding examples you saw how Mixer applies rate limits to requests
 that match certain conditions.
 
 Every named quota instance like `requestcount` represents a set of counters.
@@ -241,7 +245,7 @@ The `maxAmount` in the adapter configuration sets the default limit for all
 counters associated with a quota instance. This default limit applies if a
 quota override does not match the request. Memquota selects the first
 override that matches a request. An override need not specify all quota
-dimensions. In the example, the `0.2qps` override is selected by matching
+dimensions. In the example, the `0.2 qps` override is selected by matching
 only three out of four quota dimensions.
 
 If you would like the above policies enforced for a given namespace instead
@@ -250,18 +254,18 @@ with the given namespace.
 
 ## Cleanup
 
-* Remove the rate limit configuration:
+1. Remove the rate limit configuration:
 
     {{< text bash >}}
     $ istioctl delete -f @samples/bookinfo/policy/mixer-rule-ratings-ratelimit.yaml@
     {{< /text >}}
 
-* Remove the application routing rules:
+2. Remove the application routing rules:
 
     {{< text bash >}}
     $ istioctl delete -f @samples/bookinfo/networking/virtual-service-all-v1.yaml@
     {{< /text >}}
 
-* If you are not planning to explore any follow-on tasks, refer to the
+3. If you are not planning to explore any follow-on tasks, refer to the
   [Bookinfo cleanup](/docs/examples/bookinfo/#cleanup) instructions
   to shutdown the application.


### PR DESCRIPTION
Replace "we" with "you" throughout. Use a numbered list in "Before you begin" and "Cleanup" because the order matters. Added info about the 3 versions in the Bookinfo sample. Added info about setting the default version before the command. Added a space between the number and 'qps' throughout. 