### PR TITLE
There is no authPolicy in configmap. Modified to correct key.

### DIFF
--- a/content/docs/examples/endpoints/index.md
+++ b/content/docs/examples/endpoints/index.md
@@ -80,10 +80,10 @@ Adding `"--http_port=8081"` in the ESP deployment arguments and expose the HTTP 
     $ kubectl edit cm istio -n istio-system
     {{< /text >}}
 
-    And uncomment the line:
+    And change the value of `controlPlaneAuthPolicy` to `MUTUAL_TLS`:
 
     {{< text yaml >}}
-    authPolicy: MUTUAL_TLS
+    controlPlaneAuthPolicy: MUTUAL_TLS
     {{< /text >}}
 
 1. After this, you will find access to `EXTERNAL_IP` no longer works because istio proxy only accept secure mesh connections.

--- a/content/docs/tasks/security/mutual-tls/index.md
+++ b/content/docs/tasks/security/mutual-tls/index.md
@@ -54,10 +54,10 @@ Citadel is up if the "AVAILABLE" column is 1.
 
 ### Verifying service configuration
 
-* Check installation mode. If mutual TLS is enabled by default (e.g `istio-demo-auth.yaml` was used when installing Istio), you can expect to see uncommented `authPolicy: MUTUAL_TLS` in the configmap.
+* Check installation mode. If mutual TLS is enabled by default (e.g `istio-demo-auth.yaml` was used when installing Istio), you can expect to see `controlPlaneAuthPolicy: MUTUAL_TLS` in the configmap.
 
     {{< text bash >}}
-    $ kubectl get configmap istio -o yaml -n istio-system | grep authPolicy | head -1
+    $ kubectl get configmap istio -o yaml -n istio-system | grep controlPlaneAuthPolicy | head -1
     {{< /text >}}
 
 * Check authentication policies. Mutual TLS can also be enabled (or disabled) per service(s) by authentication policy. A policy, if exist, will overwrite the configmap setting for the targeted services. Unfortunately, there is no quick way to get relevant policies for a service, other than examining all policies in the applicable namespace:
@@ -66,7 +66,7 @@ Citadel is up if the "AVAILABLE" column is 1.
     $ kubectl get policies.authentication.istio.io -n default -o yaml
     {{< /text >}}
 
-* Check destination rule. Starting with Istio 0.8, destination rule's [traffic policy](/docs/reference/config/istio.networking.v1alpha3/#TrafficPolicy) is used to configure client side to use (or not use) mutual TLS. For backward compatibility, the _default_ traffic policy is inferred from configmap flag (i.e, if `authPolicy: MUTUAL_TLS`, _default_ traffic policy also be `MUTUAL_TLS`). If there is authentication policy overrules this setting for some services, it should accompany with the appropriate destination rule(s). Similar to authentication policy, the only way to verify the settings is to manually check all rules:
+* Check destination rule. Starting with Istio 0.8, destination rule's [traffic policy](/docs/reference/config/istio.networking.v1alpha3/#TrafficPolicy) is used to configure client side to use (or not use) mutual TLS. For backward compatibility, the _default_ traffic policy is inferred from configmap flag (i.e, if `controlPlaneAuthPolicy: MUTUAL_TLS`, _default_ traffic policy also be `MUTUAL_TLS`). If there is authentication policy overrules this setting for some services, it should accompany with the appropriate destination rule(s). Similar to authentication policy, the only way to verify the settings is to manually check all rules:
 
     {{< text bash >}}
     $ kubectl get destinationrules.networking.istio.io --all-namespaces -o yaml

--- a/content/help/faq/security/enabling-disabling-mtls.md
+++ b/content/help/faq/security/enabling-disabling-mtls.md
@@ -14,7 +14,7 @@ If you are an advanced user and understand the risks you can also do the followi
 $ kubectl edit configmap -n istio-system istio
 {{< /text >}}
 
-comment out or uncomment `authPolicy: MUTUAL_TLS` to toggle mutual TLS and then
+and set to either `controlPlaneAuthPolicy: MUTUAL_TLS` or `controlPlaneAuthPolicy: NONE` to toggle mutual TLS and then
 
 {{< text bash >}}
 $ kubectl delete pods -n istio-system -l istio=pilot

--- a/content_zh/docs/tasks/security/mutual-tls/index.md
+++ b/content_zh/docs/tasks/security/mutual-tls/index.md
@@ -58,10 +58,10 @@ istio-citadel   1         1         1            1           1m
 
 ### 检查服务配置
 
-* 检查安装模式。如果缺省启用了双向 TLS（也就是在安装 Istio 的时候使用了 `istio-demo-auth.yaml`），会在 Configmap 中看到未被注释的 `authPolicy: MUTUAL_TLS` 一行：
+* 检查安装模式。如果缺省启用了双向 TLS（也就是在安装 Istio 的时候使用了 `istio-demo-auth.yaml`），会在 Configmap 中看到未被注释的 `controlPlaneAuthPolicy: MUTUAL_TLS` 一行：
 
     {{< text bash >}}
-    $ kubectl get configmap istio -o yaml -n istio-system | grep authPolicy | head -1
+    $ kubectl get configmap istio -o yaml -n istio-system | grep controlPlaneAuthPolicy | head -1
     {{< /text >}}
 
 * 检查认证策略。双向 TLS 的策略还能够以服务为单位进行启用（或停用）。如果存在仅对部分服务生效的策略，那么这部分服务原有的来自 Configmap 的策略就会被覆盖。不幸的是，目前没有快速的方法能够方便的获取某个服务的对应策略，只能在命名空间内获取所有策略。
@@ -70,7 +70,7 @@ istio-citadel   1         1         1            1           1m
     $ kubectl get policies.authentication.istio.io -n default -o yaml
     {{< /text >}}
 
-* 检查目标规则。从 Istio 0.8 开始，会使用目标规则的[流量策略](/docs/reference/config/istio.networking.v1alpha3/#TrafficPolicy)来对客户端进行配置，决定是否使用双向 TLS。为了向后兼容，**缺省**流量策略来自 Configmap 中的标志（也就是说，如果设置了 `authPolicy: MUTUAL_TLS`，那么**缺省**流量策略也会是 `MUTUAL_TLS` ）。如果使用针对部分服务的认证策略覆盖了原有配置，那么就要通过目标规则来实现了。跟认证策略类似，验证这一设置的方法也是需要通过获取全部规则的方式来进行：
+* 检查目标规则。从 Istio 0.8 开始，会使用目标规则的[流量策略](/docs/reference/config/istio.networking.v1alpha3/#TrafficPolicy)来对客户端进行配置，决定是否使用双向 TLS。为了向后兼容，**缺省**流量策略来自 Configmap 中的标志（也就是说，如果设置了 `controlPlaneAuthPolicy: MUTUAL_TLS`，那么**缺省**流量策略也会是 `MUTUAL_TLS` ）。如果使用针对部分服务的认证策略覆盖了原有配置，那么就要通过目标规则来实现了。跟认证策略类似，验证这一设置的方法也是需要通过获取全部规则的方式来进行：
 
     {{< text bash >}}
     $ kubectl get destinationrules.networking.istio.io --all-namespaces -o yaml


### PR DESCRIPTION
There is actually no `authPolicy` in Istio configmap and no commenting/uncommenting of a line.
We have (for few months now) a `controlPlaneAuthPolicy` field which can be set to `NONE` or `MUTUAL_TLS`.