### PR TITLE
Control Ingress Traffic clean up command error

### DIFF
--- a/content/docs/tasks/traffic-management/ingress/index.md
+++ b/content/docs/tasks/traffic-management/ingress/index.md
@@ -278,7 +278,7 @@ and exposed an HTTP endpoint of the service to external traffic.
 Delete the `Gateway` configuration, the `VirtualService` and the secret, and shutdown the [httpbin]({{< github_tree >}}/samples/httpbin) service:
 
 {{< text bash >}}
-$ kubectl delete gateway httpbin-gateway
-$ kubectl delete virtualservice httpbin
+$ istioctl delete gateway httpbin-gateway
+$ istioctl delete virtualservice httpbin
 $ kubectl delete --ignore-not-found=true -f @samples/httpbin/httpbin.yaml@
 {{< /text >}}


### PR DESCRIPTION
delete virtualservice or gateway should use istioctl, using kuberctl will encounter an error:
`[root@localhost istio-1.1.0.snapshot.0]#  kubectl delete gateway httpbin-gateway
Error from server (NotFound): gateways.config.istio.io "httpbin-gateway" not found
`
`[root@localhost istio-1.1.0.snapshot.0]# istioctl delete Gateway httpbin-gateway
Deleted config: Gateway httpbin-gateway
`