### PR TITLE
Fix broken Mixer Adapter Dev Guide links

### DIFF
--- a/content/about/notes/0.2/index.md
+++ b/content/about/notes/0.2/index.md
@@ -63,7 +63,7 @@ rich proxy-side caching and batching for increased performance.
 
 - **New Mixer Adapter Model**. A new adapter composition model makes it easier to extend Mixer by adding whole new classes of adapters via templates. This
 new model will serve as the foundational building block for many features in the future. See the
-[Adapter Developer's Guide](https://github.com/istio/istio/wiki/Mixer-Adapter-Dev-Guide) to learn how
+[Adapter Developer's Guide](https://github.com/istio/istio/wiki/Mixer-Compiled-In-Adapter-Dev-Guide) to learn how
 to write adapters.
 
 - **Improved Mixer Build Model**. It’s now easier to build a Mixer binary that includes custom adapters.

--- a/content/blog/2017/0.2-announcement/index.md
+++ b/content/blog/2017/0.2-announcement/index.md
@@ -27,7 +27,7 @@ Kubernetes deployment, and get Istio features like telemetry, policy and securit
 
 * _Extending Istio_: An improved Mixer design that lets vendors write Mixer adapters to implement support for their own systems, such as application
 management or policy enforcement. The
-[Mixer Adapter Developer's Guide](https://github.com/istio/istio/wiki/Mixer-Adapter-Dev-Guide) can help
+[Mixer Adapter Developer's Guide](https://github.com/istio/istio/wiki/Mixer-Compiled-In-Adapter-Dev-Guide) can help
 you easily integrate your solution with Istio.
 
 * _Bring your own CA certificates_: Allows users to provide their own key and certificate for Istio CA and persistent CA key/certificate Storage. Enables storing signing key/certificates in persistent storage to facilitate CA restarts.

--- a/content/blog/2017/adapter-model/index.md
+++ b/content/blog/2017/adapter-model/index.md
@@ -21,7 +21,7 @@ Mixer serves as an abstraction layer between Istio and an open-ended set of infr
 In addition to insulating application-level code from the details of infrastructure backends, Mixer provides an intermediation model that allows operators to inject and control policies between application code and backends. Operators can control which data is reported to which backend, which backend to consult for authorization, and much more.
 
 Given that individual infrastructure backends each have different interfaces and operational models, Mixer needs custom
-code to deal with each and we call these custom bundles of code [*adapters*](https://github.com/istio/istio/wiki/Mixer-Adapter-Dev-Guide).
+code to deal with each and we call these custom bundles of code [*adapters*](https://github.com/istio/istio/wiki/Mixer-Compiled-In-Adapter-Dev-Guide).
 
 Adapters are Go packages that are directly linked into the Mixer binary. It’s fairly simple to create custom Mixer binaries linked with specialized sets of adapters, in case the default set of adapters is not sufficient for specific use cases.
 

--- a/content/docs/reference/config/policy-and-telemetry/adapters/_index.md
+++ b/content/docs/reference/config/policy-and-telemetry/adapters/_index.md
@@ -8,4 +8,4 @@ aliases:
 ---
 
 To implement a new adapter for Mixer, please refer to the
-[Adapter Developer's Guide](https://github.com/istio/istio/wiki/Mixer-Adapter-Dev-Guide).
+[Adapter Developer's Guide](https://github.com/istio/istio/wiki/Mixer-Compiled-In-Adapter-Dev-Guide).

--- a/content_zh/about/notes/0.2/index.md
+++ b/content_zh/about/notes/0.2/index.md
@@ -46,7 +46,7 @@ page_icon: /img/notes.svg
 
 - **新的Mixer API**。Envoy 用于与 Mixer 交互的 API 已经过全面重新设计，以提高稳健性，灵活性，并支持丰富的代理端缓存和批处理以提高性能。
 
-- **新的 Mixer 适配器模型**。新的适配器组合模型通过模板添加全新的适配器类，可以更轻松地扩展Mixer,这个新模型将成为未来许多功能的基础构建模块,请参阅[适配器开发人员指南](https://github.com/istio/istio/wiki/Mixer-Adapter-Dev-Guide)了解具体写适配器的方法。
+- **新的 Mixer 适配器模型**。新的适配器组合模型通过模板添加全新的适配器类，可以更轻松地扩展Mixer,这个新模型将成为未来许多功能的基础构建模块,请参阅[适配器开发人员指南](https://github.com/istio/istio/wiki/Mixer-Compiled-In-Adapter-Dev-Guide)了解具体写适配器的方法。
 
 - **改进的 Mixer 构建模型**。现在，构建包含自定义适配器的 Mixer 二进制文件变得更加容易。
 

--- a/content_zh/blog/2017/adapter-model/index.md
+++ b/content_zh/blog/2017/adapter-model/index.md
@@ -18,7 +18,7 @@ Mixer 服务作为 Istio 和一套开放式基础设施之间的抽象层。Isti
 
 除了作为应用层与基础设施隔离外，Mixer 提供了一种中介模型，这种模型允许注入和控制应用和后端的策略。操作人员可以控制哪些数据汇报给哪个后端，哪个后端提供授权等等。
 
-考虑到每个基础服务都有不同的接口和操作模型，Mixer 需要用户通过代码来解决这些差异，我们可以称这些用户自己封装的代码为[*适配器*](https://github.com/istio/istio/wiki/Mixer-Adapter-Dev-Guide)。
+考虑到每个基础服务都有不同的接口和操作模型，Mixer 需要用户通过代码来解决这些差异，我们可以称这些用户自己封装的代码为[*适配器*](https://github.com/istio/istio/wiki/Mixer-Compiled-In-Adapter-Dev-Guide)。
 
 适配器以 Go 包的形式直接链接到 Mixer 二进制中。如果默认的适配器不能满足特定的使用需求，自定义适配器也是很简单的。
 

--- a/content_zh/docs/reference/config/policy-and-telemetry/adapters/_index.md
+++ b/content_zh/docs/reference/config/policy-and-telemetry/adapters/_index.md
@@ -5,4 +5,4 @@ weight: 40
 type: section-index
 ---
 
-要实现一个新的 Mixer 适配器，请参考[适配器开发者指南](https://github.com/istio/istio/wiki/Mixer-Adapter-Dev-Guide)。
+要实现一个新的 Mixer 适配器，请参考[适配器开发者指南](https://github.com/istio/istio/wiki/Mixer-Compiled-In-Adapter-Dev-Guide)。


### PR DESCRIPTION
This PR fixes broken links to the Istio Mixer Adapter Dev Guide.

Signed-off-by: Venil Noronha <veniln@vmware.com>