### PR TITLE
Chinese content was aliasing English content.

### DIFF
--- a/content_zh/about/community/index.md
+++ b/content_zh/about/community/index.md
@@ -4,8 +4,6 @@ description: 有关参与 Istio 社区和与之互动的各种方式的信息。
 weight: 90
 keywords: [community]
 type: community
-aliases:
-    - /community
 page_icon: /img/community.svg
 ---
 Istio 是一个开源项目，拥有一个支持其使用和持续开发的活跃社区。我们很乐意您加入我们并参与其中！

--- a/content_zh/about/contribute/_index.md
+++ b/content_zh/about/contribute/_index.md
@@ -3,7 +3,5 @@ title: 贡献文档
 description: 了解如何为提高和改善 Istio 的文档做贡献。
 weight: 100
 type: section-index
-aliases:
-    - /docs/welcome/contribute/index.html
 page_icon: /img/contribute.svg
 ---

--- a/content_zh/about/contribute/github/index.md
+++ b/content_zh/about/contribute/github/index.md
@@ -2,13 +2,6 @@
 title: 使用 GitHub
 description: 向您展示如何使用 GitHub 处理 Istio 文档。
 weight: 20
-aliases:
-    - /docs/welcome/contribute/creating-a-pull-request.html
-    - /docs/welcome/contribute/staging-your-changes.html
-    - /docs/welcome/contribute/editing.html
-    - /about/contribute/creating-a-pull-request
-    - /about/contribute/editing
-    - /about/contribute/staging-your-changes
 keywords: [contribute]
 ---
 

--- a/content_zh/about/contribute/style-guide/index.md
+++ b/content_zh/about/contribute/style-guide/index.md
@@ -2,9 +2,6 @@
 title: 样式指南
 description: 编写 Istio 文档时候的“要”和“不要”。
 weight: 70
-aliases:
-    - /docs/welcome/contribute/style-guide.html
-    - /docs/reference/contribute/style-guide.html
 keywords: [contribute]
 ---
 

--- a/content_zh/about/feature-stages/index.md
+++ b/content_zh/about/feature-stages/index.md
@@ -2,11 +2,6 @@
 title: 功能状态
 description: 功能列表和发布阶段。
 weight: 10
-aliases:
-    - /docs/reference/release-roadmap.html
-    - /docs/reference/feature-stages.html
-    - /docs/welcome/feature-stages.html
-    - /docs/home/roadmap.html
 page_icon: /img/feature-status.svg
 ---
 

--- a/content_zh/about/notes/0.1/index.md
+++ b/content_zh/about/notes/0.1/index.md
@@ -1,8 +1,6 @@
 ---
 title: Istio 0.1
 weight: 100
-aliases:
-    - /docs/welcome/notes/0.1.html
 page_icon: /img/notes.svg
 ---
 

--- a/content_zh/about/notes/0.2/index.md
+++ b/content_zh/about/notes/0.2/index.md
@@ -1,8 +1,6 @@
 ---
 title: Istio 0.2
 weight: 99
-aliases:
-    - /docs/welcome/notes/0.2.html
 page_icon: /img/notes.svg
 ---
 

--- a/content_zh/about/notes/0.3/index.md
+++ b/content_zh/about/notes/0.3/index.md
@@ -1,8 +1,6 @@
 ---
 title: Istio 0.3
 weight: 98
-aliases:
-    - /docs/welcome/notes/0.3.html
 page_icon: /img/notes.svg
 ---
 

--- a/content_zh/about/notes/0.4/index.md
+++ b/content_zh/about/notes/0.4/index.md
@@ -1,8 +1,6 @@
 ---
 title: Istio 0.4
 weight: 97
-aliases:
-    - /docs/welcome/notes/0.4.html
 page_icon: /img/notes.svg
 ---
 

--- a/content_zh/about/notes/_index.md
+++ b/content_zh/about/notes/_index.md
@@ -2,11 +2,6 @@
 title: 发行说明
 description: 每个 Istio 版本的功能和改进说明。
 weight: 5
-aliases:
-  - /docs/reference/release-notes.html
-  - /release-notes
-  - /docs/welcome/notes/index.html
-  - /docs/references/notes
 ---
 
 - [Istio 1.0](./1.0)

--- a/content_zh/blog/2017/0.1-canary/index.md
+++ b/content_zh/blog/2017/0.1-canary/index.md
@@ -5,8 +5,6 @@ publishdate: 2017-06-14
 attribution: Frank Budinsky
 weight: 98
 keywords: [traffic-management,canary]
