### PR TITLE
Full text RSS feeds

### DIFF
--- a/layouts/feed/single.rss.xml
+++ b/layouts/feed/single.rss.xml
@@ -20,7 +20,7 @@
       {{ if and (not $post.Draft) $post.IsPage }}
         <item>
           <title>{{ $post.Title }}</title>
-          <description>{{ $post.Description }}</description>
+          <description>{{ $post.Content | html }}</description>
           <pubDate>{{ $post.PublishDate.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
           <link>{{ $post.Permalink }}</link>
           <author>{{ $post.Params.attribution }}</author>


### PR DESCRIPTION
Currently, only the short description of each post is included in the RSS feed.  This change will update the feed to include the whole text of each blog post.