### PR TITLE
Change `mTLS` in YAML config examples to `mtls`

### DIFF
--- a/content/docs/concepts/security/index.md
+++ b/content/docs/concepts/security/index.md
@@ -492,7 +492,7 @@ recommendations to avoid disruption when updating your authentication policies:
 
 {{< text yaml >}}
 peers:
-- mTLS:
+- mtls:
     mode: PERMISSIVE
 {{< /text >}}
 

--- a/content/docs/tasks/security/authn-policy/index.md
+++ b/content/docs/tasks/security/authn-policy/index.md
@@ -584,7 +584,7 @@ spec:
   targets:
   - name: httpbin
   peers:
-  - mTLS: {}
+  - mtls: {}
   origins:
   - jwt:
       issuer: "testing@secure.istio.io"
@@ -613,7 +613,7 @@ EOF
 {{< /text >}}
 
 > If you already enable mutual TLS mesh-wide or namespace-wide, the host `httpbin.foo` is already covered by the other destination rule.
-Therefore, you do not need adding this destination rule. On the other hand, you still need to add the `mTLS` stanza to the authentication policy as the service-specific policy will override the mesh-wide (or namespace-wide) policy completely.
+Therefore, you do not need adding this destination rule. On the other hand, you still need to add the `mtls` stanza to the authentication policy as the service-specific policy will override the mesh-wide (or namespace-wide) policy completely.
 
 After these changes, traffic from Istio services, including ingress gateway, to `httpbin.foo` will use mutual TLS. The test command above will still work. Requests from Istio services directly to `httpbin.foo` also work, given the correct token:
 

--- a/content_zh/docs/concepts/security/index.md
+++ b/content_zh/docs/concepts/security/index.md
@@ -329,7 +329,7 @@ principalBinding: USE_ORIGIN
 
 {{< text yaml >}}
 peers:
-- mTLS:
+- mtls:
     mode: PERMISSIVE
 {{< /text >}}
 


### PR DESCRIPTION
- The `mtls` key is case sensitive.

If you use:
```
apiVersion: "authentication.istio.io/v1alpha1"
kind: "MeshPolicy"
metadata:
  name: "default"
spec:
  peers:
  - mTLS: {}
```

You will get an error:

```
- mTLS: {}
 unknown field "mTLS" in v1alpha1.PeerAuthenticationMethod
```

Changing it to:

```
apiVersion: "authentication.istio.io/v1alpha1"
kind: "MeshPolicy"
metadata:
  name: "default"
spec:
  peers:
  - mtls: {}
```

works.