### PR TITLE
Use mock JWT and JWKS from codebase for end-user auth tutorial

### DIFF
--- a/content/docs/tasks/security/authn-policy/index.md
+++ b/content/docs/tasks/security/authn-policy/index.md
@@ -457,7 +457,9 @@ $ kubectl delete destinationrules httpbin -n bar
 
 ## End-user authentication
 
-To experiment with this feature, you will need a valid JWT (corresponding to the JWKS endpoint you want to use for the demo). In this tutorial, we will use a test [JWT]({{< github_file >}}/security/tools/jwt/samples/demo.jwt) and [JWKS endpoint]({{< github_file >}}/security/tools/jwt/samples/jwks.json) from Istio code base.
+To experiment with this feature, you need a valid JWT. The JWT must correspond to the JWKS endpoint you want to use for the demo. In
+this tutorial, we use this [JWT test]({{< github_file >}}/security/tools/jwt/samples/demo.jwt) and this
+[JWKS endpoint]({{< github_file >}}/security/tools/jwt/samples/jwks.json) from the Istio code base.
 
 Also, for convenience, expose `httpbin.foo` via ingressgateway (for more details, see the [ingress task](/docs/tasks/traffic-management/ingress/)).
 
@@ -550,7 +552,9 @@ $ curl --header "Authorization: Bearer $TOKEN" $INGRESS_HOST/headers -s -o /dev/
 200
 {{< /text >}}
 
-You may want to use the script [`gen-jwt.py`]({{< github_tree >}}/security/tools/jwt/samples) to generate new tokens for testing with different issuer, audiences, expiry date etc to observe other aspects of JWT validation. For example, the command below creates a token that will expire in 5 seconds. As you will see, requests using that token will be authenticated successfully at first, but then be rejected after 5 seconds:
+To observe other aspects of JWT validation, use the script [gen-jwt.py]({{< github_tree >}}/security/tools/jwt/samples/gen-jwt.py) to
+generate new tokens to test with different issuer, audiences, expiry date, etc. For example, the command below creates a token that
+expires in 5 seconds. As you see, Istio authenticates requests using that token successfully at first but rejects them after 5 seconds:
 
 {{< text bash >}}
 $ TOKEN=$(@security/tools/jwt/samples/gen-jwt.py@ @security/tools/jwt/samples/key.pem@ --expire 5)

--- a/content/docs/tasks/security/authn-policy/index.md
+++ b/content/docs/tasks/security/authn-policy/index.md
@@ -457,7 +457,7 @@ $ kubectl delete destinationrules httpbin -n bar
 
 ## End-user authentication
 
