### PR TITLE
Create destination rules when running bookinfo

### DIFF
--- a/content/docs/examples/bookinfo/index.md
+++ b/content/docs/examples/bookinfo/index.md
@@ -207,10 +207,11 @@ Run the following command to create default destination rules for the bookinfo s
 
 Wait a few seconds for the destination rules to propagate.
 
-> You can display the destination rules with the following command:
-    {{< text bash >}}
-    $ istioctl get destinationrules -o yaml
-    {{< /text >}}
+You can display the destination rules with the following command:
+
+{{< text bash >}}
+$ istioctl get destinationrules -o yaml
+{{< /text >}}
 
 ## What's next
 

--- a/content/docs/examples/bookinfo/index.md
+++ b/content/docs/examples/bookinfo/index.md
@@ -142,7 +142,7 @@ To start the application, follow the instructions below corresponding to your Is
     $ export GATEWAY_URL=$INGRESS_HOST:$INGRESS_PORT
     {{< /text >}}
 
-1.  Proceed to [What's next](#what-s-next), below.
+1.  Proceed to [Confirm the app is running](#confirm-the-app-is-running), below.
 
 ### If you are running on Docker with Consul
 
@@ -171,7 +171,7 @@ To start the application, follow the instructions below corresponding to your Is
     $ export GATEWAY_URL=localhost:9081
     {{< /text >}}
 
-## What's next
+## Confirm the app is running
 
 To confirm that the Bookinfo application is running, run the following `curl` command:
 
@@ -185,6 +185,34 @@ to view the Bookinfo web page. If you refresh the page several times, you should
 see different versions of reviews shown in productpage, presented in a round robin style (red
 stars, black stars, no stars), since we haven't yet used Istio to control the
 version routing.
+
+## Apply default destination rules
+
+Before you can use Istio to control the bookinfo version routing, you need to define the available
+versions, called *subsets*, in destination rules.
+
+Run the following command to create default destination rules for the bookinfo services:
+
+* If you did **not** enable mutual TLS, execute this command:
+
+    {{< text bash >}}
+    $ istioctl create -f @samples/bookinfo/networking/destination-rule-all.yaml@
+    {{< /text >}}
+
+* If you **did** enable mutual TLS, execute this command:
+
+    {{< text bash >}}
+    $ istioctl create -f @samples/bookinfo/networking/destination-rule-all-mtls.yaml@
+    {{< /text >}}
+
+Wait a few seconds for the destination rules to propagate.
+
+> You can display the destination rules with the following command:
+    {{< text bash >}}
+    $ istioctl get destinationrules -o yaml
+    {{< /text >}}
+
+## What's next
 
 You can now use this sample to experiment with Istio's features for
 traffic routing, fault injection, rate limiting, etc.

--- a/content/docs/tasks/traffic-management/request-routing/index.md
+++ b/content/docs/tasks/traffic-management/request-routing/index.md
@@ -30,44 +30,15 @@ will apply a rule to route traffic based on the value of an HTTP request header.
 To illustrate the problem this task solves, access the Bookinfo app's `/productpage` in a browser and refresh several times. You’ll notice that sometimes the book review output contains star ratings and other times it does not. This is because without an explicit default service version to route to, Istio routes requests to all available versions
 in a round robin fashion.
 
-## Apply a default destination rule
-
-To route to one version only, you start by applying destination rules. Destination rules define traffic policies that Istio applies to requests. Destination rules also let you define which versions of the destination host are addressable. These addressable versions are called *subsets*.
-
-1.  Run the following command to apply a default destination rule:
-
-    If you did **not** enable mutual TLS, execute this command:
-
-    {{< text bash >}}
-    $ istioctl create -f @samples/bookinfo/networking/destination-rule-all.yaml@
-    {{< /text >}}
-
-    If you **did** enable mutual TLS, execute this command:
-
-    {{< text bash >}}
-    $ istioctl create -f @samples/bookinfo/networking/destination-rule-all-mtls.yaml@
-    {{< /text >}}
-
-    Wait a few seconds for the destination rules to propagate.
-
-1. Display the destination rules with the following command:
-
-    {{< text bash >}}
-    $ istioctl get destinationrules -o yaml
-    {{< /text >}}
-
-    In the next step, you will add virtual services that refer to the subsets
-    defined in the rules.
-
 ## Apply a virtual service
 
-Next, apply a virtual service to set the default version for all of the microservices.
-In this case, the virtual service routes all traffic to `v1` of each microservice.
+To route to one version only, you apply virtual services that set the default version for the microservices.
+In this case, the virtual services will route all traffic to `v1` of each microservice.
 
  > Before continuing, be sure you don't have any existing virtual services applied
 to the Bookinfo app. If you already created conflicting virtual services for Bookinfo, you must use `replace` rather than `create` in the following command.
 
-1.  Run the following command to apply the virtual service:
+1.  Run the following command to apply the virtual services:
 
     {{< text bash >}}
     $ istioctl create -f @samples/bookinfo/networking/virtual-service-all-v1.yaml@
@@ -240,22 +211,10 @@ gradually send traffic from one version of a service to another.
 
 ## Cleanup
 
-1.   Remove the application virtual services.
+1. Remove the application virtual services.
 
     {{< text bash >}}
     $ istioctl delete -f @samples/bookinfo/networking/virtual-service-all-v1.yaml@
-    {{< /text >}}
-
-1.   Remove the application destination rules.
-
-    {{< text bash >}}
-    $ istioctl delete -f @samples/bookinfo/networking/destination-rule-all.yaml@
-    {{< /text >}}
-
-    If you enabled mutual TLS, please run the following instead
-
-    {{< text bash >}}
-    $ istioctl delete -f @samples/bookinfo/networking/destination-rule-all-mtls.yaml@
     {{< /text >}}
 
 1. If you are not planning to explore any follow-on tasks, refer to the


### PR DESCRIPTION
The bookinfo destinations rules (subsets) are needed in several tasks, so rather than repeating the instructions for applying them in all these places, this change will do it once, up front, when starting the bookinfo sample.