### PR TITLE
Work around Hugo bug with GitHub last modification times.

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -54,7 +54,10 @@
                 {{ if .Site.Data.args.archive }}
                     Archived on {{ dateFormat "January 2, 2006" .Site.Data.args.archive_date }}
                 {{ else }}
-                    Page last modified: {{ .Page.Lastmod.Format "January 2, 2006" }}
+                    {{ $lastmod := .Page.Lastmod.Format "January 2, 2006" }}
+                    {{ if ne $lastmod "January 1, 0001" }}
+                        Page last modified: {{ $lastmod }}
+                    {{ end }}
                 {{ end }}
             </p>
         </div>


### PR DESCRIPTION
Hugo is unable to report accurate GitHub information for a certain
percentage of our files. Instead of displayed a last mod time of
"January 1, 0001" we omit display a last modification date at all.
https://github.com/gohugoio/hugo/issues/5054