### PR TITLE
fix-404

### DIFF
--- a/content/docs/setup/kubernetes/helm-install/index.md
+++ b/content/docs/setup/kubernetes/helm-install/index.md
@@ -28,7 +28,7 @@ plane and the sidecars for the Istio data plane.
 
 1. Check the [Requirements for Pods and Services](/docs/setup/kubernetes/spec-requirements/) on Pods and Services.
 
-1. [Install the Helm client](https://docs.helm.sh/using_helm/#installing-helm).
+1. [Install the Helm client](https://docs.helm.sh/using_helm/).
 
 1. Istio by default uses `LoadBalancer` service object types.  Some platforms do not support `LoadBalancer`
    service objects.  For platforms lacking `LoadBalancer` support, install Istio with `NodePort` support

--- a/content/docs/setup/kubernetes/quick-start-gke-dm/index.md
+++ b/content/docs/setup/kubernetes/quick-start-gke-dm/index.md
@@ -7,7 +7,7 @@ keywords: [kubernetes,gke,google]
 
 Quick Start instructions to install and run Istio in [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/) (GKE) using [Google Cloud Deployment Manager](https://cloud.google.com/deployment-manager/).
 
-This Quick Start creates a new GKE [zonal cluster](https://cloud.google.com/kubernetes-engine/versioning-and-upgrades#versions_available_for_new_cluster_masters), installs the current release version of Istio and then deploys the [Bookinfo](/docs/examples/bookinfo/) sample
+This Quick Start creates a new GKE [zonal cluster](https://cloud.google.com/kubernetes-engine/versioning-and-upgrades#checking_available_versions), installs the current release version of Istio and then deploys the [Bookinfo](/docs/examples/bookinfo/) sample
 application.  It uses Deployment Manager to automate the steps detailed in the [Istio on Kubernetes setup instructions](/docs/setup/kubernetes/quick-start/) for Kubernetes Engine
 
 ## Prerequisites

--- a/content_zh/docs/setup/kubernetes/quick-start-gke-dm/index.md
+++ b/content_zh/docs/setup/kubernetes/quick-start-gke-dm/index.md
@@ -7,7 +7,7 @@ keywords: [kubernetes,gke]
 
 快速开始操作指南，使用 [Google Cloud Deployment Manager](https://cloud.google.com/deployment-manager/)，在 [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/)（GKE）上安装和运行 Istio。
 
-这个快速开始创建了一个新的 GKE [zonal cluster](https://cloud.google.com/kubernetes-engine/versioning-and-upgrades#versions_available_for_new_cluster_masters)，安装当前版本的 Istio 并部署 [Bookinfo](/zh/docs/examples/bookinfo/) 样例应用。在 [Kubernetes 安装 Istio 指南](/zh/docs/setup/kubernetes/quick-start/) 的基础上，使用 Deployment Manager 为 Kubernetes Engine 提供一个自动的细化步骤。
+这个快速开始创建了一个新的 GKE [zonal cluster](https://cloud.google.com/kubernetes-engine/versioning-and-upgrades#checking_available_versions)，安装当前版本的 Istio 并部署 [Bookinfo](/zh/docs/examples/bookinfo/) 样例应用。在 [Kubernetes 安装 Istio 指南](/zh/docs/setup/kubernetes/quick-start/) 的基础上，使用 Deployment Manager 为 Kubernetes Engine 提供一个自动的细化步骤。
 
 ## 前置条件
 


### PR DESCRIPTION
in #2374 ：

~~~plain
- ./public/docs/setup/kubernetes/helm-install/index.html
  *  External link https://docs.helm.sh/using_helm/#installing-helm failed: https://docs.helm.sh/using_helm/ exists, but the hash 'installing-helm' does not
- ./public/docs/setup/kubernetes/quick-start-gke-dm/index.html
  *  External link https://cloud.google.com/kubernetes-engine/versioning-and-upgrades#versions_available_for_new_cluster_masters failed: https://cloud.google.com/kubernetes-engine/versioning-and-upgrades exists, but the hash 'versions_available_for_new_cluster_masters' does not
~~~

The hash "#installing-helm"  had been removed from "https://docs.helm.sh/using_helm",
and the other one had been updated.