-aliases:
-    - /blog/canary-deployments-using-istio.html
 ---
 
 > 本篇博客最后更新时间 2018 年 5 月 16 号，采用了最新版本的流量管理模型。

--- a/content_zh/blog/2017/adapter-model/index.md
+++ b/content_zh/blog/2017/adapter-model/index.md
@@ -6,8 +6,6 @@ subtitle: 将 Istio 与后端基础设施整合
 attribution: Martin Taillefer
 weight: 95
 keywords: [adapters,mixer,policies,telemetry]
-aliases:
-    - /blog/mixer-adapter-model.html
 ---
 
 Istio 0.2 引入了一种新的 Mixer 适配器模型，这种模型使接入后端基础设施具有更多的灵活性 。本文将解释这种模型是如何工作的。

--- a/content_zh/blog/2018/egress-tcp/index.md
+++ b/content_zh/blog/2018/egress-tcp/index.md
@@ -5,8 +5,6 @@ publishdate: 2018-02-06
 subtitle: Egress rules for TCP traffic
 attribution: Vadim Eisenberg
 weight: 92
-aliases:
-  - /docs/tasks/traffic-management/egress-tcp/
 keywords: [traffic-management,egress,tcp]
 ---
 

--- a/content_zh/blog/_index.md
+++ b/content_zh/blog/_index.md
@@ -5,7 +5,5 @@ linktitle: 博客
 type: section-index
 sidebar_multicard: true
 page_icon: /img/blog.svg
-aliases:
-    - /blog/posts/index.html
 ---
 

--- a/content_zh/docs/concepts/performance-and-scalability/index.md
+++ b/content_zh/docs/concepts/performance-and-scalability/index.md
@@ -2,14 +2,6 @@
 title: 性能与可伸缩性
 description: 介绍 Istio 组件的性能与可伸缩性方法论、结果和最佳实践。
 weight: 50
-aliases:
-    - /docs/performance-and-scalability/overview
-    - /docs/performance-and-scalability/microbenchmarks
-    - /docs/performance-and-scalability/performance-testing-automation
-    - /docs/performance-and-scalability/realistic-app-benchmark
-    - /docs/performance-and-scalability/scalability
-    - /docs/performance-and-scalability/scenarios
-    - /docs/performance-and-scalability/synthetic-benchmarks
 keywords: [performance,scalability,scale,benchmarks]
 ---
 

--- a/content_zh/docs/concepts/policies-and-telemetry/index.md
+++ b/content_zh/docs/concepts/policies-and-telemetry/index.md
@@ -3,10 +3,6 @@ title: 策略与遥测
 description: 描述策略实施和遥测机制。
 weight: 40
 keywords: [policies,telemetry,control,config]
-aliases:
-    - /docs/concepts/policy-and-control/mixer.html
-    - /docs/concepts/policy-and-control/mixer-config.html
-    - /docs/concepts/policy-and-control/attributes.html
 ---
 
 Istio 提供灵活的模型来执行授权策略，并为网格中的服务收集遥测数据。

--- a/content_zh/docs/concepts/traffic-management/index.md
+++ b/content_zh/docs/concepts/traffic-management/index.md
@@ -3,14 +3,6 @@ title: 流量管理
 description: 介绍 Istio 中关于流量路由与控制的各项功能。
 weight: 20
 keywords: [traffic-management]
-aliases:
-    - /docs/concepts/traffic-management/overview
-    - /docs/concepts/traffic-management/pilot
-    - /docs/concepts/traffic-management/rules-configuration
-    - /docs/concepts/traffic-management/fault-injection
-    - /docs/concepts/traffic-management/handling-failures
-    - /docs/concepts/traffic-management/load-balancing
-    - /docs/concepts/traffic-management/request-routing
 ---
 
 本页概述了 Istio 中流量管理的工作原理，包括流量管理原则的优点。本文假设你已经阅读了 [Istio 是什么？](/zh/docs/concepts/what-is-istio/)并熟悉 Istio 的高级架构。有关单个流量管理功能的更多信息，您可以在本节其他指南中了解。

--- a/content_zh/docs/concepts/what-is-istio/index.md
+++ b/content_zh/docs/concepts/what-is-istio/index.md
@@ -2,10 +2,6 @@
 title: Istio 是什么?
 description: 介绍 Istio 及其要解决的问题、顶层架构和设计目标。
 weight: 15
