### PR TITLE
Update Guideline

### DIFF
--- a/content/help/ops/traffic-management/deploy-guidelines/index.md
+++ b/content/help/ops/traffic-management/deploy-guidelines/index.md
@@ -235,8 +235,8 @@ This should stop Istio from restarting Envoy and disconnecting TCP connections.
 
 ## Configuring multiple TLS hosts in a gateway
 
-If you configure multiple gateway servers, either in a single Gateway,
-or spread across more than one that use the same selector labels,
+If you configure multiple gateway servers, either in a single `Gateway`,
+or spread across more than one that use the same `selector` labels,
 with the same port number and protocol HTTPS,
 then you must ensure that the corresponding port names are unique. For example:
 
@@ -273,10 +273,10 @@ spec:
 EOF
 {{< /text >}}
 
-If the port name is not unique, the `istio-pilot` pod returns the following error:
+If the port names are not unique, `istio-pilot` will return the following error in the log:
 
 {{< text plain >}}
 port https.443.HTTPS: non unique port name for HTTPS port
 {{< /text >}}
 
-If you run a `curl` command, Istio returns the same error under the `SSL_SYSCALL_ERROR` value.
+If you run a `curl` command, command returns 0 and print `SSL_SYSCALL_ERROR`.

--- a/content/help/ops/traffic-management/deploy-guidelines/index.md
+++ b/content/help/ops/traffic-management/deploy-guidelines/index.md
@@ -233,10 +233,12 @@ $ kubectl scale --replicas=0 deploy/istio-citadel -n istio-system
 
 This should stop Istio from restarting Envoy and disconnecting TCP connections.
 
-## Configure a multiple host gateway with SSL
+## Configuring multiple TLS hosts in a gateway
 
-To configure the ingress gateway with TLS correctly for you to deploy multiple
-hosts, you must configure a unique port name with the following command:
+If you configure multiple gateway servers, either in a single Gateway,
+or spread across more than one that use the same selector labels,
+with the same port number and protocol HTTPS,
+then you must ensure that the corresponding port names are unique. For example:
 
 {{< text bash >}}
 $ cat <<EOF | kubectl apply -f -


### PR DESCRIPTION
Add guideline/warning, that we need to have unique name in `port name` if we use multiple host and HTTPS protocol.