### PR TITLE
Clean up of the platform section

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -126,7 +126,6 @@ OP_QUERY
 OpenID_Connect
 OpenSSL
 OpenShift
-openshift
 Ostrowski
 PaaS
 Papertrail

--- a/content/blog/2018/export-logs-through-stackdriver/index.md
+++ b/content/blog/2018/export-logs-through-stackdriver/index.md
@@ -50,7 +50,7 @@ Common setup for all sinks:
 1.  Record the ID of the dataset. It will be needed to configure the Stackdriver handler.
     It would be of the form `bigquery.googleapis.com/projects/[PROJECT_ID]/datasets/[DATASET_ID]`
 1.  Give [sink’s writer identity](https://cloud.google.com/logging/docs/api/tasks/exporting-logs#writing_to_the_destination): `cloud-logs@system.gserviceaccount.com` BigQuery Data Editor role in IAM.
-1.  If using [Google Kubernetes Engine](/docs/setup/kubernetes/gke/), make sure `bigquery` [Scope](https://cloud.google.com/sdk/gcloud/reference/container/clusters/create) is enabled on the cluster.
+1.  If using [Google Kubernetes Engine](/docs/setup/kubernetes/platform-setup/gke/), make sure `bigquery` [Scope](https://cloud.google.com/sdk/gcloud/reference/container/clusters/create) is enabled on the cluster.
 
 #### Google Cloud Storage (GCS)
 
@@ -65,7 +65,7 @@ Common setup for all sinks:
 1.  Recode the ID of the topic. It will be needed to configure Stackdriver.
     It would be of the form `pubsub.googleapis.com/projects/[PROJECT_ID]/topics/[TOPIC_ID]`
 1.  Give [sink’s writer identity](https://cloud.google.com/logging/docs/api/tasks/exporting-logs#writing_to_the_destination): `cloud-logs@system.gserviceaccount.com` Pub/Sub Publisher role in IAM.
-1.  If using [Google Kubernetes Engine](/docs/setup/kubernetes/gke/), make sure `pubsub` [Scope](https://cloud.google.com/sdk/gcloud/reference/container/clusters/create) is enabled on the cluster.
+1.  If using [Google Kubernetes Engine](/docs/setup/kubernetes/platform-setup/gke/), make sure `pubsub` [Scope](https://cloud.google.com/sdk/gcloud/reference/container/clusters/create) is enabled on the cluster.
 
 ### Setting up Stackdriver
 

--- a/content/docs/examples/endpoints/index.md
+++ b/content/docs/examples/endpoints/index.md
@@ -21,7 +21,7 @@ You may test the service using the following command:
 $ curl --request POST --header "content-type:application/json" --data '{"message":"hello world"}' "http://${EXTERNAL_IP}:80/echo?key=${ENDPOINTS_KEY}"
 {{< /text >}}
 
-To install Istio for GKE, follow our [Quick Start with Google Kubernetes Engine](/docs/setup/kubernetes/gke).
+To install Istio for GKE, follow our [Quick Start with Google Kubernetes Engine](/docs/setup/kubernetes/platform-setup/gke).
 
 ## HTTP Endpoints service
 

--- a/content/docs/setup/kubernetes/ansible-install/index.md
+++ b/content/docs/setup/kubernetes/ansible-install/index.md
@@ -1,7 +1,7 @@
 ---
 title: Installation with Ansible
 description: Install Istio with the included Ansible playbook.
-weight: 4
+weight: 40
 keywords: [kubernetes,ansible]
 ---
 

--- a/content/docs/setup/kubernetes/download-release/index.md
+++ b/content/docs/setup/kubernetes/download-release/index.md
@@ -1,7 +1,7 @@
 ---
 title: Download the Istio release
 description: Instructions to download the Istio release.
-weight: 9
+weight: 90
 keywords: [kubernetes]
 ---
 

--- a/content/docs/setup/kubernetes/helm-install/index.md
+++ b/content/docs/setup/kubernetes/helm-install/index.md
@@ -1,7 +1,7 @@
 ---
 title: Installation with Helm
 description: Install Istio with the included Helm chart.
-weight: 3
+weight: 30
 keywords: [kubernetes,helm]
 aliases:
     - /docs/setup/kubernetes/helm.html

--- a/content/docs/setup/kubernetes/helm-install/index.md
+++ b/content/docs/setup/kubernetes/helm-install/index.md
@@ -21,7 +21,7 @@ plane and the sidecars for the Istio data plane.
   * [Minikube](/docs/setup/kubernetes/platform-setup/minikube/)
   * [Google Container Engine (GKE)](/docs/setup/kubernetes/platform-setup/gke/)
   * [IBM Cloud Kubernetes Service (IKS)](/docs/setup/kubernetes/platform-setup/ibm/)
-  * [Openshift Origin](/docs/setup/kubernetes/platform-setup/openshift/)
+  * [OpenShift Origin](/docs/setup/kubernetes/platform-setup/openshift/)
   * [Amazon Web Services (AWS) with Kops](/docs/setup/kubernetes/platform-setup/aws/)
   * [Azure](/docs/setup/kubernetes/platform-setup/azure/)
 

--- a/content/docs/setup/kubernetes/helm-install/index.md
+++ b/content/docs/setup/kubernetes/helm-install/index.md
@@ -17,13 +17,13 @@ plane and the sidecars for the Istio data plane.
 
 1. [Download the Istio release](/docs/setup/kubernetes/download-release/).
 
-1. Kubernetes platform setup
-  * [Minikube](/docs/setup/kubernetes/minikube/)
-  * [Google Container Engine (GKE)](/docs/setup/kubernetes/gke/)
-  * [IBM Cloud Kubernetes Service (IKS)](/docs/setup/kubernetes/ibm/)
-  * [Openshift Origin](/docs/setup/kubernetes/openshift/)
-  * [Amazon Web Services (AWS) with Kops](/docs/setup/kubernetes/aws/)
-  * [Azure](/docs/setup/kubernetes/azure/)
+1. [Kubernetes platform setup](/docs/setup/kubernetes/platform-setup/):
+  * [Minikube](/docs/setup/kubernetes/platform-setup/minikube/)
+  * [Google Container Engine (GKE)](/docs/setup/kubernetes/platform-setup/gke/)
+  * [IBM Cloud Kubernetes Service (IKS)](/docs/setup/kubernetes/platform-setup/ibm/)
+  * [Openshift Origin](/docs/setup/kubernetes/platform-setup/openshift/)
+  * [Amazon Web Services (AWS) with Kops](/docs/setup/kubernetes/platform-setup/aws/)
+  * [Azure](/docs/setup/kubernetes/platform-setup/azure/)
 
 1. [Install the Helm client](https://docs.helm.sh/using_helm/#installing-helm).
 

--- a/content/docs/setup/kubernetes/mesh-expansion/index.md
+++ b/content/docs/setup/kubernetes/mesh-expansion/index.md
@@ -1,7 +1,7 @@
 ---
 title: Mesh Expansion
 description: Instructions for integrating VMs and bare metal hosts into an Istio mesh deployed on Kubernetes.
-weight: 5
+weight: 50
 keywords: [kubernetes,vms]
 ---
 

--- a/content/docs/setup/kubernetes/multicluster-install/index.md
+++ b/content/docs/setup/kubernetes/multicluster-install/index.md
@@ -1,7 +1,7 @@
 ---
 title: Istio Multicluster
 description: Install Istio with multicluster support.
-weight: 6
+weight: 60
 keywords: [kubernetes,multicluster]
 ---
 

--- a/content/docs/setup/kubernetes/platform-setup/_index.md
+++ b/content/docs/setup/kubernetes/platform-setup/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Platform Setup
 description: How to prepare various Kubernetes platforms before installing Istio.
-weight: 10
+weight: 1
 keywords: [platform-setup]
 type: section-index
 ---

--- a/content/docs/setup/kubernetes/platform-setup/_index.md
+++ b/content/docs/setup/kubernetes/platform-setup/_index.md
@@ -1,0 +1,7 @@
+---
+title: Platform Setup
+description: How to prepare various Kubernetes platforms for Istio installation.
+weight: 10
+keywords: [platform-setup]
+type: section-index
+---

--- a/content/docs/setup/kubernetes/platform-setup/_index.md
+++ b/content/docs/setup/kubernetes/platform-setup/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Platform Setup
-description: How to prepare various Kubernetes platforms for Istio installation.
+description: How to prepare various Kubernetes platforms before installing Istio.
 weight: 10
 keywords: [platform-setup]
 type: section-index

--- a/content/docs/setup/kubernetes/platform-setup/aws/index.md
+++ b/content/docs/setup/kubernetes/platform-setup/aws/index.md
@@ -1,6 +1,6 @@
 ---
 title: Amazon Web Services
-description: Instructions to setup the AWS with Kops cluster for Istio.
+description: Instructions to setup an AWS cluster with Kops cluster for Istio.
 weight: 3
 keywords: [platform-setup,aws]
 ---

--- a/content/docs/setup/kubernetes/platform-setup/aws/index.md
+++ b/content/docs/setup/kubernetes/platform-setup/aws/index.md
@@ -1,7 +1,7 @@
 ---
 title: Amazon Web Services
 description: Instructions to setup the AWS with Kops cluster for Istio.
-weight: 14
+weight: 3
 keywords: [platform-setup,aws]
 ---
 

--- a/content/docs/setup/kubernetes/platform-setup/aws/index.md
+++ b/content/docs/setup/kubernetes/platform-setup/aws/index.md
@@ -2,7 +2,7 @@
 title: Platform setup for Amazon Web Services
 description: Instructions to setup the AWS with Kops cluster for Istio.
 weight: 14
-keywords: [aws]
+keywords: [platform-setup,aws]
 ---
 
 To setup the AWS with Kops cluster for Istio, follow these instructions:

--- a/content/docs/setup/kubernetes/platform-setup/aws/index.md
+++ b/content/docs/setup/kubernetes/platform-setup/aws/index.md
@@ -1,5 +1,5 @@
 ---
-title: Platform setup for Amazon Web Services
+title: Amazon Web Services
 description: Instructions to setup the AWS with Kops cluster for Istio.
 weight: 14
 keywords: [platform-setup,aws]

--- a/content/docs/setup/kubernetes/platform-setup/azure/index.md
+++ b/content/docs/setup/kubernetes/platform-setup/azure/index.md
@@ -1,6 +1,6 @@
 ---
 title: Azure
-description: Instructions to setup the Azure cluster for Istio.
+description: Instructions to setup an Azure cluster for Istio.
 weight: 6
 keywords: [platform-setup,azure]
 ---

--- a/content/docs/setup/kubernetes/platform-setup/azure/index.md
+++ b/content/docs/setup/kubernetes/platform-setup/azure/index.md
@@ -2,7 +2,7 @@
 title: Platform setup for Azure
 description: Instructions to setup the Azure cluster for Istio.
 weight: 15
-keywords: [azure]
+keywords: [platform-setup,azure]
 ---
 
 To setup the Azure cluster for Istio, follow these instructions:

--- a/content/docs/setup/kubernetes/platform-setup/azure/index.md
+++ b/content/docs/setup/kubernetes/platform-setup/azure/index.md
@@ -1,5 +1,5 @@
 ---
-title: Platform setup for Azure
+title: Azure
 description: Instructions to setup the Azure cluster for Istio.
 weight: 15
 keywords: [platform-setup,azure]

--- a/content/docs/setup/kubernetes/platform-setup/azure/index.md
+++ b/content/docs/setup/kubernetes/platform-setup/azure/index.md
@@ -1,7 +1,7 @@
 ---
 title: Azure
 description: Instructions to setup the Azure cluster for Istio.
-weight: 15
+weight: 6
 keywords: [platform-setup,azure]
 ---
 

--- a/content/docs/setup/kubernetes/platform-setup/gke/index.md
+++ b/content/docs/setup/kubernetes/platform-setup/gke/index.md
@@ -1,6 +1,6 @@
 ---
 title: Google Kubernetes Engine
-description: Instructions to setup the Google Kubernetes Engine cluster for Istio.
+description: Instructions to setup a Google Kubernetes Engine cluster for Istio.
 weight: 9
 keywords: [platform-setup,kubernetes,gke,google]
 ---

--- a/content/docs/setup/kubernetes/platform-setup/gke/index.md
+++ b/content/docs/setup/kubernetes/platform-setup/gke/index.md
@@ -2,7 +2,7 @@
 title: Platform setup for Google Kubernetes Engine
 description: Instructions to setup the Google Kubernetes Engine cluster for Istio.
 weight: 11
-keywords: [kubernetes,gke,google]
+keywords: [platform-setup,kubernetes,gke,google]
 ---
 
 To setup the Google Kubernetes Engine cluster for Istio, follow these instructions:

--- a/content/docs/setup/kubernetes/platform-setup/gke/index.md
+++ b/content/docs/setup/kubernetes/platform-setup/gke/index.md
@@ -1,5 +1,5 @@
 ---
-title: Platform setup for Google Kubernetes Engine
+title: Google Kubernetes Engine
 description: Instructions to setup the Google Kubernetes Engine cluster for Istio.
 weight: 11
 keywords: [platform-setup,kubernetes,gke,google]

--- a/content/docs/setup/kubernetes/platform-setup/gke/index.md
+++ b/content/docs/setup/kubernetes/platform-setup/gke/index.md
@@ -1,7 +1,7 @@
 ---
 title: Google Kubernetes Engine
 description: Instructions to setup the Google Kubernetes Engine cluster for Istio.
-weight: 11
+weight: 9
 keywords: [platform-setup,kubernetes,gke,google]
 ---
 

--- a/content/docs/setup/kubernetes/platform-setup/ibm/index.md
+++ b/content/docs/setup/kubernetes/platform-setup/ibm/index.md
@@ -1,6 +1,6 @@
 ---
 title: IBM Cloud Kubernetes Service
-description: Instructions to setup the IBM Cloud Kubernetes Service (IKS) cluster for Istio.
+description: Instructions to setup a IBM Cloud Kubernetes Service (IKS) cluster for Istio.
 weight: 12
 keywords: [platform-setup,ibm,iks]
 ---

--- a/content/docs/setup/kubernetes/platform-setup/ibm/index.md
+++ b/content/docs/setup/kubernetes/platform-setup/ibm/index.md
@@ -1,5 +1,5 @@
 ---
-title: Platform setup for IBM Cloud Kubernetes Service
+title: IBM Cloud Kubernetes Service
 description: Instructions to setup the IBM Cloud Kubernetes Service (IKS) cluster for Istio.
 weight: 12
 keywords: [platform-setup,ibm,iks]

--- a/content/docs/setup/kubernetes/platform-setup/ibm/index.md
+++ b/content/docs/setup/kubernetes/platform-setup/ibm/index.md
@@ -2,7 +2,7 @@
 title: Platform setup for IBM Cloud Kubernetes Service
 description: Instructions to setup the IBM Cloud Kubernetes Service (IKS) cluster for Istio.
 weight: 12
-keywords: [ibm,iks]
+keywords: [platform-setup,ibm,iks]
 ---
 
 To setup the IBM Cloud Kubernetes Service (IKS) cluster for Istio, follow these instructions:

--- a/content/docs/setup/kubernetes/platform-setup/minikube/index.md
+++ b/content/docs/setup/kubernetes/platform-setup/minikube/index.md
@@ -1,7 +1,7 @@
 ---
 title: Minikube
 description: Instructions to setup Minikube for use with Istio.
-weight: 10
+weight: 15
 keywords: [platform-setup,kubernetes,minikube]
 ---
 

--- a/content/docs/setup/kubernetes/platform-setup/minikube/index.md
+++ b/content/docs/setup/kubernetes/platform-setup/minikube/index.md
@@ -1,6 +1,6 @@
 ---
 title: Minikube
-description: Instructions to setup Minikube for use with Istio
+description: Instructions to setup Minikube for use with Istio.
 weight: 10
 keywords: [platform-setup,kubernetes,minikube]
 ---

--- a/content/docs/setup/kubernetes/platform-setup/minikube/index.md
+++ b/content/docs/setup/kubernetes/platform-setup/minikube/index.md
@@ -2,7 +2,7 @@
 title: Platform setup for Minikube
 description: Instructions to setup Minikube for use with Istio
 weight: 10
-keywords: [kubernetes,minikube]
+keywords: [platform-setup,kubernetes,minikube]
 ---
 
 To setup the Kubernetes cluster for Istio with Minikube, follow these instructions:

--- a/content/docs/setup/kubernetes/platform-setup/minikube/index.md
+++ b/content/docs/setup/kubernetes/platform-setup/minikube/index.md
@@ -1,5 +1,5 @@
 ---
-title: Platform setup for Minikube
+title: Minikube
 description: Instructions to setup Minikube for use with Istio
 weight: 10
 keywords: [platform-setup,kubernetes,minikube]

--- a/content/docs/setup/kubernetes/platform-setup/openshift/index.md
+++ b/content/docs/setup/kubernetes/platform-setup/openshift/index.md
@@ -1,6 +1,6 @@
 ---
 title: OpenShift
-description: Instructions to setup the Openshift cluster for Istio.
+description: Instructions to setup an OpenShift cluster for Istio.
 weight: 15
 keywords: [platform-setup,openshift]
 ---

--- a/content/docs/setup/kubernetes/platform-setup/openshift/index.md
+++ b/content/docs/setup/kubernetes/platform-setup/openshift/index.md
@@ -1,7 +1,7 @@
 ---
 title: OpenShift
 description: Instructions to setup an OpenShift cluster for Istio.
-weight: 15
+weight: 18
 keywords: [platform-setup,openshift]
 ---
 

--- a/content/docs/setup/kubernetes/platform-setup/openshift/index.md
+++ b/content/docs/setup/kubernetes/platform-setup/openshift/index.md
@@ -1,7 +1,7 @@
 ---
 title: OpenShift
 description: Instructions to setup the Openshift cluster for Istio.
-weight: 13
+weight: 15
 keywords: [platform-setup,openshift]
 ---
 

--- a/content/docs/setup/kubernetes/platform-setup/openshift/index.md
+++ b/content/docs/setup/kubernetes/platform-setup/openshift/index.md
@@ -5,7 +5,7 @@ weight: 15
 keywords: [platform-setup,openshift]
 ---
 
-To setup the Openshift cluster for Istio, follow these instructions:
+To setup an OpenShift cluster for Istio, follow these instructions:
 
 By default, OpenShift doesn't allow containers running with user ID 0.
 

--- a/content/docs/setup/kubernetes/platform-setup/openshift/index.md
+++ b/content/docs/setup/kubernetes/platform-setup/openshift/index.md
@@ -2,7 +2,7 @@
 title: Platform setup for Openshift
 description: Instructions to setup the Openshift cluster for Istio.
 weight: 13
-keywords: [openshift]
+keywords: [platform-setup,openshift]
 ---
 
 To setup the Openshift cluster for Istio, follow these instructions:

--- a/content/docs/setup/kubernetes/platform-setup/openshift/index.md
+++ b/content/docs/setup/kubernetes/platform-setup/openshift/index.md
@@ -1,5 +1,5 @@
 ---
-title: Platform setup for Openshift
+title: OpenShift
 description: Instructions to setup the Openshift cluster for Istio.
 weight: 13
 keywords: [platform-setup,openshift]

--- a/content/docs/setup/kubernetes/quick-start-gke-dm/index.md
+++ b/content/docs/setup/kubernetes/quick-start-gke-dm/index.md
@@ -1,7 +1,7 @@
 ---
 title: Quick Start with Google Kubernetes Engine
 description: Quick Start instructions to setup the Istio service using Google Kubernetes Engine (GKE)
-weight: 2
+weight: 20
 keywords: [kubernetes,gke,google]
 ---
 

--- a/content/docs/setup/kubernetes/quick-start/index.md
+++ b/content/docs/setup/kubernetes/quick-start/index.md
@@ -1,7 +1,7 @@
 ---
 title: Quick Start with Kubernetes
 description: Instructions to setup the Istio service mesh in a Kubernetes cluster.
-weight: 1
+weight: 5
 keywords: [kubernetes]
 ---
 

--- a/content/docs/setup/kubernetes/quick-start/index.md
+++ b/content/docs/setup/kubernetes/quick-start/index.md
@@ -15,7 +15,7 @@ To install and configure Istio in a Kubernetes cluster, follow these instruction
   * [Minikube](/docs/setup/kubernetes/platform-setup/minikube/)
   * [Google Container Engine (GKE)](/docs/setup/kubernetes/platform-setup/gke/)
   * [IBM Cloud Kubernetes Service (IKS)](/docs/setup/kubernetes/platform-setup/ibm/)
-  * [OpensSift Origin](/docs/setup/kubernetes/platform-setup/openshift/)
+  * [OpenShift Origin](/docs/setup/kubernetes/platform-setup/openshift/)
   * [Amazon Web Services (AWS) with Kops](/docs/setup/kubernetes/platform-setup/aws/)
   * [Azure](/docs/setup/kubernetes/platform-setup/azure/)
 

--- a/content/docs/setup/kubernetes/quick-start/index.md
+++ b/content/docs/setup/kubernetes/quick-start/index.md
@@ -15,7 +15,7 @@ To install and configure Istio in a Kubernetes cluster, follow these instruction
   * [Minikube](/docs/setup/kubernetes/platform-setup/minikube/)
   * [Google Container Engine (GKE)](/docs/setup/kubernetes/platform-setup/gke/)
   * [IBM Cloud Kubernetes Service (IKS)](/docs/setup/kubernetes/platform-setup/ibm/)
-  * [Openshift Origin](/docs/setup/kubernetes/platform-setup/openshift/)
+  * [OpensSift Origin](/docs/setup/kubernetes/platform-setup/openshift/)
   * [Amazon Web Services (AWS) with Kops](/docs/setup/kubernetes/platform-setup/aws/)
   * [Azure](/docs/setup/kubernetes/platform-setup/azure/)
 

--- a/content/docs/setup/kubernetes/quick-start/index.md
+++ b/content/docs/setup/kubernetes/quick-start/index.md
@@ -5,20 +5,19 @@ weight: 1
 keywords: [kubernetes]
 ---
 
-To install and configure Istio in a Kubernetes
-cluster, follow these instructions:
+To install and configure Istio in a Kubernetes cluster, follow these instructions:
 
 ## Prerequisites
 
 1. [Download the Istio release](/docs/setup/kubernetes/download-release/).
 
-1. Kubernetes platform setup
-  * [Minikube](/docs/setup/kubernetes/minikube/)
-  * [Google Container Engine (GKE)](/docs/setup/kubernetes/gke/)
-  * [IBM Cloud Kubernetes Service (IKS)](/docs/setup/kubernetes/ibm/)
-  * [Openshift Origin](/docs/setup/kubernetes/openshift/)
-  * [Amazon Web Services (AWS) with Kops](/docs/setup/kubernetes/aws/)
-  * [Azure](/docs/setup/kubernetes/azure/)
+1. [Kubernetes platform setup](/docs/setup/kubernetes/platform-setup/):
+  * [Minikube](/docs/setup/kubernetes/platform-setup/minikube/)
+  * [Google Container Engine (GKE)](/docs/setup/kubernetes/platform-setup/gke/)
+  * [IBM Cloud Kubernetes Service (IKS)](/docs/setup/kubernetes/platform-setup/ibm/)
+  * [Openshift Origin](/docs/setup/kubernetes/platform-setup/openshift/)
+  * [Amazon Web Services (AWS) with Kops](/docs/setup/kubernetes/platform-setup/aws/)
+  * [Azure](/docs/setup/kubernetes/platform-setup/azure/)
 
 ## Installation steps
 

--- a/content/docs/setup/kubernetes/sidecar-injection/index.md
+++ b/content/docs/setup/kubernetes/sidecar-injection/index.md
@@ -1,7 +1,7 @@
 ---
 title: Installing the Istio sidecar
 description: Instructions for installing the Istio sidecar in application pods automatically using the sidecar injector webhook or manually using istioctl CLI.
-weight: 3
+weight: 30
 keywords: [kubernetes,sidecar,sidecar-injection]
 aliases:
     - /docs/setup/kubernetes/automatic-sidecar-inject.html

--- a/content/docs/setup/kubernetes/upgrading-istio/index.md
+++ b/content/docs/setup/kubernetes/upgrading-istio/index.md
@@ -1,7 +1,7 @@
 ---
 title: Upgrading Istio
 description: Demonstrates how to upgrade the Istio control plane and data plane independently.
-weight: 7
+weight: 70
 keywords: [kubernetes,upgrading]
 ---
 

--- a/content_zh/docs/setup/kubernetes/helm-install/index.md
+++ b/content_zh/docs/setup/kubernetes/helm-install/index.md
@@ -14,13 +14,7 @@ aliases:
 ## 先决条件
 
 1. [下载 Istio 的发布版本](/docs/setup/kubernetes/download-release/)。
-1. [在 Kubernetes 中安装 Istio]
-  * [Minikube](/docs/setup/kubernetes/minikube/)
-  * [Google Container Engine (GKE)](/docs/setup/kubernetes/gke/)
-  * [IBM Cloud Kubernetes Service (IKS)](/docs/setup/kubernetes/ibm/)
-  * [Openshift Origin](/docs/setup/kubernetes/openshift/)
-  * [Amazon Web Services (AWS) with Kops](/docs/setup/kubernetes/aws/)
-  * [Azure](/docs/setup/kubernetes/azure/)
+1. [在 Kubernetes 中安装 Istio](/docs/setup/kubernetes/platform-setup/)
 
 ## 安装步骤
 


### PR DESCRIPTION
This cleans up the platform section into its own subdirectory.
I am not all that happy about how "see-also" works, but maybe that
is how it is meant to work, or alternatively I'm doing it wrong :)