### PR TITLE
update doc as ansible installation policy changes

### DIFF
--- a/content/docs/setup/kubernetes/ansible-install/index.md
+++ b/content/docs/setup/kubernetes/ansible-install/index.md
@@ -9,7 +9,11 @@ Instructions for the installation and configuration of Istio using Ansible.
 
 ## Prerequisites
 
-The following instructions require [Ansible 2.4](https://docs.ansible.com/ansible/latest/intro_installation.html). Additionally Kubernetes **1.9.0 or newer** is required.
+1. [Download the Istio release](/docs/setup/kubernetes/download-release/).
+
+1. [Kubernetes platform setup](/docs/setup/kubernetes/platform-setup/).
+
+1. [Ansible 2.4 Installed](https://docs.ansible.com/ansible/latest/intro_installation.html).
 
 The following prerequisites must be met if using OpenShift.
 
@@ -22,7 +26,7 @@ The following prerequisites must be met if using OpenShift.
 
 {{< warning_icon >}} All execution of the Ansible playbooks must take place in the `install/kubernetes/ansible` path of Istio.
 
-This playbook will download and install Istio locally on your machine. To deploy the default settings of
+This playbook will install Istio locally on your machine. To deploy the default settings of
 Istio on OpenShift, the following command may be used:
 
 {{< text bash >}}
@@ -38,11 +42,8 @@ The currently exposed options are:
 | Parameter | Description | Values | Default |
 | --- | --- | --- | --- |
 | `cluster_flavour` | Define the target cluster type | `k8s` or `ocp` | `ocp` |
-| `github_api_token` | A valid GitHub API authentication token used for authenticating with GitHub | A valid GitHub API token | empty |
 | `cmd_path` | Override the path to `kubectl` or `oc` | A valid path to a `kubectl` or `oc` binary | `$PATH/oc` |
-| `istio.dest` | The directory of the target machine where Istio will be installed | Any directory with read+write permissions | `~/.istio` |
 | `istio.auth` | Install with mutual TLS | `true` or `false` | `false` |
-| `istio.namespace` | Kubernetes namespace where Istio will be installed | any namespace may be specified | `istio-system` |
 | `istio.addon` | Istio addons to install | array containing any of `kiali` | Istio already installs `grafana`, `prometheus`, `jaeger` by default |
 | `istio.delete_resources` | Delete resources created under Istio namespace | `true` or `false` | false |
 | `istio.samples` | Array containing the names of the samples that should be installed | `bookinfo`, `helloworld`, `httpbin`, `sleep` | none |


### PR DESCRIPTION
In[ istio/istio](https://github.com/istio/istio), the ansible setup way has changed to install istio with the local release version rather than the latest release version. PR is here: https://github.com/istio/istio/pull/7354. Update this doc to make them consistent