### PR TITLE
Add port-forward cleanup step in distributed-tracing, fluentd, metric…

### DIFF
--- a/content/docs/tasks/telemetry/distributed-tracing/index.md
+++ b/content/docs/tasks/telemetry/distributed-tracing/index.md
@@ -139,12 +139,12 @@ When you make downstream calls in your applications, make sure to include these 
 
 ## Cleanup
 
-* Remove any `kubectl port-forward` processes that may still be running:
+*   Remove any `kubectl port-forward` processes that may still be running:
 
-  {{< text bash >}}
-  $ killall kubectl
-  {{< /text >}}
+    {{< text bash >}}
+    $ killall kubectl
+    {{< /text >}}
 
-* If you are not planning to explore any follow-on tasks, refer to the
-  [Bookinfo cleanup](/docs/examples/bookinfo/#cleanup) instructions
-  to shutdown the application.
+*   If you are not planning to explore any follow-on tasks, refer to the
+    [Bookinfo cleanup](/docs/examples/bookinfo/#cleanup) instructions
+    to shutdown the application.

--- a/content/docs/tasks/telemetry/distributed-tracing/index.md
+++ b/content/docs/tasks/telemetry/distributed-tracing/index.md
@@ -139,6 +139,12 @@ When you make downstream calls in your applications, make sure to include these 
 
 ## Cleanup
 
+* Remove any `kubectl port-forward` processes that may still be running:
+
+  {{< text bash >}}
+  $ killall kubectl
+  {{< /text >}}
+
 * If you are not planning to explore any follow-on tasks, refer to the
   [Bookinfo cleanup](/docs/examples/bookinfo/#cleanup) instructions
   to shutdown the application.

--- a/content/docs/tasks/telemetry/fluentd/index.md
+++ b/content/docs/tasks/telemetry/fluentd/index.md
@@ -400,6 +400,12 @@ example stack.
     $ kubectl delete -f logging-stack.yaml
     {{< /text >}}
 
+*   Remove any `kubectl port-forward` processes that may still be running:
+
+    {{< text bash >}}
+    $ killall kubectl
+    {{< /text >}}
+
 * If you are not planning to explore any follow-on tasks, refer to the
   [Bookinfo cleanup](/docs/examples/bookinfo/#cleanup) instructions
   to shutdown the application.

--- a/content/docs/tasks/telemetry/metrics-logs/index.md
+++ b/content/docs/tasks/telemetry/metrics-logs/index.md
@@ -294,6 +294,12 @@ here to illustrate how to use `match` expressions to control rule execution.
     $ istioctl delete -f new_telemetry.yaml
     {{< /text >}}
 
+*   Remove any `kubectl port-forward` processes that may still be running:
+
+    {{< text bash >}}
+    $ killall kubectl
+    {{< /text >}}
+
 * If you are not planning to explore any follow-on tasks, refer to the
   [Bookinfo cleanup](/docs/examples/bookinfo/#cleanup) instructions
   to shutdown the application.

--- a/content/docs/tasks/telemetry/servicegraph/index.md
+++ b/content/docs/tasks/telemetry/servicegraph/index.md
@@ -105,6 +105,12 @@ depends on the standard Istio metric configuration.
 
 ## Cleanup
 
+* Remove any `kubectl port-forward` processes that may still be running:
+
+  {{< text bash >}}
+  $ killall kubectl
+  {{< /text >}}
+
 * If you are not planning to explore any follow-on tasks, refer to the
 [Bookinfo cleanup](/docs/examples/bookinfo/#cleanup) instructions
 to shutdown the application.

--- a/content/docs/tasks/telemetry/servicegraph/index.md
+++ b/content/docs/tasks/telemetry/servicegraph/index.md
@@ -105,12 +105,12 @@ depends on the standard Istio metric configuration.
 
 ## Cleanup
 
-* Remove any `kubectl port-forward` processes that may still be running:
+*   Remove any `kubectl port-forward` processes that may still be running:
 
-  {{< text bash >}}
-  $ killall kubectl
-  {{< /text >}}
+    {{< text bash >}}
+    $ killall kubectl
+    {{< /text >}}
 
-* If you are not planning to explore any follow-on tasks, refer to the
-[Bookinfo cleanup](/docs/examples/bookinfo/#cleanup) instructions
-to shutdown the application.
+*   If you are not planning to explore any follow-on tasks, refer to the
+    [Bookinfo cleanup](/docs/examples/bookinfo/#cleanup) instructions
+    to shutdown the application.


### PR DESCRIPTION
Add port-forward cleanup step in distributed-tracing, fluentd, metrics-logs and servicegraph tasks

This addresses Issue https://github.com/istio/istio.github.io/issues/1842