-aliases:
-    - /docs/concepts/what-is-istio/overview
-    - /docs/concepts/what-is-istio/goals
-    - /about/intro
 ---
 
 使用云平台可以为组织提供丰富的好处。然而，不可否认的是，采用云可能会给 DevOps 团队带来压力。开发人员必须使用微服务已满足应用的可移植性，同时运营商管理了极其庞大的混合和多云部署。Istio 允许您连接、保护、控制和观测服务。

--- a/content_zh/docs/examples/_index.md
+++ b/content_zh/docs/examples/_index.md
@@ -3,8 +3,5 @@ title: 示例
 description: 这里包括多个可供 Istio 使用的可完整工作的示例，你可以用来亲自部署和体验这些示例。
 weight: 30
 type: section-index
-aliases:
-    - /docs/samples/index.html
-    - /docs/guides/index.html
 page_icon: /img/examples.svg
 ---

--- a/content_zh/docs/examples/bookinfo/index.md
+++ b/content_zh/docs/examples/bookinfo/index.md
@@ -2,9 +2,6 @@
 title: Bookinfo 应用
 description: 部署一个用于演示多种 Istio 特性的应用，由四个单独的微服务构成。
 weight: 10
-aliases:
-    - /docs/samples/bookinfo.html
-    - /docs/guides/bookinfo/index.html
 ---
 
 部署一个样例应用，它由四个单独的微服务构成，用来演示多种 Istio 特性。这个应用模仿在线书店的一个分类，显示一本书的信息。页面上会显示一本书的描述，书籍的细节（ISBN、页数等），以及关于这本书的一些评论。

--- a/content_zh/docs/examples/endpoints/index.md
+++ b/content_zh/docs/examples/endpoints/index.md
@@ -2,8 +2,6 @@
 title: 在谷歌云 Endpoints 服务中安装 Istio
 description: 说明如何在谷歌云 Endpoints 服务中手动整合 Istio。
 weight: 42
-aliases:
-    - /docs/guides/endpoints/index.html
 ---
 
 这篇文档展示了如何手动整合 Istio 和现有的谷歌云 Endpoints 服务。

--- a/content_zh/docs/examples/integrating-vms/index.md
+++ b/content_zh/docs/examples/integrating-vms/index.md
@@ -1,10 +1,8 @@
 ---
 title: 虚拟机集成
-description: 在单一服务网格中，如何使用 Istio 对 Kubernetes 集群以及虚拟机进行控制。 
+description: 在单一服务网格中，如何使用 Istio 对 Kubernetes 集群以及虚拟机进行控制。
 weight: 60
 keywords: [vms]
-aliases:
-    - /docs/guides/integrating-vms/index.html
 ---
 
 这个例子把 Bookinfo 服务部署到 Kubernetes 集群和一组虚拟机上，然后演示从单一服务网格的角度，如何使用 Istio 来对其进行控制。

--- a/content_zh/docs/examples/intelligent-routing/index.md
+++ b/content_zh/docs/examples/intelligent-routing/index.md
@@ -3,8 +3,6 @@ title: 智能路由
 description: 如何在 Istio 服务网格中使用多种流量管理功能。
 weight: 20
 keywords: [traffic-management,routing]
-aliases:
-    - /docs/guides/intelligent-routing/index.html
 ---
 
 本文示例演示了如何在 Istio 服务网格中使用多种流量管理功能。

--- a/content_zh/docs/examples/telemetry/index.md
+++ b/content_zh/docs/examples/telemetry/index.md
@@ -3,8 +3,6 @@ title: 深入遥测
 description: 演示如何使用 Istio Mixer 和 Istio sidecar 获取指标和日志，并在不同的服务间进行跟踪。
 weight: 30
 keywords: [telemetry,metrics,logging,tracing]
-aliases:
-    - /docs/guides/telemetry/index.html
 ---
 
 演示如何使用 Istio Mixer 和 Istio sidecar 获取指标和日志，并在不同的服务间进行跟踪。

--- a/content_zh/docs/reference/config/policy-and-telemetry/_index.md
+++ b/content_zh/docs/reference/config/policy-and-telemetry/_index.md
@@ -3,6 +3,4 @@ title: 策略和遥测
 description: 描述如何配置 Istio 的策略和遥测功能。
 weight: 30
 type: section-index
-aliases:
-    - /docs/reference/config/mixer/index.html
 ---

--- a/content_zh/docs/reference/config/policy-and-telemetry/adapters/_index.md
+++ b/content_zh/docs/reference/config/policy-and-telemetry/adapters/_index.md
@@ -3,8 +3,6 @@ title: 适配器
 description: Mixer 适配器能够让 Istio 连接各种基础设施后端以完成类似指标和日志这样的功能。
 weight: 40
 type: section-index
