### PR TITLE
use kubectl logs -l instead of applying kubectl logs on selected pods

### DIFF
--- a/content/docs/tasks/security/role-based-access-control/index.md
+++ b/content/docs/tasks/security/role-based-access-control/index.md
@@ -127,10 +127,10 @@ Before you start, please make sure that you have finished [preparation task](#be
 1.  Verify the logs stream has been created and check `permissiveResponseCode`.
 
     In a Kubernetes environment, search through the logs for the istio-telemetry
-    pod as follows:
+    pods as follows:
 
     {{< text bash json >}}
-    $ kubectl -n istio-system logs $(kubectl -n istio-system get pods -l istio-mixer-type=telemetry -o jsonpath='{.items[0].metadata.name}') -c mixer | grep \"instance\":\"rbacsamplelog.logentry.istio-system\"
+    $ kubectl -n istio-system logs -l istio-mixer-type=telemetry -c mixer | grep \"instance\":\"rbacsamplelog.logentry.istio-system\"
     {"level":"warn","time":"2018-08-30T21:53:42.059444Z","instance":"rbacsamplelog.logentry.istio-system","destination":"ratings","latency":"9.158879ms","permissiveResponseCode":"403","permissiveResponsePolicyID":"","responseCode":200,"responseSize":48,"source":"reviews","user":"cluster.local/ns/default/sa/bookinfo-reviews"}
     {"level":"warn","time":"2018-08-30T21:53:41.037824Z","instance":"rbacsamplelog.logentry.istio-system","destination":"reviews","latency":"1.091670916s","permissiveResponseCode":"403","permissiveResponsePolicyID":"","responseCode":200,"responseSize":379,"source":"productpage","user":"cluster.local/ns/default/sa/bookinfo-productpage"}
     {"level":"warn","time":"2018-08-30T21:53:41.019851Z","instance":"rbacsamplelog.logentry.istio-system","destination":"productpage","latency":"1.112521495s","permissiveResponseCode":"403","permissiveResponsePolicyID":"","responseCode":200,"responseSize":5723,"source":"istio-ingressgateway","user":"cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account"}
@@ -167,10 +167,10 @@ Before you start, please make sure that you have finished [preparation task](#be
 1.  Verify the logs and check `permissiveResponseCode` again.
 
     In a Kubernetes environment, search through the logs for the istio-telemetry
-    pod as follows:
+    pods as follows:
 
     {{< text bash json >}}
-    $ kubectl -n istio-system logs $(kubectl -n istio-system get pods -l istio-mixer-type=telemetry -o jsonpath='{.items[0].metadata.name}') -c mixer | grep \"instance\":\"rbacsamplelog.logentry.istio-system\"
+    $ kubectl -n istio-system logs -l istio-mixer-type=telemetry -c mixer | grep \"instance\":\"rbacsamplelog.logentry.istio-system\"
     {"level":"warn","time":"2018-08-30T21:55:53.590430Z","instance":"rbacsamplelog.logentry.istio-system","destination":"ratings","latency":"4.415633ms","permissiveResponseCode":"403","permissiveResponsePolicyID":"","responseCode":200,"responseSize":48,"source":"reviews","user":"cluster.local/ns/default/sa/bookinfo-reviews"}
     {"level":"warn","time":"2018-08-30T21:55:53.565914Z","instance":"rbacsamplelog.logentry.istio-system","destination":"reviews","latency":"32.97524ms","permissiveResponseCode":"403","permissiveResponsePolicyID":"","responseCode":200,"responseSize":379,"source":"productpage","user":"cluster.local/ns/default/sa/bookinfo-productpage"}
     {"level":"warn","time":"2018-08-30T21:55:53.544441Z","instance":"rbacsamplelog.logentry.istio-system","destination":"productpage","latency":"57.800056ms","permissiveResponseCode":"200","permissiveResponsePolicyID":"productpage-viewer","responseCode":200,"responseSize":5723,"source":"istio-ingressgateway","user":"cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account"}
@@ -251,10 +251,10 @@ Before you start, please make sure that you have finished [step 1](#step-1-allow
 1.  Verify the logs and check `permissiveResponseCode` again.
 
     In a Kubernetes environment, search through the logs for the istio-telemetry
-    pod as follows:
+    pods as follows:
 
     {{< text bash json >}}
-    $ kubectl -n istio-system logs $(kubectl -n istio-system get pods -l istio-mixer-type=telemetry -o jsonpath='{.items[0].metadata.name}') -c mixer | grep \"instance\":\"rbacsamplelog.logentry.istio-system\"
+    $ kubectl -n istio-system logs -l istio-mixer-type=telemetry -c mixer | grep \"instance\":\"rbacsamplelog.logentry.istio-system\"
     {"level":"warn","time":"2018-08-30T22:59:42.707093Z","instance":"rbacsamplelog.logentry.istio-system","destination":"details","latency":"423.381µs","permissiveResponseCode":"200","permissiveResponsePolicyID":"details-reviews-viewer","responseCode":403,"responseSize":19,"source":"productpage","user":"cluster.local/ns/default/sa/bookinfo-productpage"}
     {"level":"warn","time":"2018-08-30T22:59:42.763423Z","instance":"rbacsamplelog.logentry.istio-system","destination":"reviews","latency":"237.333µs","permissiveResponseCode":"200","permissiveResponsePolicyID":"details-reviews-viewer","responseCode":403,"responseSize":19,"source":"productpage","user":"cluster.local/ns/default/sa/bookinfo-productpage"}
     {{< /text >}}

--- a/content/docs/tasks/telemetry/metrics-logs/index.md
+++ b/content/docs/tasks/telemetry/metrics-logs/index.md
@@ -170,7 +170,7 @@ as the example application throughout this task.
     follows:
 
     {{< text bash json >}}
-    $ for TELEMETRY_POD in $(kubectl -n istio-system get pods -l istio-mixer-type=telemetry -o jsonpath='{.items[*].metadata.name}'); do kubectl -n istio-system logs $TELEMETRY_POD -c mixer; done | grep \"instance\":\"newlog.logentry.istio-system\" | grep -v '"destination":"telemetry"' | grep -v '"destination":"pilot"' | grep -v '"destination":"policy"' | grep -v '"destination":"unknown"'
+    $ kubectl logs -n istio-system -l istio-mixer-type=telemetry -c mixer | grep \"instance\":\"newlog.logentry.istio-system\" | grep -v '"destination":"telemetry"' | grep -v '"destination":"pilot"' | grep -v '"destination":"policy"' | grep -v '"destination":"unknown"'
     {"level":"warn","time":"2018-09-15T20:46:36.009801Z","instance":"newlog.logentry.istio-system","destination":"details","latency":"13.601485ms","responseCode":200,"responseSize":178,"source":"productpage","user":"unknown"}
     {"level":"warn","time":"2018-09-15T20:46:36.026993Z","instance":"newlog.logentry.istio-system","destination":"reviews","latency":"919.482857ms","responseCode":200,"responseSize":295,"source":"productpage","user":"unknown"}
     {"level":"warn","time":"2018-09-15T20:46:35.982761Z","instance":"newlog.logentry.istio-system","destination":"productpage","latency":"968.030256ms","responseCode":200,"responseSize":4415,"source":"istio-ingressgateway","user":"unknown"}

--- a/content/docs/tasks/telemetry/metrics-logs/index.md
+++ b/content/docs/tasks/telemetry/metrics-logs/index.md
@@ -170,11 +170,10 @@ as the example application throughout this task.
     follows:
 
     {{< text bash json >}}
-    $ for TELEMETRY_POD in $(kubectl -n istio-system get pods -l istio-mixer-type=telemetry -o jsonpath='{.items[*].metadata.name}'); do kubectl -n istio-system logs $TELEMETRY_POD -c mixer; done | grep \"instance\":\"newlog.logentry.istio-system\"
-    {"level":"warn","time":"2018-07-11T00:09:55.530274Z","instance":"newlog.logentry.istio-system","destination":"productpage","latency":"27.769937ms","responseCode":200,"responseSize":4415,"source":"istio-ingressgateway","user":"unknown"}
-    {"level":"warn","time":"2018-07-11T00:09:56.450852Z","instance":"newlog.logentry.istio-system","destination":"policy","latency":"566.375µs","responseCode":200,"responseSize":82,"source":"istio-ingressgateway","user":"unknown"}
-    {"level":"warn","time":"2018-07-11T00:09:56.458926Z","instance":"newlog.logentry.istio-system","destination":"reviews","latency":"4.940979ms","responseCode":200,"responseSize":295,"source":"productpage","user":"unknown"}
-    {"level":"warn","time":"2018-07-11T00:09:57.348865Z","instance":"newlog.logentry.istio-system","destination":"details","latency":"2.112762ms","responseCode":200,"responseSize":178,"source":"productpage","user":"unknown"}
+    $ for TELEMETRY_POD in $(kubectl -n istio-system get pods -l istio-mixer-type=telemetry -o jsonpath='{.items[*].metadata.name}'); do kubectl -n istio-system logs $TELEMETRY_POD -c mixer; done | grep \"instance\":\"newlog.logentry.istio-system\" | grep -v '"destination":"telemetry"' | grep -v '"destination":"pilot"' | grep -v '"destination":"policy"' | grep -v '"destination":"unknown"'
+    {"level":"warn","time":"2018-09-15T20:46:36.009801Z","instance":"newlog.logentry.istio-system","destination":"details","latency":"13.601485ms","responseCode":200,"responseSize":178,"source":"productpage","user":"unknown"}
+    {"level":"warn","time":"2018-09-15T20:46:36.026993Z","instance":"newlog.logentry.istio-system","destination":"reviews","latency":"919.482857ms","responseCode":200,"responseSize":295,"source":"productpage","user":"unknown"}
+    {"level":"warn","time":"2018-09-15T20:46:35.982761Z","instance":"newlog.logentry.istio-system","destination":"productpage","latency":"968.030256ms","responseCode":200,"responseSize":4415,"source":"istio-ingressgateway","user":"unknown"}
     {{< /text >}}
 
 ## Understanding the telemetry configuration

--- a/content/docs/tasks/telemetry/metrics-logs/index.md
+++ b/content/docs/tasks/telemetry/metrics-logs/index.md
@@ -166,11 +166,11 @@ as the example application throughout this task.
 1.  Verify that the logs stream has been created and is being populated for
     requests.
 
-    In a Kubernetes environment, search through the logs for the istio-telemetry pod as
+    In a Kubernetes environment, search through the logs for the istio-telemetry pods as
     follows:
 
     {{< text bash json >}}
-    $ kubectl -n istio-system logs $(kubectl -n istio-system get pods -l istio-mixer-type=telemetry -o jsonpath='{.items[0].metadata.name}') -c mixer | grep \"instance\":\"newlog.logentry.istio-system\"
+    $ for TELEMETRY_POD in $(kubectl -n istio-system get pods -l istio-mixer-type=telemetry -o jsonpath='{.items[*].metadata.name}'); do kubectl -n istio-system logs $TELEMETRY_POD -c mixer; done | grep \"instance\":\"newlog.logentry.istio-system\"
     {"level":"warn","time":"2018-07-11T00:09:55.530274Z","instance":"newlog.logentry.istio-system","destination":"productpage","latency":"27.769937ms","responseCode":200,"responseSize":4415,"source":"istio-ingressgateway","user":"unknown"}
     {"level":"warn","time":"2018-07-11T00:09:56.450852Z","instance":"newlog.logentry.istio-system","destination":"policy","latency":"566.375µs","responseCode":200,"responseSize":82,"source":"istio-ingressgateway","user":"unknown"}
     {"level":"warn","time":"2018-07-11T00:09:56.458926Z","instance":"newlog.logentry.istio-system","destination":"reviews","latency":"4.940979ms","responseCode":200,"responseSize":295,"source":"productpage","user":"unknown"}

--- a/content/help/faq/mixer/mixer-self-monitoring.md
+++ b/content/help/faq/mixer/mixer-self-monitoring.md
@@ -18,13 +18,13 @@ Mixer logs can be accessed via a `kubectl logs` command, as follows:
 - For the `istio-policy` service:
 
 {{< text bash >}}
-$ kubectl -n istio-system logs $(kubectl -n istio-system get pods -lapp=policy -o jsonpath='{.items[0].metadata.name}') -c mixer
+$ kubectl -n istio-system logs -l app=policy -c mixer
 {{< /text >}}
 
 - For the `istio-telemetry` service:
 
 {{< text bash >}}
-$ kubectl -n istio-system logs $(kubectl -n istio-system get pods -lapp=telemetry -o jsonpath='{.items[0].metadata.name}') -c mixer
+$ kubectl -n istio-system logs -l app=telemetry -c mixer
 {{< /text >}}
 
 Mixer trace generation is controlled by command-line flags: `trace_zipkin_url`, `trace_jaeger_url`, and `trace_log_spans`. If

--- a/content_zh/docs/tasks/telemetry/metrics-logs/index.md
+++ b/content_zh/docs/tasks/telemetry/metrics-logs/index.md
@@ -149,10 +149,10 @@ keywords: [遥测,指标]
 
 1. 检查请求过程中生成和处理的日志流。
 
-    在 Kubernetes 环境中，像这样在 istio-telemetry pod 中搜索日志：
+    在 Kubernetes 环境中，像这样在 istio-telemetry pods 中搜索日志：
 
     {{< text bash json >}}
-    $ kubectl -n istio-system logs $(kubectl -n istio-system get pods -l istio-mixer-type=telemetry -o jsonpath='{.items[0].metadata.name}') -c mixer | grep \"instance\":\"newlog.logentry.istio-system\"
+    $ kubectl -n istio-system logs -l istio-mixer-type=telemetry -c mixer | grep \"instance\":\"newlog.logentry.istio-system\"
     {"level":"warn","ts":"2017-09-21T04:33:31.249Z","instance":"newlog.logentry.istio-system","destination":"details","latency":"6.848ms","responseCode":200,"responseSize":178,"source":"productpage","user":"unknown"}
     {"level":"warn","ts":"2017-09-21T04:33:31.291Z","instance":"newlog.logentry.istio-system","destination":"ratings","latency":"6.753ms","responseCode":200,"responseSize":48,"source":"reviews","user":"unknown"}
     {"level":"warn","ts":"2017-09-21T04:33:31.263Z","instance":"newlog.logentry.istio-system","destination":"reviews","latency":"39.848ms","responseCode":200,"responseSize":379,"source":"productpage","user":"unknown"}

--- a/content_zh/help/faq/mixer/mixer-self-monitoring.md
+++ b/content_zh/help/faq/mixer/mixer-self-monitoring.md
@@ -14,13 +14,13 @@ Mixer 提供了监控端点（默认端口：`9093`）。Mixer 提供的性能�
 - 关于 `istio-policy` 服务：
 
 {{< text bash >}}
-$ kubectl -n istio-system logs ​$(kubectl -n istio-system get pods -lapp=policy -o jsonpath='{.items[0].metadata.name}') -c mixer
+$ kubectl -n istio-system logs -lapp=policy -c mixer
 {{< /text >}}
 
 - 关于 `istio-telemetry` 服务：
 
 {{< text bash >}}
-$ kubectl -n istio-system logs $(kubectl -n istio-system get pods -lapp=telemetry -o jsonpath='{.items[0].metadata.name}') -c mixer
+$ kubectl -n istio-system logs -lapp=telemetry -c mixer
 {{< /text >}}
 
 Mixer 跟踪功能由以下命令行参数控制：`trace_zipkin_url`、`trace_jaeger_url` 和 `trace_log_spans`。如果设置了以上参数中的任何一个，则跟踪数据将上报至配置的相关服务地址。如果未提供跟踪相关设置参数，则 Mixer 将不会产生应用程序级别的跟踪信息。


### PR DESCRIPTION
also handle multiplicity of policy/telemetry pods. The current commands print the log of the first policy/telemetry pod, instead of printing the log of all the pods.

Using `kubectl logs -l` is shorter and simpler