### PR TITLE
Fixed output of a command attempting to connect to httpbin.foo from legacy ns

### DIFF
--- a/content/docs/tasks/security/authn-policy/index.md
+++ b/content/docs/tasks/security/authn-policy/index.md
@@ -626,7 +626,8 @@ However, requests from non-Istio services, which use plain-text will fail:
 
 {{< text bash >}}
 $ kubectl exec $(kubectl get pod -l app=sleep -n legacy -o jsonpath={.items..metadata.name}) -c sleep -n legacy -- curl http://httpbin.foo:8000/ip -s -o /dev/null -w "%{http_code}\n" --header "Authorization: Bearer $TOKEN"
-401
+000
+command terminated with exit code 56
 {{< /text >}}
 
 ### Cleanup part 3


### PR DESCRIPTION
As there's no mtls between foo and legacy namespaces, a connection between sleep.legacy and httpbin.foo cannot be established, and will fail before reaching authentication stage.