-aliases:
-    - /docs/reference/config/mixer/adapters/index.html
 ---
 
 要实现一个新的 Mixer 适配器，请参考[适配器开发者指南](https://github.com/istio/istio/wiki/Mixer-Adapter-Dev-Guide)。

--- a/content_zh/docs/reference/config/policy-and-telemetry/attribute-vocabulary/index.md
+++ b/content_zh/docs/reference/config/policy-and-telemetry/attribute-vocabulary/index.md
@@ -2,8 +2,6 @@
 title: 属性词汇
 description: 介绍策略和控制中会用到的一些基础属性词汇。
 weight: 10
-aliases:
-    - /docs/reference/config/mixer/attribute-vocabulary.html
 ---
 
 属性是整个 Istio 使用的核心概念。可以在[这里](/zh/docs/concepts/policies-and-telemetry/#属性)找到属性是什么和用于何处的描述。

--- a/content_zh/docs/reference/config/policy-and-telemetry/templates/_index.md
+++ b/content_zh/docs/reference/config/policy-and-telemetry/templates/_index.md
@@ -3,6 +3,4 @@ title: 模板
 description: Mixer 模板用于将数据发送到各个适配器。
 weight: 50
 type: section-index
-aliases:
-    - /docs/reference/config/template/index.html
 ---

--- a/content_zh/docs/setup/kubernetes/helm-install/index.md
+++ b/content_zh/docs/setup/kubernetes/helm-install/index.md
@@ -3,9 +3,6 @@ title: 使用 Helm 进行安装
 description: 使用内含的 Helm chart 安装 Istio。
 weight: 30
 keywords: [kubernetes,helm]
-aliases:
-    - /docs/setup/kubernetes/helm.html
-    - /docs/tasks/integrating-services-into-istio.html
 page_icon: /img/helm.svg
 ---
 

--- a/content_zh/docs/setup/kubernetes/sidecar-injection/index.md
+++ b/content_zh/docs/setup/kubernetes/sidecar-injection/index.md
@@ -3,8 +3,6 @@ title: 注入 Istio sidecar
 description: 介绍两种将 Istio sidecar 注入应用 Pod 的方法：使用 Sidecar 注入 Webhook 自动完成，或使用 istioctl 客户端工具手工完成。
 weight: 50
 keywords: [kubernetes,sidecar,sidecar-injection]
-aliases:
-    - /docs/setup/kubernetes/automatic-sidecar-inject.html
 ---
 
 ## 对 Pod 的要求

--- a/content_zh/docs/tasks/policy-enforcement/denial-and-list/index.md
+++ b/content_zh/docs/tasks/policy-enforcement/denial-and-list/index.md
@@ -3,10 +3,6 @@ title: Denier 适配器以及黑白名单
 description: 展示使用简单的 Denier 适配器或黑白名单对服务进行访问控制的方法
 weight: 20
 keywords: [policies, denial, whitelist, blacklist]
-aliases:
-    - /docs/tasks/basic-access-control.html
-    - /docs/tasks/security/basic-access-control/index.html
-    - /docs/tasks/security/secure-access-control/index.html
 ---
 
 本文任务展示了使用简单的 Denier 适配器或黑白名单对服务进行访问控制的方法

--- a/content_zh/docs/tasks/policy-enforcement/rate-limiting/index.md
+++ b/content_zh/docs/tasks/policy-enforcement/rate-limiting/index.md
@@ -3,8 +3,6 @@ title: 启用速率限制
 description: 这一任务展示了如何使用 Istio 动态的对服务通信进行速率限制。
 weight: 10
 keywords: [policies,quotas]
-aliases:
-    - /docs/tasks/rate-limiting.html
 ---
 
 这一任务展示了如何使用 Istio 动态的对服务通信进行速率限制。

--- a/content_zh/docs/tasks/security/authn-policy/index.md
+++ b/content_zh/docs/tasks/security/authn-policy/index.md
@@ -3,8 +3,6 @@ title: 基础认证策略
 description: 介绍如何使用 Istio 认证策略设置双向 TLS 和基本的终端用户认证。
 weight: 10
 keywords: [security,authentication]
-aliases:
-    - /docs/tasks/security/istio-auth.html
 ---
 
 通过这项任务，你将学习:

--- a/content_zh/docs/tasks/telemetry/distributed-tracing/index.md
+++ b/content_zh/docs/tasks/telemetry/distributed-tracing/index.md
@@ -3,8 +3,6 @@ title: 分布式跟踪
 description: 如何进行代理配置将跟踪请求发送给 Zipkin 或 Jaeger
 weight: 10
 keywords: [telemetry,tracing]
-aliases:
-    - /docs/tasks/zipkin-tracing.html
 ---
 
 本文任务演示如何让 Istio 网格中的应用能够进行跟踪 Span 的收集。完成这一任务之后，读者会理解所有关于应用的先决条件，以便将应用加入跟踪过程。这一过程对实现应用的语言、架构以及平台等并无关联。

--- a/content_zh/docs/tasks/telemetry/metrics-logs/index.md
+++ b/content_zh/docs/tasks/telemetry/metrics-logs/index.md
@@ -3,8 +3,6 @@ title: 收集指标和日志
 description: 这一任务讲述如何配置 Istio，进行指标和日志的收集工作。
 weight: 20
 keywords: [telemetry,metrics]
-aliases:
-    - /docs/tasks/metrics-logs.html
 ---
 
 本任务展示了配置 Istio，对网格内服务的遥测数据进行自动收集的方法。在任务的后一部分，会创建一个新的指标以及新的日志流，并在网格内的服务被调用时触发收集过程。

--- a/content_zh/docs/tasks/traffic-management/fault-injection/index.md
+++ b/content_zh/docs/tasks/traffic-management/fault-injection/index.md
@@ -3,8 +3,6 @@ title: 故障注入
 description: 此任务说明如何注入延迟并测试应用程序的弹性。
 weight: 20
 keywords: [traffic-management,fault-injection]
-aliases:
-    - /docs/tasks/fault-injection.html
 ---
 
 > 注意：此任务使用新的 [v1alpha3 流量管理 API](/zh/blog/2018/v1alpha3-routing/)。旧的 API 已被弃用，将在下一个 Istio 版本中删除。如果您需要使用旧版本，请按照[此处](https://archive.istio.io/v0.7/docs/tasks/traffic-management/)的文档操作。

--- a/content_zh/docs/tasks/traffic-management/ingress/index.md
+++ b/content_zh/docs/tasks/traffic-management/ingress/index.md
@@ -3,8 +3,6 @@ title: 控制 Ingress 流量
 description: 介绍在服务网格 Istio 中如何配置外部公开服务
 weight: 30
 keywords: [traffic-management,ingress]
-aliases:
-    - /docs/tasks/ingress.html
 ---
 
 > 注意：此任务使用新的 [v1alpha3 流量管理 API](/zh/blog/2018/v1alpha3-routing/)。旧的 API 已被弃用，将在下一个 Istio 版本中删除。如果您需要使用旧版本，请按照[此处](https://archive.istio.io/v0.7/docs/tasks/traffic-management/)的文档操作。

--- a/content_zh/docs/tasks/traffic-management/request-routing/index.md
+++ b/content_zh/docs/tasks/traffic-management/request-routing/index.md
@@ -2,8 +2,6 @@
 title: 配置请求路由
 description: 此任务向您展示如何根据权重和 HTTP header配置动态请求路由。
 weight: 10
-aliases:
-    - /docs/tasks/request-routing.html
 keywords: [traffic-management,routing]
 ---
 

--- a/content_zh/docs/tasks/traffic-management/request-timeouts/index.md
+++ b/content_zh/docs/tasks/traffic-management/request-timeouts/index.md
@@ -2,8 +2,6 @@
 title: 设置请求超时
 description: 本任务用于示范如何使用 Istio 在 Envoy 中设置请求超时。
 weight: 28
-aliases:
-    - /docs/tasks/request-timeouts.html
 keywords: [traffic-management,timeouts]
 ---
 

--- a/content_zh/docs/tasks/traffic-management/traffic-shifting/index.md
+++ b/content_zh/docs/tasks/traffic-management/traffic-shifting/index.md
@@ -3,8 +3,6 @@ title: 流量转移
 description: 向您展示如何将流量从旧版本迁移到新版本的服务。
 weight: 25
 keywords: [traffic-management,traffic-shifting]
-aliases:
-    - /docs/tasks/traffic-management/version-migration.html
 ---
 
 > 该任务使用新的 [v1alpha3 流量管理 API](/zh/blog/2018/v1alpha3-routing/)。旧版本的API已被弃用，并将在下一个Istio版本中删除。 如果您需要使用旧版本，请点击[此处](https://archive.istio.io/v0.7/docs/tasks/traffic-management/)的文档。


### PR DESCRIPTION
Page aliases are intended to redirect users from a page old's location to a new location.
As it was, the Chinese content pages were redirect old English locations to Chinese, which
made Chinese show up on English systems that were using the old links.