### PR TITLE
Fixed manual sidecar command

### DIFF
--- a/content/docs/setup/kubernetes/sidecar-injection/index.md
+++ b/content/docs/setup/kubernetes/sidecar-injection/index.md
@@ -82,7 +82,8 @@ $ istioctl kube-inject \
     --injectConfigFile inject-config.yaml \
     --meshConfigFile mesh-config.yaml \
     --filename @samples/sleep/sleep.yaml@ \
-    --output sleep-injected.yaml | kubectl apply -f -
+    --output sleep-injected.yaml
+$ kubectl apply -f sleep-injected.yaml
 {{< /text >}}
 
 Verify that the sidecar has been injected into the deployment.


### PR DESCRIPTION
This fixes the command so that it reads from the file we created with --ouptut rather than from the CLI. Without this, kubectl gives an error: no objects passed to apply. This fixes https://github.com/istio/istio.github.io/issues/1985.