### PR TITLE
Use kubectl with EOF instead of cat with pipe

### DIFF
--- a/content/blog/2017/0.1-canary/index.md
+++ b/content/blog/2017/0.1-canary/index.md
@@ -92,7 +92,7 @@ rule to control the traffic distribution. For example if we want to send 10% of 
 to set a routing rule something like this:
 
 {{< text bash >}}
-$ cat <<EOF | kubectl apply -f -
+$ kubectl apply -f - <<EOF
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
@@ -197,7 +197,7 @@ helloworld-v2-4095161145-963wt   2/2       Running   0          1h
 As mentioned above, the Istio routing rules can be used to route traffic based on specific criteria, allowing more sophisticated canary deployment scenarios. Say, for example, instead of exposing the canary to an arbitrary percentage of users, we want to try it out on internal users, maybe even just a percentage of them. The following command could be used to send 50% of traffic from users at *some-company-name.com* to the canary version, leaving all other users unaffected:
 
 {{< text bash >}}
-$ cat <<EOF | kubectl apply -f -
+$ kubectl apply -f - <<EOF
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:

--- a/content/blog/2018/egress-https/index.md
+++ b/content/blog/2018/egress-https/index.md
@@ -103,7 +103,7 @@ No worries, define a **mesh-external service entry** and fix your application. Y
 service_ to perform routing by [SNI](https://en.wikipedia.org/wiki/Server_Name_Indication) to the external service.
 
 {{< text bash >}}
-$ cat <<EOF | kubectl apply -f -
+$ kubectl apply -f - <<EOF
 apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
@@ -259,7 +259,7 @@ In the next section you will configure TLS origination for accessing an external
 1.  Create a mesh-external service entry for `www.google.apis` and a destination rule to perform TLS origination.
 
     {{< text bash >}}
-    $ cat <<EOF | kubectl apply -f -
+    $ kubectl apply -f - <<EOF
     apiVersion: networking.istio.io/v1alpha3
     kind: ServiceEntry
     metadata:

--- a/content/blog/2018/egress-tcp/index.md
+++ b/content/blog/2018/egress-tcp/index.md
@@ -261,7 +261,7 @@ TCP mesh-external service entries come to our rescue.
 1.  Define a TCP mesh-external service entry:
 
     {{< text bash >}}
-    $ cat <<EOF | kubectl apply -f -
+    $ kubectl apply -f - <<EOF
     apiVersion: networking.istio.io/v1alpha3
     kind: ServiceEntry
     metadata:

--- a/content/docs/examples/advanced-gateways/egress-gateway-mtls-origination/index.md
+++ b/content/docs/examples/advanced-gateways/egress-gateway-mtls-origination/index.md
@@ -109,7 +109,7 @@ to hold the configuration of the NGINX server:
 1.  Deploy the NGINX server:
 
     {{< text bash >}}
-    $ cat <<EOF | kubectl apply -f -
+    $ kubectl apply -f - <<EOF
     apiVersion: v1
     kind: Service
     metadata:
@@ -171,7 +171,7 @@ to hold the configuration of the NGINX server:
     to `nginx.example.com` to your NGINX server:
 
     {{< text bash >}}
-    $ cat <<EOF | kubectl apply -f -
+    $ kubectl apply -f - <<EOF
     apiVersion: networking.istio.io/v1alpha3
     kind: ServiceEntry
     metadata:
@@ -227,7 +227,7 @@ to hold the configuration of the NGINX server:
     requests to the NGINX server:
 
     {{< text bash >}}
-    $ cat <<EOF | kubectl apply -f -
+    $ kubectl apply -f - <<EOF
     # Copyright 2017 Istio Authors
     #
     #   Licensed under the Apache License, Version 2.0 (the "License");
@@ -395,7 +395,7 @@ to hold the configuration of the NGINX server:
     service.
 
     {{< text bash >}}
-    $ cat <<EOF | kubectl apply -f -
+    $ kubectl apply -f - <<EOF
     apiVersion: networking.istio.io/v1alpha3
     kind: Gateway
     metadata:
@@ -440,7 +440,7 @@ to hold the configuration of the NGINX server:
     mutual TLS origination:
 
     {{< text bash >}}
-    $ cat <<EOF | kubectl apply -f -
+    $ kubectl apply -f - <<EOF
     apiVersion: networking.istio.io/v1alpha3
     kind: VirtualService
     metadata:

--- a/content/docs/examples/advanced-gateways/egress-gateway/index.md
+++ b/content/docs/examples/advanced-gateways/egress-gateway/index.md
@@ -55,7 +55,7 @@ First direct HTTP traffic without TLS origination
 1.  Define a `ServiceEntry` for `edition.cnn.com`:
 
     {{< text bash >}}
-    $ cat <<EOF | kubectl apply -f -
+    $ kubectl apply -f - <<EOF
     apiVersion: networking.istio.io/v1alpha3
     kind: ServiceEntry
     metadata:
@@ -101,7 +101,7 @@ First direct HTTP traffic without TLS origination
     command.
 
     {{< text bash >}}
-    $ cat <<EOF | kubectl apply -f -
+    $ kubectl apply -f - <<EOF
     apiVersion: networking.istio.io/v1alpha3
     kind: Gateway
     metadata:
@@ -145,7 +145,7 @@ First direct HTTP traffic without TLS origination
     otherwise:
 
     {{< text bash >}}
-    $ cat <<EOF | kubectl apply -f -
+    $ kubectl apply -f - <<EOF
     apiVersion: networking.istio.io/v1alpha3
     kind: Gateway
     metadata:
@@ -175,7 +175,7 @@ First direct HTTP traffic without TLS origination
 1.  Define a `VirtualService` to direct the traffic through the egress gateway:
 
     {{< text bash >}}
-    $ cat <<EOF | kubectl apply -f -
+    $ kubectl apply -f - <<EOF
     apiVersion: networking.istio.io/v1alpha3
     kind: VirtualService
     metadata:
@@ -262,7 +262,7 @@ be done by the egress Gateway server, as opposed to by the sidecar in the previo
 1.  Define a `ServiceEntry` for `edition.cnn.com`:
 
     {{< text bash >}}
-    $ cat <<EOF | kubectl apply -f -
+    $ kubectl apply -f - <<EOF
     apiVersion: networking.istio.io/v1alpha3
     kind: ServiceEntry
     metadata:
@@ -304,7 +304,7 @@ be done by the egress Gateway server, as opposed to by the sidecar in the previo
     command.
 
     {{< text bash >}}
-    $ cat <<EOF | kubectl apply -f -
+    $ kubectl apply -f - <<EOF
     apiVersion: networking.istio.io/v1alpha3
     kind: Gateway
     metadata:
@@ -348,7 +348,7 @@ be done by the egress Gateway server, as opposed to by the sidecar in the previo
     otherwise:
 
     {{< text bash >}}
-    $ cat <<EOF | kubectl apply -f -
+    $ kubectl apply -f - <<EOF
     apiVersion: networking.istio.io/v1alpha3
     kind: Gateway
     metadata:
@@ -379,7 +379,7 @@ be done by the egress Gateway server, as opposed to by the sidecar in the previo
     origination:
 
     {{< text bash >}}
-    $ cat <<EOF | kubectl apply -f -
+    $ kubectl apply -f - <<EOF
     apiVersion: networking.istio.io/v1alpha3
     kind: VirtualService
     metadata:
@@ -474,7 +474,7 @@ You specify the port 443, protocol `TLS` in the corresponding `ServiceEntry`, eg
 1.  Define a `ServiceEntry` for `edition.cnn.com`:
 
     {{< text bash >}}
-    $ cat <<EOF | kubectl apply -f -
+    $ kubectl apply -f - <<EOF
     apiVersion: networking.istio.io/v1alpha3
     kind: ServiceEntry
     metadata:
@@ -509,7 +509,7 @@ The output should be the same as in the previous section.
     command.
 
     {{< text bash >}}
-    $ cat <<EOF | kubectl apply -f -
+    $ kubectl apply -f - <<EOF
     apiVersion: networking.istio.io/v1alpha3
     kind: Gateway
     metadata:
@@ -588,7 +588,7 @@ The output should be the same as in the previous section.
     otherwise:
 
     {{< text bash >}}
-    $ cat <<EOF | kubectl apply -f -
+    $ kubectl apply -f - <<EOF
     apiVersion: networking.istio.io/v1alpha3
     kind: Gateway
     metadata:

--- a/content/docs/examples/advanced-gateways/egress-tls-origination/index.md
+++ b/content/docs/examples/advanced-gateways/egress-tls-origination/index.md
@@ -54,7 +54,7 @@ Note that you use a wildcard `*` in your `hosts` definition: `*.cnn.com`. Using 
 1.  Create a `ServiceEntry` to allow access to an external HTTP and HTTPS services:
 
     {{< text bash >}}
-    $ cat <<EOF | kubectl apply -f -
+    $ kubectl apply -f - <<EOF
     apiVersion: networking.istio.io/v1alpha3
     kind: ServiceEntry
     metadata:
@@ -115,7 +115,7 @@ to DNS to correctly configure Envoy.
 proxy needs to know exactly which host to access using HTTPS:
 
     {{< text bash >}}
-    $ cat <<EOF | kubectl apply -f -
+    $ kubectl apply -f - <<EOF
     apiVersion: networking.istio.io/v1alpha3
     kind: ServiceEntry
     metadata:

--- a/content/docs/examples/advanced-gateways/ingress-sni-passthrough/index.md
+++ b/content/docs/examples/advanced-gateways/ingress-sni-passthrough/index.md
@@ -97,7 +97,7 @@ to hold the configuration of the NGINX server:
 1.  Deploy the NGINX server:
 
     {{< text bash >}}
-    $ cat <<EOF | kubectl apply -f -
+    $ kubectl apply -f - <<EOF
     apiVersion: v1
     kind: Service
     metadata:
@@ -188,7 +188,7 @@ to hold the configuration of the NGINX server:
     the gateway to pass the ingress traffic AS IS, without terminating TLS.
 
     {{< text bash >}}
-    $ cat <<EOF | kubectl apply -f -
+    $ kubectl apply -f - <<EOF
     apiVersion: networking.istio.io/v1alpha3
     kind: Gateway
     metadata:
@@ -211,7 +211,7 @@ to hold the configuration of the NGINX server:
 1.  Configure routes for traffic entering via the `Gateway`:
 
     {{< text bash >}}
-    $ cat <<EOF | kubectl apply -f -
+    $ kubectl apply -f - <<EOF
     apiVersion: networking.istio.io/v1alpha3
     kind: VirtualService
     metadata:

--- a/content/docs/examples/endpoints/index.md
+++ b/content/docs/examples/endpoints/index.md
@@ -35,7 +35,7 @@ Otherwise, ESP won't be able to access Google cloud service control.
 1.  If you want to access the service through Ingress, create the following Ingress definition:
 
     {{< text bash >}}
-    $ cat <<EOF | kubectl apply -f -
+    $ kubectl apply -f - <<EOF
     apiVersion: extensions/v1beta1
     kind: Ingress
     metadata:

--- a/content/docs/tasks/security/authn-policy/index.md
+++ b/content/docs/tasks/security/authn-policy/index.md
@@ -91,7 +91,7 @@ $ kubectl get destinationrules.networking.istio.io --all-namespaces -o yaml | gr
 To set a mesh-wide authentication policy that enables mutual TLS, submit *mesh authentication policy* like below:
 
 {{< text bash >}}
-$ cat <<EOF | kubectl apply -f -
+$ kubectl apply -f - <<EOF
 apiVersion: "authentication.istio.io/v1alpha1"
 kind: "MeshPolicy"
 metadata:
@@ -121,7 +121,7 @@ multiple destination rules, one for each applicable service (or namespace). Howe
 services so that it is on par with the mesh-wide authentication policy.
 
 {{< text bash >}}
-$ cat <<EOF | kubectl apply -f -
+$ kubectl apply -f - <<EOF
 apiVersion: "networking.istio.io/v1alpha3"
 kind: "DestinationRule"
 metadata:
@@ -187,7 +187,7 @@ sleep.bar to httpbin.legacy: 503
 To fix this issue, we can add a destination rule to overwrite the TLS setting for `httpbin.legacy`. For example:
 
 {{< text bash >}}
-$ cat <<EOF | kubectl apply -f -
+$ kubectl apply -f - <<EOF
 apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
@@ -215,7 +215,7 @@ command terminated with exit code 35
 Again, we can correct this by overriding the destination rule for the API server (`kubernetes.default`)
 
 {{< text bash >}}
-$ cat <<EOF | kubectl apply -f -
+$ kubectl apply -f - <<EOF
 apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
@@ -259,7 +259,7 @@ The example below shows the policy to enable mutual TLS for all services in name
 and specifies a namespace, in this case, `foo`. If you don’t specify a namespace value the policy will apply to the default namespace.
 
 {{< text bash >}}
-$ cat <<EOF | kubectl apply -f -
+$ kubectl apply -f - <<EOF
 apiVersion: "authentication.istio.io/v1alpha1"
 kind: "Policy"
 metadata:
@@ -276,7 +276,7 @@ EOF
 Add corresponding destination rule:
 
 {{< text bash >}}
-$ cat <<EOF | kubectl apply -f -
+$ kubectl apply -f - <<EOF
 apiVersion: "networking.istio.io/v1alpha3"
 kind: "DestinationRule"
 metadata:
@@ -463,7 +463,7 @@ this tutorial, we use this [JWT test]({{< github_file >}}/security/tools/jwt/sam
 Also, for convenience, expose `httpbin.foo` via `ingressgateway` (for more details, see the [ingress task](/docs/tasks/traffic-management/ingress/)).
 
 {{< text bash >}}
-$ cat <<EOF | kubectl apply -f -
+$ kubectl apply -f - <<EOF
 apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
@@ -483,7 +483,7 @@ EOF
 {{< /text >}}
 
 {{< text bash >}}
-$ cat <<EOF | kubectl apply -f -
+$ kubectl apply -f - <<EOF
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
@@ -598,7 +598,7 @@ EOF
 And add a destination rule:
 
 {{< text bash >}}
-$ cat <<EOF | kubectl apply -f -
+$ kubectl apply -f - <<EOF
 apiVersion: "networking.istio.io/v1alpha3"
 kind: "DestinationRule"
 metadata:

--- a/content/docs/tasks/security/health-check/index.md
+++ b/content/docs/tasks/security/health-check/index.md
@@ -50,7 +50,7 @@ $ kubectl apply -f install/kubernetes/istio-citadel-with-health-check.yaml
 Deploy the `istio-citadel` service so that the CSR service can be found by the health checker.
 
 {{< text bash >}}
-$ cat <<EOF | kubectl create -f -
+$ kubectl create -f - <<EOF
 apiVersion: v1
 kind: Service
 metadata:

--- a/content/docs/tasks/security/role-based-access-control/index.md
+++ b/content/docs/tasks/security/role-based-access-control/index.md
@@ -85,7 +85,7 @@ Before you start, please make sure that you have finished [preparation task](#be
     Run the following command:
 
     {{< text bash >}}
-    $ cat <<EOF | kubectl apply -f -
+    $ kubectl apply -f - <<EOF
     apiVersion: "rbac.istio.io/v1alpha1"
     kind: RbacConfig
     metadata:

--- a/content/docs/tasks/traffic-management/app-health-check/index.md
+++ b/content/docs/tasks/traffic-management/app-health-check/index.md
@@ -52,7 +52,7 @@ Follow these steps to complete the configuration:
 1. To configure the authentication policy, run:
 
     {{< text bash >}}
-    $ cat <<EOF | kubectl apply -f -
+    $ kubectl apply -f - <<EOF
     apiVersion: "authentication.istio.io/v1alpha1"
     kind: "Policy"
     metadata:
@@ -67,7 +67,7 @@ Follow these steps to complete the configuration:
 1. To configure the destination rule, run:
 
     {{< text bash >}}
-    $ cat <<EOF | kubectl apply -f -
+    $ kubectl apply -f - <<EOF
     apiVersion: "networking.istio.io/v1alpha3"
     kind: "DestinationRule"
     metadata:
@@ -139,7 +139,7 @@ Again, enable mutual TLS for services in the default namespace by adding namespa
 1. To configure the authentication policy, run:
 
     {{< text bash >}}
-    $ cat <<EOF | kubectl apply -f -
+    $ kubectl apply -f - <<EOF
     apiVersion: "authentication.istio.io/v1alpha1"
     kind: "Policy"
     metadata:
@@ -154,7 +154,7 @@ Again, enable mutual TLS for services in the default namespace by adding namespa
 1. To configure the destination rule, run:
 
     {{< text bash >}}
-    $ cat <<EOF | kubectl apply -f -
+    $ kubectl apply -f - <<EOF
     apiVersion: "networking.istio.io/v1alpha3"
     kind: "DestinationRule"
     metadata:

--- a/content/docs/tasks/traffic-management/circuit-breaking/index.md
+++ b/content/docs/tasks/traffic-management/circuit-breaking/index.md
@@ -43,7 +43,7 @@ when calling the `httpbin` service:
     > If you installed/configured Istio with mutual TLS Authentication enabled, you must add a TLS traffic policy `mode: ISTIO_MUTUAL` to the `DestinationRule` before applying it. Otherwise requests will generate 503 errors as described [here](/help/ops/traffic-management/deploy-guidelines/#503-errors-after-setting-destination-rule).
 
     {{< text bash >}}
-    $ cat <<EOF | kubectl apply -f -
+    $ kubectl apply -f - <<EOF
     apiVersion: networking.istio.io/v1alpha3
     kind: DestinationRule
     metadata:

--- a/content/docs/tasks/traffic-management/egress/index.md
+++ b/content/docs/tasks/traffic-management/egress/index.md
@@ -55,7 +55,7 @@ from within your Istio cluster. This task shows you how to access an external HT
 1.  Create a `ServiceEntry` to allow access to an external HTTP service:
 
     {{< text bash >}}
-    $ cat <<EOF | kubectl apply -f -
+    $ kubectl apply -f - <<EOF
     apiVersion: networking.istio.io/v1alpha3
     kind: ServiceEntry
     metadata:
@@ -91,7 +91,7 @@ from within your Istio cluster. This task shows you how to access an external HT
     The `VirtualService` must include a `tls` rule with `sni_hosts` in the `match` clause to enable SNI routing.
 
     {{< text bash >}}
-    $ cat <<EOF | kubectl apply -f -
+    $ kubectl apply -f - <<EOF
     apiVersion: networking.istio.io/v1alpha3
     kind: ServiceEntry
     metadata:
@@ -163,7 +163,7 @@ In this example, you set a timeout rule on calls to the `httpbin.org` service.
 1.  Exit the source pod and use `kubectl` to set a 3s timeout on calls to the `httpbin.org` external service:
 
     {{< text bash >}}
-    $ cat <<EOF | kubectl apply -f -
+    $ kubectl apply -f - <<EOF
     apiVersion: networking.istio.io/v1alpha3
     kind: VirtualService
     metadata:

--- a/content/docs/tasks/traffic-management/ingress/index.md
+++ b/content/docs/tasks/traffic-management/ingress/index.md
@@ -133,7 +133,7 @@ Let's see how you can configure a `Gateway` on port 80 for HTTP traffic.
 1.  Create an Istio `Gateway`:
 
     {{< text bash >}}
-    $ cat <<EOF | kubectl apply -f -
+    $ kubectl apply -f - <<EOF
     apiVersion: networking.istio.io/v1alpha3
     kind: Gateway
     metadata:
@@ -154,7 +154,7 @@ Let's see how you can configure a `Gateway` on port 80 for HTTP traffic.
 1.  Configure routes for traffic entering via the `Gateway`:
 
     {{< text bash >}}
-    $ cat <<EOF | kubectl apply -f -
+    $ kubectl apply -f - <<EOF
     apiVersion: networking.istio.io/v1alpha3
     kind: VirtualService
     metadata:
@@ -225,7 +225,7 @@ Entering the `httpbin` service URL in a browser won't work because you can't tel
 To work around this problem for simple tests and demos, use a wildcard `*` value for the host in the `Gateway` and `VirtualService` configurations. For example, if you change your ingress configuration to the following:
 
 {{< text bash >}}
-$ cat <<EOF | kubectl apply -f -
+$ kubectl apply -f - <<EOF
 apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:

--- a/content/docs/tasks/traffic-management/mirroring/index.md
+++ b/content/docs/tasks/traffic-management/mirroring/index.md
@@ -77,7 +77,7 @@ you will apply a rule to mirror a portion of traffic to `v2`.
     **httpbin Kubernetes service:**
 
     {{< text bash >}}
-    $ cat <<EOF | kubectl create -f -
+    $ kubectl create -f - <<EOF
     apiVersion: v1
     kind: Service
     metadata:
@@ -128,7 +128,7 @@ In this step, you will change that behavior so that all traffic goes to `v1`.
     > If you installed/configured Istio with mutual TLS Authentication enabled, you must add a TLS traffic policy `mode: ISTIO_MUTUAL` to the `DestinationRule` before applying it. Otherwise requests will generate 503 errors as described [here](/help/ops/traffic-management/deploy-guidelines/#503-errors-after-setting-destination-rule).
 
     {{< text bash >}}
-    $ cat <<EOF | kubectl apply -f -
+    $ kubectl apply -f - <<EOF
     apiVersion: networking.istio.io/v1alpha3
     kind: VirtualService
     metadata:
@@ -200,7 +200,7 @@ log entries for `v1` and none for `v2`:
 1.  Change the route rule to mirror traffic to v2:
 
     {{< text bash >}}
-    $ cat <<EOF | kubectl apply -f -
+    $ kubectl apply -f - <<EOF
     apiVersion: networking.istio.io/v1alpha3
     kind: VirtualService
     metadata:

--- a/content/docs/tasks/traffic-management/request-timeouts/index.md
+++ b/content/docs/tasks/traffic-management/request-timeouts/index.md
@@ -33,7 +33,7 @@ to the `ratings` service.
 1.  Route requests to v2 of the `reviews` service, i.e., a version that calls the `ratings` service:
 
     {{< text bash >}}
-    $ cat <<EOF | kubectl apply -f -
+    $ kubectl apply -f - <<EOF
     apiVersion: networking.istio.io/v1alpha3
     kind: VirtualService
     metadata:
@@ -52,7 +52,7 @@ to the `ratings` service.
 1.  Add a 2 second delay to calls to the `ratings` service:
 
     {{< text bash >}}
-    $ cat <<EOF | kubectl apply -f -
+    $ kubectl apply -f - <<EOF
     apiVersion: networking.istio.io/v1alpha3
     kind: VirtualService
     metadata:
@@ -80,7 +80,7 @@ to the `ratings` service.
 1.  Now add a half second request timeout for calls to the `reviews` service:
 
     {{< text bash >}}
-    $ cat <<EOF | kubectl apply -f -
+    $ kubectl apply -f - <<EOF
     apiVersion: networking.istio.io/v1alpha3
     kind: VirtualService
     metadata:

--- a/content/docs/tasks/traffic-management/secure-ingress/index.md
+++ b/content/docs/tasks/traffic-management/secure-ingress/index.md
@@ -88,7 +88,7 @@ with a certificate and a private key. Then you create a `Gateway` definition tha
     > The location of the certificate and the private key **must** be `/etc/istio/ingressgateway-certs`, or the gateway will fail to load them.
 
     {{< text bash >}}
-    $ cat <<EOF | kubectl apply -f -
+    $ kubectl apply -f - <<EOF
     apiVersion: networking.istio.io/v1alpha3
     kind: Gateway
     metadata:
@@ -113,7 +113,7 @@ with a certificate and a private key. Then you create a `Gateway` definition tha
 1.  Configure routes for traffic entering via the `Gateway`. Define the same `VirtualService` as in the [Control Ingress Traffic](/docs/tasks/traffic-management/ingress/#configuring-ingress-using-an-istio-gateway) task:
 
     {{< text bash >}}
-    $ cat <<EOF | kubectl apply -f -
+    $ kubectl apply -f - <<EOF
     apiVersion: networking.istio.io/v1alpha3
     kind: VirtualService
     metadata:
@@ -206,7 +206,7 @@ the server will use to verify its clients. Create the secret `istio-ingressgatew
     from, in this case `ca-chain.cert.pem`.
 
     {{< text bash >}}
-    $ cat <<EOF | kubectl apply -f -
+    $ kubectl apply -f - <<EOF
     apiVersion: networking.istio.io/v1alpha3
     kind: Gateway
     metadata:
@@ -348,7 +348,7 @@ In this subsection, perform the same steps as in the [Generate client and server
 1.  Redeploy the `Gateway` definition with a host for `bookinfo.com`:
 
     {{< text bash >}}
-    $ cat <<EOF | kubectl apply -f -
+    $ kubectl apply -f - <<EOF
     apiVersion: networking.istio.io/v1alpha3
     kind: Gateway
     metadata:
@@ -384,7 +384,7 @@ In this subsection, perform the same steps as in the [Generate client and server
     [`samples/bookinfo/networking/bookinfo-gateway.yaml`]({{< github_file >}}/samples/bookinfo/networking/bookinfo-gateway.yaml):
 
     {{< text bash >}}
-    $ cat <<EOF | kubectl apply -f -
+    $ kubectl apply -f - <<EOF
     apiVersion: networking.istio.io/v1alpha3
     kind: VirtualService
     metadata:

--- a/content/help/faq/security/accessing-non-istio-services.md
+++ b/content/help/faq/security/accessing-non-istio-services.md
@@ -8,7 +8,7 @@ This includes the Kubernetes API server, as well as any non-Istio services in th
 sidecar, you need to set a destination rule to exempt the service. For example:
 
 {{< text bash >}}
-$ cat <<EOF | kubectl apply -f -
+$ kubectl apply -f - <<EOF
 apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:

--- a/content/help/faq/traffic-management/ingress-with-no-route-rules.md
+++ b/content/help/faq/traffic-management/ingress-with-no-route-rules.md
@@ -12,7 +12,7 @@ For example, the following ingress resource matches requests for the
 example.com host, with /helloworld as the URL.
 
 {{< text bash >}}
-$ cat <<EOF | kubectl create -f -
+$ kubectl create -f - <<EOF
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -35,7 +35,7 @@ However, the following rules will not work because they use regular
 expressions in the path and `ingress.kubernetes.io` annotations:
 
 {{< text bash >}}
-$ cat <<EOF | kubectl create -f -
+$ kubectl create -f - <<EOF
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:

--- a/content_zh/blog/2017/0.1-canary/index.md
+++ b/content_zh/blog/2017/0.1-canary/index.md
@@ -82,7 +82,7 @@ spec:
 但是在[启用 Istio](/zh/docs/setup/) 的集群中，我们可以通过设置路由规则来控制流量分配。如将 10％ 的流量发送到金丝雀版本本，我们可以使用 `kubectl` 来设置以下的路由规则：
 
 {{< text bash >}}
-$ cat <<EOF | kubectl apply -f -
+$ kubectl apply -f - <<EOF
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
@@ -190,7 +190,7 @@ helloworld-v2-4095161145-963wt   2/2       Running   0          1h
 以下命令可将特定网站上 50％ 的用户流量路由到金丝雀版本，而其他用户则不受影响：
 
 {{< text bash >}}
-$ cat <<EOF | kubectl apply -f -
+$ kubectl apply -f - <<EOF
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:

--- a/content_zh/blog/2018/egress-https/index.md
+++ b/content_zh/blog/2018/egress-https/index.md
@@ -93,7 +93,7 @@ $ kubectl apply -f @samples/bookinfo/networking/virtual-service-details-v2.yaml@
 service_ 使用 [SNI](https://en.wikipedia.org/wiki/Server_Name_Indication)对外部服务执行路由。
 
 {{< text bash >}}
-$ cat <<EOF | kubectl apply -f -
+$ kubectl apply -f - <<EOF
 apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
@@ -239,7 +239,7 @@ env:
 1.  为 `www.google.apis` 创建网格外部 `ServiceEntry`，并执行目标规则以执行 TLS 发起。
 
     {{< text bash >}}
-    $ cat <<EOF | kubectl apply -f -
+    $ kubectl apply -f - <<EOF
     apiVersion: networking.istio.io/v1alpha3
     kind: ServiceEntry
     metadata:

--- a/content_zh/blog/2018/egress-tcp/index.md
+++ b/content_zh/blog/2018/egress-tcp/index.md
@@ -210,7 +210,7 @@ keywords: [流量管理,egress,tcp]
 1. 定义一个网格外部服务入口：
 
     {{< text bash >}}
-    $ cat <<EOF | kubectl apply -f -
+    $ kubectl apply -f - <<EOF
     apiVersion: networking.istio.io/v1alpha3
     kind: ServiceEntry
     metadata:

--- a/content_zh/docs/examples/advanced-gateways/ingress-sni-passthrough/index.md
+++ b/content_zh/docs/examples/advanced-gateways/ingress-sni-passthrough/index.md
@@ -94,7 +94,7 @@ keywords: [流量管理,ingress, https]
 1.  部署 NGINX 服务器：
 
     {{< text bash >}}
-    $ cat <<EOF | kubectl apply -f -
+    $ kubectl apply -f - <<EOF
     apiVersion: v1
     kind: Service
     metadata:
@@ -185,7 +185,7 @@ keywords: [流量管理,ingress, https]
 而不终止 TLS。
 
     {{< text bash >}}
-    $ cat <<EOF | kubectl apply -f -
+    $ kubectl apply -f - <<EOF
     apiVersion: networking.istio.io/v1alpha3
     kind: Gateway
     metadata:
@@ -208,7 +208,7 @@ keywords: [流量管理,ingress, https]
 1.  配置通过 `Gateway` 进入的流量路由：
 
     {{< text bash >}}
-    $ cat <<EOF | kubectl apply -f -
+    $ kubectl apply -f - <<EOF
     apiVersion: networking.istio.io/v1alpha3
     kind: VirtualService
     metadata:

--- a/content_zh/docs/examples/endpoints/index.md
+++ b/content_zh/docs/examples/endpoints/index.md
@@ -25,7 +25,7 @@ $ curl --request POST --header "content-type:application/json" --data '{"message
 1.  如果你想通过 Ingress 访问服务，以下是创建 Ingress 的定义：
 
     {{< text bash >}}
-    $ cat <<EOF | kubectl apply -f -
+    $ kubectl apply -f - <<EOF
     apiVersion: extensions/v1beta1
     kind: Ingress
     metadata:

--- a/content_zh/docs/tasks/security/authn-policy/index.md
+++ b/content_zh/docs/tasks/security/authn-policy/index.md
@@ -91,7 +91,7 @@ $ kubectl get destinationrules.networking.istio.io --all-namespaces -o yaml | gr
 你可以提交如下 *网格认证策略* 和目的地规则为网格中所有服务启用双向 TLS 认证：
 
 {{< text bash >}}
-$ cat <<EOF | kubectl apply -f -
+$ kubectl apply -f - <<EOF
 apiVersion: "authentication.istio.io/v1alpha1"
 kind: "MeshPolicy"
 metadata:
@@ -121,7 +121,7 @@ sleep.bar to httpbin.bar: 503
 多个目标规则，可以一个一个的设置每个适用的服务（或命名空间）。然而在规则中使用 * 符号来匹配所有服务会更方便，这样也就跟网格范围的认证策略一致了。
 
 {{< text bash >}}
-$ cat <<EOF | kubectl apply -f -
+$ kubectl apply -f - <<EOF
 apiVersion: "networking.istio.io/v1alpha3"
 kind: "DestinationRule"
 metadata:
@@ -186,7 +186,7 @@ sleep.bar to httpbin.legacy: 503
 要解决此问题，我们可以添加目标规则来覆盖 `httpbin.legacy` 的 TLS 设置。例如：
 
 {{< text bash >}}
-$ cat <<EOF | kubectl apply -f -
+$ kubectl apply -f - <<EOF
 apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
@@ -214,7 +214,7 @@ command terminated with exit code 35
 同样，我们可以通过覆盖 API 服务器的目标规则来更正此问题（ `kubernetes.default` ）
 
 {{< text bash >}}
-$ cat <<EOF | kubectl apply -f -
+$ kubectl apply -f - <<EOF
 apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
@@ -258,7 +258,7 @@ $ kubectl delete destinationrules default httpbin-legacy api-server
 并指定一个命名空间，在本例中为 `foo`。如果未指定命名空间值，则策略将应用于默认命名空间。
 
 {{< text bash >}}
-$ cat <<EOF | kubectl apply -f -
+$ kubectl apply -f - <<EOF
 apiVersion: "authentication.istio.io/v1alpha1"
 kind: "Policy"
 metadata:
@@ -275,7 +275,7 @@ EOF
 添加相应的目的地规则：
 
 {{< text bash >}}
-$ cat <<EOF | kubectl apply -f -
+$ kubectl apply -f - <<EOF
 apiVersion: "networking.istio.io/v1alpha3"
 kind: "DestinationRule"
 metadata:
@@ -453,7 +453,7 @@ $ kubectl delete destinationrules httpbin -n bar
 你需要一个有效的 JWT （与在本例中你想使用的 JWKS endpoint 相一致）。请按照[这里]({{< github_tree >}}/security/tools/jwt)的说明进行操作来创建一个 JWT。你也可以在示例中使用自己的 JWT/JWKS endpoint。创建之后，在环境变量中设置相关信息。
 
 {{< text bash >}}
-$ cat <<EOF | kubectl apply -f -
+$ kubectl apply -f - <<EOF
 apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
@@ -473,7 +473,7 @@ EOF
 {{< /text >}}
 
 {{< text bash >}}
-$ cat <<EOF | kubectl apply -f -
+$ kubectl apply -f - <<EOF
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
@@ -587,7 +587,7 @@ EOF
 并添加目标规则：
 
 {{< text bash >}}
-$ cat <<EOF | kubectl apply -f -
+$ kubectl apply -f - <<EOF
 apiVersion: "networking.istio.io/v1alpha3"
 kind: "DestinationRule"
 metadata:

--- a/content_zh/docs/tasks/security/health-check/index.md
+++ b/content_zh/docs/tasks/security/health-check/index.md
@@ -38,7 +38,7 @@ $ kubectl apply -f install/kubernetes/istio-citadel-with-health-check.yaml
 部署 `istio-citadel` 服务，这样健康检查器才能找到 CSR 服务.
 
 {{< text bash >}}
-$ cat <<EOF | kubectl create -f -
+$ kubectl create -f - <<EOF
 apiVersion: v1
 kind: Service
 metadata:

--- a/content_zh/docs/tasks/traffic-management/egress/index.md
+++ b/content_zh/docs/tasks/traffic-management/egress/index.md
@@ -45,7 +45,7 @@ keywords: [流量管理,egress]
 1. 创建一个 `ServiceEntry` 对象，放行对一个外部 HTTP 服务的访问：
 
     {{< text bash >}}
-    $ cat <<EOF | kubectl apply -f -
+    $ kubectl apply -f - <<EOF
     apiVersion: networking.istio.io/v1alpha3
     kind: ServiceEntry
     metadata:
@@ -80,7 +80,7 @@ keywords: [流量管理,egress]
     对于 TLS 协议（包括 HTTPS），除了 `ServiceEntry` 之外，还需要 `VirtualService`。 `VirtualService` 必须在 `match` 子句中包含 `tls` 规则和 `sni_hosts` 以启用 SNI 路由。
 
     {{< text bash >}}
-    $ cat <<EOF | kubectl apply -f -
+    $ kubectl apply -f - <<EOF
     apiVersion: networking.istio.io/v1alpha3
     kind: ServiceEntry
     metadata:
@@ -149,7 +149,7 @@ keywords: [流量管理,egress]
 1. 退出测试 Pod，使用 `kubectl` 为 httpbin.org 外部服务的访问设置一个 3 秒钟的超时：
 
     {{< text bash >}}
-    $ cat <<EOF | kubectl apply -f -
+    $ kubectl apply -f - <<EOF
     apiVersion: networking.istio.io/v1alpha3
     kind: VirtualService
     metadata:

--- a/content_zh/docs/tasks/traffic-management/mirroring/index.md
+++ b/content_zh/docs/tasks/traffic-management/mirroring/index.md
@@ -72,7 +72,7 @@ keywords: [流量管理,镜像]
     **httpbin Kubernetes service:**
 
     {{< text bash >}}
-    $ cat <<EOF | kubectl create -f -
+    $ kubectl create -f - <<EOF
     apiVersion: v1
     kind: Service
     metadata:

--- a/content_zh/docs/tasks/traffic-management/secure-ingress/index.md
+++ b/content_zh/docs/tasks/traffic-management/secure-ingress/index.md
@@ -78,7 +78,7 @@ keywords: [流量管理,ingress]
     > 证书的私钥的位置 **必须** 是 `/etc/istio/ingressgateway-certs`，否则 Gateway 无法载入。
 
     {{< text bash >}}
-    $ cat <<EOF | kubectl apply -f -
+    $ kubectl apply -f - <<EOF
     apiVersion: networking.istio.io/v1alpha3
     kind: Gateway
     metadata:
@@ -103,7 +103,7 @@ keywords: [流量管理,ingress]
 1. 为通过 Gateway 进入的流量进行路由配置。配置一个和[控制 Ingress 流量任务](/zh/docs/tasks/traffic-management/ingress/#使用-istio-网关配置-ingress) 中一致的 `Virtualservice`：
 
     {{< text bash >}}
-    $ cat <<EOF | kubectl apply -f -
+    $ kubectl apply -f - <<EOF
     apiVersion: networking.istio.io/v1alpha3
     kind: VirtualService
     metadata:
@@ -182,7 +182,7 @@ keywords: [流量管理,ingress]
     > 证书的位置 **必须** 是 `/etc/istio/ingressgateway-ca-certs`，否则 Gateway 无法加载。证书的文件名必须和创建 Secret 时使用的文件名一致，这里就是 `ca-chain.cert.pem`
 
     {{< text bash >}}
-    $ cat <<EOF | kubectl apply -f -
+    $ kubectl apply -f - <<EOF
     apiVersion: networking.istio.io/v1alpha3
     kind: Gateway
     metadata:
@@ -320,7 +320,7 @@ keywords: [流量管理,ingress]
 1. 使用 `bookinfo.com` 的主机重新部署 `Gateway` ：
 
     {{< text bash >}}
-    $ cat <<EOF | kubectl apply -f -
+    $ kubectl apply -f - <<EOF
     apiVersion: networking.istio.io/v1alpha3
     kind: Gateway
     metadata:
@@ -355,7 +355,7 @@ keywords: [流量管理,ingress]
 1. 配置 `bookinfo.com` 的路由。定义一个类似于 [`samples/bookinfo/networking/bookinfo-gateway.yaml`]({{<github_file>}}/samples/bookinfo/networking/bookinfo-gateway.yaml) 中的 `VirtualService` ：
 
     {{< text bash >}}
-    $ cat <<EOF | kubectl apply -f -
+    $ kubectl apply -f - <<EOF
     apiVersion: networking.istio.io/v1alpha3
     kind: VirtualService
     metadata:

--- a/content_zh/help/faq/security/accessing-non-istio-services.md
+++ b/content_zh/help/faq/security/accessing-non-istio-services.md
@@ -6,7 +6,7 @@ weight: 40
 当全局启用双向 TLS 时，全局目标规则 (*global* destination rule) 匹配群集中的所有服务，无论这些服务是否具有 Istio sidecar。 这包括 Kubernetes API 服务器，以及集群中的任何非 Istio 服务。 要让这些非 Istio 服务与有 Istio sidecar 的服务进行通信，你需要设置目标规则以免除服务。 例如：
 
 {{< text bash >}}
-$ cat <<EOF | kubectl apply -f -
+$ kubectl apply -f - <<EOF
 apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:

--- a/content_zh/help/faq/traffic-management/ingress-with-no-route-rules.md
+++ b/content_zh/help/faq/traffic-management/ingress-with-no-route-rules.md
@@ -8,7 +8,7 @@ weight: 40
 例如，以下 ingress 资源匹配 example.com 主机的请求，其中 /helloworld 为 URL。
 
 {{< text bash >}}
-$ cat <<EOF | kubectl create -f -
+$ kubectl create -f - <<EOF
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -30,7 +30,7 @@ EOF
 但是，以下的规则不能正常工作，因为在路径和 `ingress.kubernetes.io` 注释中使用了正则表达式：
 
 {{< text bash >}}
-$ cat <<EOF | kubectl create -f -
+$ kubectl create -f - <<EOF
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:

--- a/layouts/shortcodes/text.html
+++ b/layouts/shortcodes/text.html
@@ -46,6 +46,8 @@
     {{- else -}}
         {{- if hasPrefix (trim $text " ") "$ cat <<EOF " -}}
             {{- $text = replace $text "$ cat" "cat" -}}
+        {{- else if (or (hasPrefix (trim $text " ") "$ kubectl apply -f - <<EOF") (hasPrefix (trim $text " ") "$ kubectl create -f - <<EOF")) -}}
+            {{- $text = replace $text "$ kubectl" "kubectl" -}}
         {{- else -}}
             {{- $syntax = "command" -}}
             {{- if $output -}}


### PR DESCRIPTION
Instead of `cat <<EOF | kubectl apply -f -` use `kubectl apply -f - <<EOF`.

The version without `cat` is shorter and faster since it does not use pipe, and is the version used by kubernetes.io. For example, https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#use-multiple-service-accounts:

```
kubectl create -f - <<EOF
apiVersion: v1
kind: ServiceAccount
metadata:
  name: build-robot
EOF
serviceaccount/build-robot created
```
