### PR TITLE
Add release note about lacking Citadel Helm

### DIFF
--- a/content/about/notes/1.0/index.md
+++ b/content/about/notes/1.0/index.md
@@ -28,6 +28,6 @@ to usual pile of bug fixes and performance improvements.
   clusters.  This results in a loss of telemetry fidelity as some of the metadata associated
   with workloads on remote clusters is incomplete.
 
-- There are Kubernetes manifests available for using Citadel standalone or with Citadel healthchecking enabled.
+- There are Kubernetes manifests available for using Citadel standalone or with Citadel health checking enabled.
   There is not a Helm implementation of these modes.  See [Issue 6922](https://github.com/istio/istio/issues/6922)
   for more details.

--- a/content/about/notes/1.0/index.md
+++ b/content/about/notes/1.0/index.md
@@ -27,3 +27,7 @@ to usual pile of bug fixes and performance improvements.
   and mixer-policy components do not connect to the Kubernetes API endpoints of any of the remote
   clusters.  This results in a loss of telemetry fidelity as some of the metadata associated
   with workloads on remote clusters is incomplete.
+
+- There are Kubernetes manifests available for using Citadel standalone or with Citadel healthchecking enabled.
+  There is not a Helm implementation of these modes.  See [Issue 6922](https://github.com/istio/istio/issues/6922)
+  for more details.


### PR DESCRIPTION
The Helm Citadel implementation will not make the 1.0 release.  We
can resolve this in later revisions.