### PR TITLE
Switch to Hugo 0.47

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: gcr.io/istio-testing/website-builder:2018-07-14
+      - image: gcr.io/istio-testing/website-builder:2018-08-17
 
     working_directory: ~/site
 
@@ -13,21 +13,6 @@ jobs:
           name: Generating Site
           command: scripts/gen_site.sh "" -no_minify
 
-      # We have a cache of URLs to help improve the chances of htmlproofer not hitting a timeout
-      # when probing links for validity. Alas, this cache is only for a given pull request due to
-      # the key. Ideally, this key would be using today's date as part of the key instead, such that
-      # a single daily build would need to update the cache, and it would then it reused for the
-      # subsequent builds for that day. Alas, I can't figure out how to get the current date and use it
-      # as a component of the key.
-      - restore_cache:
-          keys:
-          - htmlproofer-cache-{{ .Environment.CIRCLE_PULL_REQUEST }}
-
       - run:
           name: Running Linters
           command: scripts/lint_site.sh
-
-      - save_cache:
-          key: htmlproofer-cache-{{ .Environment.CIRCLE_PULL_REQUEST }}
-          paths:
-            - .htmlproofer

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-img := gcr.io/istio-testing/website-builder:2018-07-14
+img := gcr.io/istio-testing/website-builder:2018-08-17
 docker := docker run -t -i --sig-proxy=true --rm -v $(shell pwd):/site -w /site $(img)
 
 ifeq ($(CONTEXT),production)
@@ -19,5 +19,4 @@ serve:
 	docker run -t -i --sig-proxy=true --rm -v $(shell pwd):/site -w /site -p 1313:1313 $(img) hugo serve --bind 0.0.0.0 --disableFastRender
 
 netlify:
-	npm install -g html-minifier
 	scripts/gen_site.sh "$(baseurl)"

--- a/content/_index.md
+++ b/content/_index.md
@@ -75,7 +75,7 @@ title: Istio
                 <a href="/docs/concepts/traffic-management/">
                     <div class="card-img-top">
                         {{< inline_image "landing/routing-and-load-balancing.svg" >}}
-                     </div>
+                    </div>
                     <div class="card-body">
                         <hr class="card-line">
                         <h5 class="card-title text-center">Connect</h5>
@@ -134,7 +134,7 @@ title: Istio
                             See what's happening with rich automatic tracing, monitoring, and logging of all your services.
                        </p>
                     </div>
-                </div>
+                </a>
             </div>
         </div>
     </div>

--- a/content/docs/concepts/security/index.md
+++ b/content/docs/concepts/security/index.md
@@ -96,7 +96,7 @@ Istio service identities on different platforms:
 The [SPIFFE](https://spiffe.io/) standard provides a specification for a framework capable of bootstrapping and issuing identities to services
 across heterogeneous environments.
 
-Istio and SPIFFE share the same identity document: [SVID](https://spiffe.io/docs/svid/) (SPIFFE Verifiable Identity Document).
+Istio and SPIFFE share the same identity document: [SVID](https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE-ID.md) (SPIFFE Verifiable Identity Document).
 For example, in Kubernetes, the X.509 certificate has the URI field in the format of
 "spiffe://\<domain\>/ns/\<namespace\>/sa/\<serviceaccount\>".
 This enables Istio services to establish and accept connections with other SPIFFE-compliant systems.

--- a/content/docs/tasks/policy-enforcement/rate-limiting/index.md
+++ b/content/docs/tasks/policy-enforcement/rate-limiting/index.md
@@ -40,7 +40,7 @@ IP address. You will also use a conditional rate limit that exempts logged in us
 For convenience, you configure the
 [memory quota](/docs/reference/config/policy-and-telemetry/adapters/memquota/)
 (`memquota`) adapter to enable rate limiting. On a production system, however,
-you need [Redis](https://redis.io/), and you configure the [Redis
+you need [Redis](http://redis.io/), and you configure the [Redis
 quota](/docs/reference/config/policy-and-telemetry/adapters/redisquota/)
 (`redisquota`) adapter. Both the `memquota` and `redisquota` adapters support
 the [quota template](/docs/reference/config/policy-and-telemetry/templates/quota/),

--- a/content_zh/docs/concepts/security/index.md
+++ b/content_zh/docs/concepts/security/index.md
@@ -57,7 +57,7 @@ Istio 支持运行于 Kubernetes、虚拟机以及物理机之上的服务。对
 
 对于运行在 Kubernetes 集群中的服务，每个集群的 Citadel 会扮演证书颁发机构的角色，负责自动化执行密钥和证书管理流程。它主要执行四个关键操作：
 
-* 为每个 Service account 生成一个 [SPIFFE](https://spiffe.github.io/docs/svid) 密钥和证书
+* 为每个 Service account 生成一个 [SPIFFE](https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE-ID.md) 密钥和证书
 
 * 根据 Service account 将密钥和证书分发给每个 Pod
 
@@ -75,7 +75,7 @@ Istio 安全工作流由部署和运行两阶段组成。Kubernetes 和虚拟机
 
 1. Citadel 观察 Kubernetes API Server。
 
-1. Citadel 为每个现有和新的 Service account 创建一个 [SPIFFE](https://spiffe.github.io/docs/svid) 密钥和证书对。
+1. Citadel 为每个现有和新的 Service account 创建一个 [SPIFFE](https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE-ID.md) 密钥和证书对。
 
 1. Citadel 将上一步新建的内容其发送到 API Server。
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,4 +3,4 @@
     command = "make netlify"
 
 [build.environment]
-    HUGO_VERSION = "0.44"
+    HUGO_VERSION = "0.47"

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -16,7 +16,7 @@ RUN apk add --no-cache \
     git \
     && apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing/ --allow-untrusted gnu-libiconv
 
-ENV HUGO_VERSION=0.44
+ENV HUGO_VERSION=0.47
 ADD https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz /tmp
 RUN tar -xf /tmp/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz -C /tmp \
     && mkdir -p /usr/local/sbin \
@@ -27,7 +27,6 @@ RUN tar -xf /tmp/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz -C /tmp \
     && rm -rf /tmp/README.md
 
 RUN npm install -g \
-    html-minifier \
     sass \
     uglify-js \
     markdown-spellcheck

--- a/scripts/gen_site.sh
+++ b/scripts/gen_site.sh
@@ -2,12 +2,9 @@
 set -e
 
 hugo version
-echo -ne "html-minifier "
-html-minifier --version
 
-hugo --baseURL "$1"
-
-if [ "$2" != "-no_minify" ]
-then
-html-minifier --input-dir public --output-dir public --file-ext html --collapse-whitespace --minify-js --minify-css --sort-attributes --sort-class-name --remove-attribute-quotes --remove-comments
+if [ "$2" == "-no_minify" ]; then
+  hugo --baseURL "$1"
+else
+  hugo --minify --baseURL "$1"
 fi


### PR DESCRIPTION
- Fixes the bug where not all of our files would get the right lastmod
time extracted from GitHub.

- Fixes most of the cases of bad HTML output around the use of {{<text>}}. There's
still a single bad case which I'll report to the Hugo folks.

- Use Hugo's new --minify option to minify HTML instead of having to use the
separate and slow html-minifier program.

- Fix some bad HTML on the landing page.