### PR TITLE
Update the Citadel certificate lifetime config document

### DIFF
--- a/content/help/faq/security/cert-lifetime-config.md
+++ b/content/help/faq/security/cert-lifetime-config.md
@@ -4,11 +4,11 @@ weight: 70
 ---
 
 For the workloads running in Kubernetes, the lifetime of their Istio certificates is controlled by the
-`workload-cert-ttl` flag on Citadel. The default value is 19 hours. This value should be no greater than
+`workload-cert-ttl` flag on Citadel. This value should be no greater than
 `max-workload-cert-ttl` of Citadel.
 
 Citadel uses a flag `max-workload-cert-ttl` to control the maximum lifetime for Istio certificates issued to
-workloads. The default value is 7 days. If `workload-cert-ttl` on Citadel or node agent is greater than
+workloads. If `workload-cert-ttl` on Citadel or node agent is greater than
 `max-workload-cert-ttl`, Citadel will fail issuing the certificate.
 
 Modify the `istio-demo-auth.yaml` file to customize the Citadel configuration.
@@ -37,7 +37,7 @@ spec:
 {{< /text >}}
 
 For the workloads running on VMs and bare metal hosts, the lifetime of their Istio certificates is specified by the
-`workload-cert-ttl` flag on each node agent. The default value is also 19 hours. This value should be no greater than
+`workload-cert-ttl` flag on each node agent. This value should be no greater than
 `max-workload-cert-ttl` of Citadel.
 
 To customize this configuration, the argument for the node agent service should be modified.


### PR DESCRIPTION
Update the Citadel certificate lifetime config document to be consistent with the implementation.