### PR TITLE
Added host header to curl command

### DIFF
--- a/content/docs/tasks/traffic-management/secure-ingress/index.md
+++ b/content/docs/tasks/traffic-management/secure-ingress/index.md
@@ -136,7 +136,7 @@ with a certificate and a private key. Then you create a `Gateway` definition tha
     [418 I'm a Teapot](https://tools.ietf.org/html/rfc7168#section-2.3.3) code.
 
     {{< text bash >}}
-    $ curl -v --resolve httpbin.example.com:$SECURE_INGRESS_PORT:$INGRESS_HOST --cacert 2_intermediate/certs/ca-chain.cert.pem https://httpbin.example.com:$SECURE_INGRESS_PORT/status/418
+    $ curl -v -HHost:httpbin.example.com --resolve httpbin.example.com:$SECURE_INGRESS_PORT:$INGRESS_HOST --cacert 2_intermediate/certs/ca-chain.cert.pem https://httpbin.example.com:$SECURE_INGRESS_PORT/status/418
     ...
     Server certificate:
       subject: C=US; ST=Denial; L=Springfield; O=Dis; CN=httpbin.example.com
@@ -220,7 +220,7 @@ the server will use to verify its clients. Create the secret `istio-ingressgatew
 1.  Access the `httpbin` service by HTTPS as in the previous section:
 
     {{< text bash >}}
-    $ curl --resolve httpbin.example.com:$SECURE_INGRESS_PORT:$INGRESS_HOST  --cacert 2_intermediate/certs/ca-chain.cert.pem https://httpbin.example.com:$SECURE_INGRESS_PORT/status/418
+    $ curl -HHost:httpbin.example.com --resolve httpbin.example.com:$SECURE_INGRESS_PORT:$INGRESS_HOST  --cacert 2_intermediate/certs/ca-chain.cert.pem https://httpbin.example.com:$SECURE_INGRESS_PORT/status/418
     curl: (35) error:14094410:SSL routines:SSL3_READ_BYTES:sslv3 alert handshake failure
     {{< /text >}}
 
@@ -234,7 +234,7 @@ the server will use to verify its clients. Create the secret `istio-ingressgatew
  and your private key (the `--key` option):
 
     {{< text bash >}}
-    $ curl --resolve httpbin.example.com:$SECURE_INGRESS_PORT:$INGRESS_HOST  --cacert 2_intermediate/certs/ca-chain.cert.pem --cert 4_client/certs/httpbin.example.com.cert.pem --key 4_client/private/httpbin.example.com.key.pem https://httpbin.example.com:$SECURE_INGRESS_PORT/status/418
+    $ curl -HHost:httpbin.example.com --resolve httpbin.example.com:$SECURE_INGRESS_PORT:$INGRESS_HOST  --cacert 2_intermediate/certs/ca-chain.cert.pem --cert 4_client/certs/httpbin.example.com.cert.pem --key 4_client/private/httpbin.example.com.key.pem https://httpbin.example.com:$SECURE_INGRESS_PORT/status/418
 
     -=[ teapot ]=-
 


### PR DESCRIPTION
I followed the steps in the secure ingress tutorial. The suggested curl commands returned 404 from envoy.

```
[cheld@christoph mtls-go-example]$ curl -v --resolve httpbin.example.com:$SECURE_INGRESS_PORT:$INGRESS_HOST  --cacert 2_intermediate/certs/ca-chain.cert.pem --cert 4_client/certs/httpbin.example.com.cert.pem --key 4_client/private/httpbin.example.com.key.pem https://httpbin.example.com:$SECURE_INGRESS_PORT/status/418 
* Added httpbin.example.com:31390:192.168.178.59 to DNS cache
* About to connect() to httpbin.example.com port 31390 (#0)
*   Trying 192.168.178.59...
* Connected to httpbin.example.com (192.168.178.59) port 31390 (#0)
* Initializing NSS with certpath: sql:/etc/pki/nssdb
*   CAfile: 2_intermediate/certs/ca-chain.cert.pem
  CApath: none
* NSS: client certificate from file
* 	subject: CN=httpbin.example.com,O=Dis,L=Springfield,ST=Denial,C=US
* 	start date: Jul 30 11:06:24 2018 GMT
* 	expire date: Aug 09 11:06:24 2019 GMT
* 	common name: httpbin.example.com
* 	issuer: CN=httpbin.example.com,O=Dis,ST=Denial,C=US
* SSL connection using TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
* Server certificate:
* 	subject: CN=httpbin.example.com,O=Dis,L=Springfield,ST=Denial,C=US
* 	start date: Jul 30 11:06:19 2018 GMT
* 	expire date: Aug 09 11:06:19 2019 GMT
* 	common name: httpbin.example.com
* 	issuer: CN=httpbin.example.com,O=Dis,ST=Denial,C=US
> GET /status/418 HTTP/1.1
> User-Agent: curl/7.29.0
> Host: httpbin.example.com:31390
> Accept: */*
> 
< HTTP/1.1 404 Not Found
< date: Wed, 08 Aug 2018 07:35:13 GMT
< server: envoy
< content-length: 0
< 
* Connection #0 to host httpbin.example.com left intact
```

After adding the host header the commands worked: 

`-HHost:httpbin.example.com`

Please check if this is a bug in the documentation