### PR TITLE
add 'location: MESH_EXTERNAL' to the service entries

### DIFF
--- a/content/docs/tasks/traffic-management/egress/index.md
+++ b/content/docs/tasks/traffic-management/egress/index.md
@@ -62,6 +62,7 @@ from within your Istio cluster. In this task you access
         name: http
         protocol: HTTP
       resolution: DNS
+      location: MESH_EXTERNAL
     EOF
     {{< /text >}}
 
@@ -82,6 +83,7 @@ from within your Istio cluster. In this task you access
         name: https
         protocol: HTTPS
       resolution: DNS
+      location: MESH_EXTERNAL
     ---
     apiVersion: networking.istio.io/v1alpha3
     kind: VirtualService


### PR DESCRIPTION
it is currently not required, however for the sake of proper configuration
it should be added