### PR TITLE
Adds a Jaeger UI detail for distributed tracing

### DIFF
--- a/content/docs/tasks/telemetry/distributed-tracing/index.md
+++ b/content/docs/tasks/telemetry/distributed-tracing/index.md
@@ -19,27 +19,28 @@ example application for this task.
 
 *   Setup Istio by following the instructions in the [Installation guide](/docs/setup/).
 
-    Either use the `istio.yaml` (or `istio-auth.yaml`) template, which includes tracing support, or
-    use the helm chart with tracing enabled using the `--set tracing.enabled=true` option.
+    Either use the `istio-demo.yaml` or `istio-demo-auth.yaml` template, which includes tracing support, or
+    use the helm chart with tracing enabled by setting the `--set tracing.enabled=true` option.
 
 * Deploy the [Bookinfo](/docs/examples/bookinfo/) sample application.
 
 ## Accessing the dashboard
 
-Setup access to the tracing dashboard URL using port-forwarding:
+Setup access to the Jaeger dashboard by using port-forwarding:
 
 {{< text bash >}}
 $ kubectl port-forward -n istio-system $(kubectl get pod -n istio-system -l app=jaeger -o jsonpath='{.items[0].metadata.name}') 16686:16686 &
 {{< /text >}}
 
-Then open your browser at [http://localhost:16686](http://localhost:16686)
+Access the Jaeger dashboard by opening your browser to [http://localhost:16686](http://localhost:16686).
 
 ## Generating traces using the Bookinfo sample
 
 With the Bookinfo application up and running, generate trace information by accessing
 `http://$GATEWAY_URL/productpage` one or more times.
 
-If you now look at the dashboard, you should see something similar to the following:
+From the left-hand pane of the Jaeger dashboard, select productpage from the Service drop-down list and click
+Find Traces. You should see something similar to the following:
 
 {{< image width="100%" ratio="42.35%"
     link="./istio-tracing-list.png"


### PR DESCRIPTION
The current "Distributed Tracing" section misses a step to have a user select the `productpage` service from the Jaeger UI. This PR also cleans-up a few sentences for readability.