### PR TITLE
Minikube settings

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -507,3 +507,7 @@ serverless
  - search.md
 searchresults
 gcse
+MB
+CPU
+CPUs
+add-ons

--- a/content/docs/setup/kubernetes/platform-setup/minikube/index.md
+++ b/content/docs/setup/kubernetes/platform-setup/minikube/index.md
@@ -16,7 +16,9 @@ Follow these instructions to prepare Minikube for Istio.
 1. Select a
    [VM driver](https://kubernetes.io/docs/setup/minikube/#quickstart)
    and substitute `your_vm_driver_choice` below with the installed virtual
-   machine (VM) driver.
+   machine (VM) driver. To install Istio control plane components and add-ons,
+   as well as other applications,
+   we recommend starting minikube with 8192 MB of memory and 4 CPUs: 
 
     On Kubernetes **1.9**:
 

--- a/content/docs/setup/kubernetes/platform-setup/minikube/index.md
+++ b/content/docs/setup/kubernetes/platform-setup/minikube/index.md
@@ -21,11 +21,18 @@ Follow these instructions to prepare Minikube for Istio.
     On Kubernetes **1.9**:
 
     {{< text bash >}}
-    $ minikube start --memory=4096 --kubernetes-version=v1.9.4 --vm-driver=`your_vm_driver_choice`
+    $ minikube start --memory=8192 --cpus=4 --kubernetes-version=v1.9.4 \
+        --extra-config=controller-manager.cluster-signing-cert-file="/var/lib/localkube/certs/ca.crt" \
+        --extra-config=controller-manager.cluster-signing-key-file="/var/lib/localkube/certs/ca.key" \
+        --extra-config=apiserver.admission-control="NamespaceLifecycle,LimitRanger,ServiceAccount,PersistentVolumeLabel,DefaultStorageClass,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota" \
+        --vm-driver=`your_vm_driver_choice`
     {{< /text >}}
 
     On Kubernetes **1.10**:
 
     {{< text bash >}}
-    $ minikube start --memory=4096 --kubernetes-version=v1.10.0 --vm-driver=`your_vm_driver_choice`
+    $ minikube start --memory=8192 --cpus=4 --kubernetes-version=v1.10.0 \
+        --extra-config=controller-manager.cluster-signing-cert-file="/var/lib/localkube/certs/ca.crt" \
+        --extra-config=controller-manager.cluster-signing-key-file="/var/lib/localkube/certs/ca.key" \
+        --vm-driver=`your_vm_driver_choice`
     {{< /text >}}

--- a/content/docs/setup/kubernetes/platform-setup/minikube/index.md
+++ b/content/docs/setup/kubernetes/platform-setup/minikube/index.md
@@ -18,7 +18,7 @@ Follow these instructions to prepare Minikube for Istio.
    and substitute `your_vm_driver_choice` below with the installed virtual
    machine (VM) driver. To install Istio control plane components and add-ons,
    as well as other applications,
-   we recommend starting minikube with 8192 MB of memory and 4 CPUs: 
+   we recommend starting Minikube with 8192 MB of memory and 4 CPUs:
 
     On Kubernetes **1.9**:
 

--- a/content/docs/setup/kubernetes/platform-setup/minikube/index.md
+++ b/content/docs/setup/kubernetes/platform-setup/minikube/index.md
@@ -16,9 +16,9 @@ Follow these instructions to prepare Minikube for Istio.
 1. Select a
    [VM driver](https://kubernetes.io/docs/setup/minikube/#quickstart)
    and substitute `your_vm_driver_choice` below with the installed virtual
-   machine (VM) driver. To install Istio control plane components and add-ons,
+   machine (VM) driver. To install Istio control plane components and addons,
    as well as other applications,
-   we recommend starting Minikube with 8192 MB of memory and 4 CPUs:
+   we recommend starting Minikube with 8192 `MB` of memory and 4 `CPUs`:
 
     On Kubernetes **1.9**:
 

--- a/content/docs/setup/kubernetes/quick-start/index.md
+++ b/content/docs/setup/kubernetes/quick-start/index.md
@@ -27,7 +27,7 @@ To install and configure Istio in a Kubernetes cluster, follow these instruction
 via `kubectl apply`, and wait a few seconds for the CRDs to be committed in the kube-apiserver:
 
     {{< text bash >}}
-    $ kubectl apply -f install/kubernetes/helm/istio/templates/crds.yaml -n istio-system
+    $ kubectl apply -f install/kubernetes/helm/istio/templates/crds.yaml 
     {{< /text >}}
 
 1. To install Istio's core components you can choose any of the following four

--- a/content/docs/setup/kubernetes/quick-start/index.md
+++ b/content/docs/setup/kubernetes/quick-start/index.md
@@ -27,7 +27,7 @@ To install and configure Istio in a Kubernetes cluster, follow these instruction
 via `kubectl apply`, and wait a few seconds for the CRDs to be committed in the kube-apiserver:
 
     {{< text bash >}}
-    $ kubectl apply -f install/kubernetes/helm/istio/templates/crds.yaml 
+    $ kubectl apply -f install/kubernetes/helm/istio/templates/crds.yaml
     {{< /text >}}
 
 1. To install Istio's core components you can choose any of the following four

--- a/content/docs/tasks/policy-enforcement/rate-limiting/index.md
+++ b/content/docs/tasks/policy-enforcement/rate-limiting/index.md
@@ -58,7 +58,7 @@ so the configuration to enable rate limiting on both adapters is the same.
     Run the following command to enable rate limits.
 
     {{< text bash >}}
-    $ kubectl apply -f @samples/bookinfo/policy/mixer-rule-productpage-ratelimit.yaml@
+    $ kubectl apply -f examples/bookinfo/policy/mixer-rule-productpage-ratelimit.yaml@
     {{< /text >}}
 
 1. Confirm the `memquota` handler was created:

--- a/content/docs/tasks/policy-enforcement/rate-limiting/index.md
+++ b/content/docs/tasks/policy-enforcement/rate-limiting/index.md
@@ -58,7 +58,7 @@ so the configuration to enable rate limiting on both adapters is the same.
     Run the following command to enable rate limits.
 
     {{< text bash >}}
-    $ kubectl apply -f examples/bookinfo/policy/mixer-rule-productpage-ratelimit.yaml@
+    $ kubectl apply -f @samples/bookinfo/policy/mixer-rule-productpage-ratelimit.yaml@
     {{< /text >}}
 
 1. Confirm the `memquota` handler was created:


### PR DESCRIPTION
We should advise the same minikube settings as tested by circleci.

Increased the memory and specified the number of CPUs.

Added the admission controllers plugins for k8s 1.9.0, they are enabled by default only starting with 1.10.0. Fixes #2017 .