### PR TITLE
Add a platform setup section and link it in helm install page

### DIFF
--- a/content/docs/setup/kubernetes/helm-install/index.md
+++ b/content/docs/setup/kubernetes/helm-install/index.md
@@ -15,6 +15,8 @@ plane and the sidecars for the Istio data plane.
 
 ## Prerequisites
 
+1. [Setup Istio in Kubernetes](/docs/setup/kubernetes/quick-start/#).
+
 1. [Download](/docs/setup/kubernetes/quick-start/#download-and-prepare-for-the-installation)
    the latest Istio release.
 

--- a/content/docs/setup/kubernetes/helm-install/index.md
+++ b/content/docs/setup/kubernetes/helm-install/index.md
@@ -15,7 +15,8 @@ plane and the sidecars for the Istio data plane.
 
 ## Prerequisites
 
-1. [Setup Istio in Kubernetes](/docs/setup/kubernetes/quick-start/).
+1. [Setup Istio in
+   Kubernetes](/docs/setup/kubernetes/quick-start/#platform-setup).
 
 1. [Download](/docs/setup/kubernetes/quick-start/#download-and-prepare-for-the-installation)
    the latest Istio release.

--- a/content/docs/setup/kubernetes/helm-install/index.md
+++ b/content/docs/setup/kubernetes/helm-install/index.md
@@ -15,7 +15,7 @@ plane and the sidecars for the Istio data plane.
 
 ## Prerequisites
 
-1. [Setup Istio in Kubernetes](/docs/setup/kubernetes/quick-start/#).
+1. [Setup Istio in Kubernetes](/docs/setup/kubernetes/quick-start/).
 
 1. [Download](/docs/setup/kubernetes/quick-start/#download-and-prepare-for-the-installation)
    the latest Istio release.

--- a/content/docs/setup/kubernetes/quick-start/index.md
+++ b/content/docs/setup/kubernetes/quick-start/index.md
@@ -23,6 +23,10 @@ The following instructions require:
   > it completely before installing the newer version. Remember to uninstall
   > the Istio sidecar for all Istio enabled application pods too.
 
+## Platform setup
+
+This section describes the setup in different platforms.
+
 ### Setup Minikube
 
 1. To install Istio locally, install the latest version of


### PR DESCRIPTION
Otherwise people will not set up corresponding environment and the installation will fail.

For instance, you need to set up RBAC https://preliminary.istio.io/docs/setup/kubernetes/quick-start/#google-kubernetes-engine in GKE.