-To experiment with this feature, you will need a valid JWT (corresponding to the JWKS endpoint you want to use for the demo). In this tutorial, we will use a test [JWT](https://raw.githubusercontent.com/istio/istio/master/security/tools/jwt/samples/demo.jwt) and [JWKS endpoint](https://raw.githubusercontent.com/istio/istio/master/security/tools/jwt/samples/jwks.json) from Istio code base.
+To experiment with this feature, you will need a valid JWT (corresponding to the JWKS endpoint you want to use for the demo). In this tutorial, we will use a test [JWT]({{< github_file >}}/security/tools/jwt/samples/demo.jwt) and [JWKS endpoint]({{< github_file >}}/master/security/tools/jwt/samples/jwks.json) from Istio code base.
 
 Also, for convenience, expose `httpbin.foo` via ingressgateway (for more details, see the [ingress task](/docs/tasks/traffic-management/ingress/)).
 
@@ -530,7 +530,7 @@ spec:
   origins:
   - jwt:
       issuer: "testing@secure.istio.io"
-      jwksUri: "https://raw.githubusercontent.com/istio/istio/master/security/tools/jwt/samples/jwks.json"
+      jwksUri: "{{< github_file >}}/security/tools/jwt/samples/jwks.json"
   principalBinding: USE_ORIGIN
 EOF
 {{< /text >}}
@@ -545,7 +545,7 @@ $ curl $INGRESS_HOST/headers -s -o /dev/null -w "%{http_code}\n"
 Attaching the valid token generated above returns success:
 
 {{< text bash>}}
-$ TOKEN=$(curl https://raw.githubusercontent.com/istio/istio/master/security/tools/jwt/samples/demo.jwt -s)
+$ TOKEN=$(curl {{< github_file >}}/security/tools/jwt/samples/demo.jwt -s)
 $ curl --header "Authorization: Bearer $TOKEN" $INGRESS_HOST/headers -s -o /dev/null -w "%{http_code}\n"
 200
 {{< /text >}}

--- a/content/docs/tasks/security/authn-policy/index.md
+++ b/content/docs/tasks/security/authn-policy/index.md
@@ -457,7 +457,7 @@ $ kubectl delete destinationrules httpbin -n bar
 
 ## End-user authentication
 
-To experiment with this feature, you will need a valid JWT (corresponding to the JWKS endpoint you want to use for the demo). In this tutorial, we will use a test [JWT]({{< github_file >}}/security/tools/jwt/samples/demo.jwt) and [JWKS endpoint]({{< github_file >}}/master/security/tools/jwt/samples/jwks.json) from Istio code base.
+To experiment with this feature, you will need a valid JWT (corresponding to the JWKS endpoint you want to use for the demo). In this tutorial, we will use a test [JWT]({{< github_file >}}/security/tools/jwt/samples/demo.jwt) and [JWKS endpoint]({{< github_file >}}/security/tools/jwt/samples/jwks.json) from Istio code base.
 
 Also, for convenience, expose `httpbin.foo` via ingressgateway (for more details, see the [ingress task](/docs/tasks/traffic-management/ingress/)).
 

--- a/content/docs/tasks/security/authn-policy/index.md
+++ b/content/docs/tasks/security/authn-policy/index.md
@@ -552,7 +552,7 @@ $ curl --header "Authorization: Bearer $TOKEN" $INGRESS_HOST/headers -s -o /dev/
 200
 {{< /text >}}
 
-To observe other aspects of JWT validation, use the script [gen-jwt.py]({{< github_tree >}}/security/tools/jwt/samples/gen-jwt.py) to
+To observe other aspects of JWT validation, use the script `[gen-jwt.py]({{< github_tree >}}/security/tools/jwt/samples/gen-jwt.py)` to
 generate new tokens to test with different issuer, audiences, expiry date, etc. For example, the command below creates a token that
 expires in 5 seconds. As you see, Istio authenticates requests using that token successfully at first but rejects them after 5 seconds:
 

--- a/content/docs/tasks/security/authn-policy/index.md
+++ b/content/docs/tasks/security/authn-policy/index.md
@@ -457,7 +457,7 @@ $ kubectl delete destinationrules httpbin -n bar
 
 ## End-user authentication
 
-To experiment with this feature, you will need a valid JWT (corresponding to the JWKS endpoint you want to use for the demo). In this tutorial, we will use a test [JWT](https://raw.githubusercontent.com/istio/istio/master/security/tools/jwt/samples/demo.jwt) and [JWKS endpoint](https://raw.githubusercontent.com/istio/istio/master/security/tools/jwt/samples/jwks.json) from Istio codebase.
+To experiment with this feature, you will need a valid JWT (corresponding to the JWKS endpoint you want to use for the demo). In this tutorial, we will use a test [JWT](https://raw.githubusercontent.com/istio/istio/master/security/tools/jwt/samples/demo.jwt) and [JWKS endpoint](https://raw.githubusercontent.com/istio/istio/master/security/tools/jwt/samples/jwks.json) from Istio code base.
 
 Also, for convenience, expose `httpbin.foo` via ingressgateway (for more details, see the [ingress task](/docs/tasks/traffic-management/ingress/)).
 
@@ -550,7 +550,7 @@ $ curl --header "Authorization: Bearer $TOKEN" $INGRESS_HOST/headers -s -o /dev/
 200
 {{< /text >}}
 
-You may want to use the script [gen-jwt.py]({{< github_tree >}}/security/tools/jwt/samples) to generate new tokens for testing with different issuer, audiences, expiry date etc to observe other aspects of JWT validation. For example, the command below creates a token that will expire in 5 seconds. As you will see, requests using that token will be authenticated succeffully at first, but then be rejected after 5 seconds:
+You may want to use the script [`gen-jwt.py`]({{< github_tree >}}/security/tools/jwt/samples) to generate new tokens for testing with different issuer, audiences, expiry date etc to observe other aspects of JWT validation. For example, the command below creates a token that will expire in 5 seconds. As you will see, requests using that token will be authenticated successfully at first, but then be rejected after 5 seconds:
 
 {{< text bash >}}
 $ TOKEN=$(@security/tools/jwt/samples/gen-jwt.py@ @security/tools/jwt/samples/key.pem@ --expire 5)


### PR DESCRIPTION
This simplify setup for end-user authentication demo.