### PR TITLE
Add in missing galley permissions for OpenShift

### DIFF
--- a/content/docs/setup/kubernetes/quick-start/index.md
+++ b/content/docs/setup/kubernetes/quick-start/index.md
@@ -133,6 +133,8 @@ $ oc adm policy add-scc-to-user anyuid -z istio-pilot-service-account \
   -n istio-system
 $ oc adm policy add-scc-to-user anyuid \
   -z istio-sidecar-injector-service-account -n istio-system
+$ oc adm policy add-scc-to-user anyuid -z istio-galley-service-account \
+  -n istio-system
 {{< /text >}}
 
 The list above accounts for the default Istio service accounts. If you enabled


### PR DESCRIPTION
There is a missing permission that needs to be granted when running Istio 1.0 on OpenShift. Without this change the galley pod will fail to start and enter a crash loopback.