### PR TITLE
fix typo

### DIFF
--- a/content/blog/2018/v1alpha3-routing/index.md
+++ b/content/blog/2018/v1alpha3-routing/index.md
@@ -192,7 +192,7 @@ spec:
       version: v2
 {{< /text >}}
 
-In `v1alph3`, we provide the same configuration in a single `VirtualService` resource:
+In `v1alpha3`, we provide the same configuration in a single `VirtualService` resource:
 
 {{< text yaml >}}
 apiVersion: networking.istio.io/v1alpha3


### PR DESCRIPTION
Dear all,

This patch fill fix typo from `v1alph3` to `v1alpha3`.