### PR TITLE
Fix an error when applying the end-user authentication policy with mTLS

### DIFF
--- a/content/docs/tasks/security/authn-policy/index.md
+++ b/content/docs/tasks/security/authn-policy/index.md
@@ -617,7 +617,7 @@ EOF
 {{< /text >}}
 
 > If you already enable mutual TLS mesh-wide or namespace-wide, the host `httpbin.foo` is already covered by the other destination rule.
-Therefore, you do not need adding this destination rule. On the other hand, you still need to add the `mtls` stanza to the authentication policy as the service-specific policy will override the mesh-wide (or namespace-wide) policy completely.
+Therefore, you do not need to add this destination rule. On the other hand, you still need to add the `mtls` stanza to the authentication policy as the service-specific policy will override the mesh-wide (or namespace-wide) policy completely.
 
 After these changes, traffic from Istio services, including ingress gateway, to `httpbin.foo` will use mutual TLS. The test command above will still work. Requests from Istio services directly to `httpbin.foo` also work, given the correct token:
 

--- a/content/docs/tasks/security/authn-policy/index.md
+++ b/content/docs/tasks/security/authn-policy/index.md
@@ -588,7 +588,7 @@ spec:
   targets:
   - name: httpbin
   peers:
-  - mTLS: {}
+  - mtls: {}
   origins:
   - jwt:
       issuer: "testing@secure.istio.io"
@@ -617,7 +617,7 @@ EOF
 {{< /text >}}
 
 > If you already enable mutual TLS mesh-wide or namespace-wide, the host `httpbin.foo` is already covered by the other destination rule.
-Therefore, you do not need adding this destination rule. On the other hand, you still need to add the `mTLS` stanza to the authentication policy as the service-specific policy will override the mesh-wide (or namespace-wide) policy completely.
+Therefore, you do not need adding this destination rule. On the other hand, you still need to add the `mtls` stanza to the authentication policy as the service-specific policy will override the mesh-wide (or namespace-wide) policy completely.
 
 After these changes, traffic from Istio services, including ingress gateway, to `httpbin.foo` will use mutual TLS. The test command above will still work. Requests from Istio services directly to `httpbin.foo` also work, given the correct token:
 


### PR DESCRIPTION
In
https://istio.io/docs/tasks/security/authn-policy/#end-user-authentication-with-mutual-tls,
the following error occurs when applying the end-user authentication policy with mTLS. This PR
fixes this error.

Error from server: error when applying patch:
{"metadata":{"annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"authentication.istio.io/v1alpha1\",\"kind\":\"Policy\",\"metadata\":{\"annotations\":{},\"name\":
\"jwt-example\",\"namespace\":\"foo\"},\"spec\":{\"origins\":[{\"jwt\":{\"issuer\":\"testing@secure.istio.io\",\"jwksUri\":\"https://raw.githubusercontent.com/istio/istio/release-1.0/security/too
ls/jwt/samples/jwks.json\"}}],\"peers\":[{\"mTLS\":{}}],\"principalBinding\":\"USE_ORIGIN\",\"targets\":[{\"name\":\"httpbin\"}]}}\n"}},"spec":{"peers":[{"mTLS":{}}]}}
to:
&{0xc4200a9a40 0xc420361260 foo jwt-example STDIN 0xc42211a040 20632 false}
for: "STDIN": admission webhook "pilot.validation.istio.io" denied the request: error decoding configuration: YAML decoding error: origins:
- jwt:
    issuer: testing@secure.istio.io
    jwksUri: https://raw.githubusercontent.com/istio/istio/release-1.0/security/tools/jwt/samples/jwks.json
peers:
- mTLS: {}
principalBinding: USE_ORIGIN
targets:
- name: httpbin
 unknown field "mTLS" in v1alpha1.PeerAuthenticationMethod