### PR TITLE
Update kubernetes engine cluster version.

### DIFF
--- a/content/docs/setup/kubernetes/quick-start/index.md
+++ b/content/docs/setup/kubernetes/quick-start/index.md
@@ -47,7 +47,7 @@ Create a new cluster.
 
 {{< text bash >}}
 $ gcloud container clusters create <cluster-name> \
-    --cluster-version=1.10.4-gke.0 \
+    --cluster-version=1.10.5-gke.0 \
     --zone <zone> \
     --project <project-name>
 {{< /text >}}


### PR DESCRIPTION
According to https://cloud.google.com/kubernetes-engine/release-notes#june-28-2018, 1.10.4-gke.0 is no longer available but 1.10.5-gke.0 now is.

With the old version I get:

```
$ gcloud container clusters create quickstart --cluster-version=1.10.4-gke.0 --zone us-east1-b --project jblatt-test
ERROR: (gcloud.container.clusters.create) ResponseError: code=400, message=master version "1.10.4-gke.0" is unsupported.
```