### PR TITLE
Improve the release note link shortcode.

### DIFF
--- a/content/about/notes/1.0.2/index.md
+++ b/content/about/notes/1.0.2/index.md
@@ -7,7 +7,7 @@ icon: /img/notes.svg
 This release addresses some critical issues found by the community when using Istio 1.0.1. This release note describes what's different between Istio 1.0.1 and
 Istio 1.0.2.
 
-{{</* relnote_links */>}}
+{{< relnote_links >}}
 
 ## Miscellaneous
 

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -84,3 +84,12 @@ other = "Privacy Policy"
 
 [page_publish_date_format]
 other = "January 2, 2006"
+
+[relnote_download]
+other = "DOWNLOAD %s"
+
+[relnote_changes]
+other = "CHANGES IN %s"
+
+[relnote_docs]
+other = "%s DOCS"

--- a/i18n/zh.toml
+++ b/i18n/zh.toml
@@ -84,3 +84,12 @@ other = "Privacy Policy"
 
 [page_publish_date_format]
 other = "January 2, 2006"
+
+[relnote_download]
+other = "DOWNLOAD %s"
+
+[relnote_changes]
+other = "CHANGES IN %s"
+
+[relnote_docs]
+other = "%s DOCS"

--- a/layouts/shortcodes/relnote_links.html
+++ b/layouts/shortcodes/relnote_links.html
@@ -3,11 +3,13 @@
 
 {{ $short_version := $dir_name }}
 {{ $full_version := printf "%s.0" $dir_name }}
+{{ $old_full_version := $full_version }}
 {{ $patch := false }}
 
 {{ if ne (len $parts) 2 }}
     {{ $short_version = printf "%s.%s" (index $parts 0) (index $parts 1) }}
-    {{ $full_version = $dir_name }}
+    {{ $full_version = printf "%s.%s.%s" (index $parts 0) (index $parts 1) (index $parts 2) }}
+    {{ $old_full_version = printf "%s.%s.%d" (index $parts 0) (index $parts 1) (sub (int (index $parts 2)) 1) }}
     {{ $patch = true }}
 {{ end }}
 
@@ -36,27 +38,27 @@
         <div class="row justify-content-center">
             {{ if .Site.Data.args.preliminary }}
                 {{ if ne $type_of_note "prelim" }}
-                    <a class="btn btn-istio" href="https://github.com/istio/istio/releases/tag/{{ $full_version }}">DOWNLOAD {{ $dir_name }}</a>
+                    <a class="btn btn-istio" href="https://github.com/istio/istio/releases/tag/{{ $full_version }}">{{ printf (i18n "relnote_download") $dir_name }}</a>
 
                     {{ if eq $type_of_note "archive" }}
-                        <a class="btn btn-istio" href="https://archive.istio.io/v{{ $short_version }}">{{ $dir_name }} DOCS</a>
+                        <a class="btn btn-istio" href="https://archive.istio.io/v{{ $short_version }}">{{ printf (i18n "relnote_docs") $dir_name }}</a>
                     {{ else }}
-                        <a class="btn btn-istio" href="https://istio.io">{{ $dir_name }} DOCS</a>
+                        <a class="btn btn-istio" href="https://istio.io">{{ printf (i18n "relnote_docs") $dir_name }}</a>
                     {{ end }}
 
                     {{ if $patch }}
-                        <a class="btn btn-istio" href="https://github.com/istio/istio/compare/{{ $short_version }}.0...{{ $full_version }}">{{ $dir_name }} CHANGES</a>
+                        <a class="btn btn-istio" href="https://github.com/istio/istio/compare/{{ $old_full_version }}...{{ $full_version }}">{{ printf (i18n "relnote_changes") $dir_name }}</a>
                     {{ end }}
                 {{ end }}
             {{ else }}
-                <a class="btn btn-istio" href="https://github.com/istio/istio/releases/tag/{{ $full_version }}">DOWNLOAD {{ $dir_name }}</a>
+                <a class="btn btn-istio" href="https://github.com/istio/istio/releases/tag/{{ $full_version }}">{{ printf (i18n "relnote_download") $dir_name }}</a>
 
                 {{ if (ne .Site.Data.args.version $short_version) }}
-                    <a class="btn btn-istio" href="https://archive.istio.io/v{{ $short_version }}">{{ $dir_name }} DOCS</a>
+                    <a class="btn btn-istio" href="https://archive.istio.io/v{{ $short_version }}">{{ printf (i18n "relnote_docs") $dir_name }}</a>
                 {{ end }}
 
                 {{ if $patch }}
-                    <a class="btn btn-istio" href="https://github.com/istio/istio/compare/{{ $short_version }}.0...{{ $full_version }}">{{ $dir_name }} CHANGES</a>
+                    <a class="btn btn-istio" href="https://github.com/istio/istio/compare/{{ $old_full_version }}...{{ $full_version }}">{{ printf (i18n "relnote_changes") $dir_name }}</a>
                 {{ end }}
             {{ end }}
         </div>


### PR DESCRIPTION
- When displaying a "Changes" button, we now display a diff from the previous patch to the current
patch, instead of a diff from the base release to the current patch.

- Properly localize the release note buttons so these can be translated.